### PR TITLE
chore: add release workflow

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -100,7 +100,6 @@ jobs:
   deploy-to-aws-test:
     needs: [release]
     name: Deploys Application to AWS test
-    environment: test
     runs-on: ubuntu-24.04
     steps:
       - name: Deploy to AWS test
@@ -109,10 +108,10 @@ jobs:
 
   deploy-to-aws-prod:
     needs: [deploy-to-aws-test]
-    name: Deploys Application to AWS test
-    environment: test
+    name: Deploys Application to AWS prod
+    environment: prod
     runs-on: ubuntu-24.04
     steps:
-      - name: Deploy to AWS test
+      - name: Deploy to AWS prod
         # Placeholder
-        run: echo "Deploying to AWS test"
+        run: echo "Deploying to AWS prod"

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -44,10 +44,56 @@ jobs:
       tag: ${{ needs.vars.outputs.pr }}
     secrets: inherit
 
-  promote:
-    name: Promote Images, make release and deploy to Test
-    needs: [deploy-to-aws-dev, vars]
+  # Separate review job since we can't use GitHub environments in reusable workflows
+  review-test-deployment:
+    name: Review Test Deployment
+    needs: [deploy-to-aws-dev]
     environment: test
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Review Test Deployment
+        run: echo "Reviewing Test Deployment"
+
+  deploy-to-aws-test:
+    needs: [review-test-deployment]
+    name: Deploys Application to AWS test
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Deploy to AWS test
+        # Placeholder
+        run: echo "Deploying to AWS test"
+
+  release:
+    name: Release
+    needs: [deploy-to-aws-test]
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Conventional Changelog Update
+        uses: TriPSs/conventional-changelog-action@v5
+        id: changelog
+        continue-on-error: true
+        with:
+          github-token: ${{ github.token }}
+          output-file: "CHANGELOG.md"
+          skip-version-file: "true"
+          skip-commit: "true"
+          git-push: "true"
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        if: ${{ steps.changelog.outputs.tag != '' }}
+        continue-on-error: true
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          token: ${{ github.token }}
+          tag_name: ${{ steps.changelog.outputs.tag }}
+          name: ${{ steps.changelog.outputs.tag }}
+          body: ${{ steps.changelog.outputs.clean_changelog }}
+
+  promote:
+    name: Promote Images
+    needs: [deploy-to-aws-test, vars]
     runs-on: ubuntu-24.04
     permissions:
       packages: write
@@ -67,44 +113,15 @@ jobs:
             latest
             ${{ needs.vars.outputs.pr }}
 
-  release:
-    name: Release
+  # Separate review job since we can't use GitHub environments in reusable workflows
+  review-prod-deployment:
+    name: Review Prod Deployment
     needs: [promote]
+    environment: prod
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
-
-      - name: Conventional Changelog Update
-        uses: TriPSs/conventional-changelog-action@v5
-        id: changelog
-        continue-on-error: true
-        with:
-          github-token: ${{ github.token }}
-          output-file: "CHANGELOG.md"
-          skip-version-file: "true"
-          skip-commit: "true"
-          git-push: "true"
-
-      - name: Create Release
-        uses: softprops/action-gh-release@v2
-        if: ${{ steps.changelog.outputs.tag != '' }}
-        continue-on-error: true
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        with:
-          token: ${{ github.token }}
-          tag_name: ${{ steps.changelog.outputs.tag }}
-          name: ${{ steps.changelog.outputs.tag }}
-          body: ${{ steps.changelog.outputs.clean_changelog }}
-
-  deploy-to-aws-test:
-    needs: [release]
-    name: Deploys Application to AWS test
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Deploy to AWS test
-        # Placeholder
-        run: echo "Deploying to AWS test"
+      - name: Review Prod Deployment
+        run: echo "Reviewing Prod Deployment"
 
   deploy-to-aws-prod:
     needs: [deploy-to-aws-test]

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -45,8 +45,9 @@ jobs:
     secrets: inherit
 
   promote:
-    name: Promote Images
+    name: Promote Images, make release and deploy to Test
     needs: [deploy-to-aws-dev, vars]
+    environment: test
     runs-on: ubuntu-24.04
     permissions:
       packages: write
@@ -65,3 +66,53 @@ jobs:
             prod
             latest
             ${{ needs.vars.outputs.pr }}
+
+  release:
+    name: Release
+    needs: [promote]
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Conventional Changelog Update
+        uses: TriPSs/conventional-changelog-action@v5
+        id: changelog
+        continue-on-error: true
+        with:
+          github-token: ${{ github.token }}
+          output-file: "CHANGELOG.md"
+          skip-version-file: "true"
+          skip-commit: "true"
+          git-push: "true"
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        if: ${{ steps.changelog.outputs.tag != '' }}
+        continue-on-error: true
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          token: ${{ github.token }}
+          tag_name: ${{ steps.changelog.outputs.tag }}
+          name: ${{ steps.changelog.outputs.tag }}
+          body: ${{ steps.changelog.outputs.clean_changelog }}
+
+  deploy-to-aws-test:
+    needs: [release]
+    name: Deploys Application to AWS test
+    environment: test
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Deploy to AWS test
+        # Placeholder
+        run: echo "Deploying to AWS test"
+
+  deploy-to-aws-prod:
+    needs: [deploy-to-aws-test]
+    name: Deploys Application to AWS test
+    environment: test
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Deploy to AWS test
+        # Placeholder
+        run: echo "Deploying to AWS test"


### PR DESCRIPTION
Workflow to review test and prod deployments and make a release. Test and prod deployment workflows are just placeholders for now. 

How it works:
- On merge to main we deploy to dev
- After dev is deployed you can manually review deploying to test 
- After deployment to test is successful a release will be created and images will be promoted. When we get more devs it would be good to discuss if we want to make releases on deployment to test or prod, though neither environment is deployed in AWS yet anyways.
