### PR TITLE
chore(cd): infra changes for ecs

### DIFF
--- a/infrastructure/api/ecs.tf
+++ b/infrastructure/api/ecs.tf
@@ -154,9 +154,16 @@ resource "aws_ecs_service" "node_api_service" {
   desired_count   = 1
   health_check_grace_period_seconds = 60
 
- capacity_provider_strategy {
+  # fargate spot which may get interrupted #https://docs.aws.amazon.com/AmazonECS/latest/developerguide/fargate-capacity-providers.html
+  capacity_provider_strategy {
     capacity_provider = "FARGATE_SPOT"
-    weight            = 100
+    weight            = "${var.fargate_spot_weight}"
+  }
+  # non interrupted service by fargate, makes sure there is alaways minimum capacity
+  capacity_provider_strategy {
+    capacity_provider = "FARGATE"
+    weight            = "${var.fargate_base_weight}"
+    base              = "${var.fargate_base_capacity}"
   }
 
 

--- a/infrastructure/api/ecs.tf
+++ b/infrastructure/api/ecs.tf
@@ -154,7 +154,8 @@ resource "aws_ecs_service" "node_api_service" {
   desired_count   = 1
   health_check_grace_period_seconds = 60
 
-  # fargate spot which may get interrupted #https://docs.aws.amazon.com/AmazonECS/latest/developerguide/fargate-capacity-providers.html
+  # fargate spot which may get interrupted
+  #https://docs.aws.amazon.com/AmazonECS/latest/developerguide/fargate-capacity-providers.html
   capacity_provider_strategy {
     capacity_provider = "FARGATE_SPOT"
     weight            = "${var.fargate_spot_weight}"

--- a/infrastructure/api/vars.tf
+++ b/infrastructure/api/vars.tf
@@ -113,7 +113,7 @@ variable "fargate_base_capacity" {
   description = "value of the base capacity for the Fargate capacity provider, which is the minimum number of tasks to keep running and not interrupted"
   type = number
   default = 1
-  
+
 }
 variable "fargate_base_weight" {
   description = "value of the base weight for the Fargate capacity provider, which is the weight of the base capacity provider"

--- a/infrastructure/api/vars.tf
+++ b/infrastructure/api/vars.tf
@@ -85,6 +85,12 @@ variable "health_check_path" {
 
 }
 
+
+variable "aws_region" {
+  type = string
+  default = "ca-central-1"
+}
+# Below vars can be manipulated to change the capacity of the ECS cluster based on app environment.
 variable "api_cpu" {
   type = number
   default     = "256"
@@ -93,10 +99,6 @@ variable "api_memory" {
   type = number
   default     = "512"
 }
-variable "aws_region" {
-  type = string
-  default = "ca-central-1"
-}
 variable "min_capacity" {
   type = number
   default = 1
@@ -104,4 +106,22 @@ variable "min_capacity" {
 variable "max_capacity" {
   type = number
   default = 3
+}
+
+
+variable "fargate_base_capacity" {
+  description = "value of the base capacity for the Fargate capacity provider, which is the minimum number of tasks to keep running and not interrupted"
+  type = number
+  default = 1
+  
+}
+variable "fargate_base_weight" {
+  description = "value of the base weight for the Fargate capacity provider, which is the weight of the base capacity provider"
+  type = number
+  default = 20
+}
+variable "fargate_spot_weight" {
+  description = "value of the spot weight for the Fargate capacity provider, which is the weight of the spot capacity provider"
+  type = number
+  default = 80
 }


### PR DESCRIPTION
This PR introduces changes how API workloads are scheduled in ECS with fargate and fargate spot.

vars are defined so numbers can be configured differently for different environment.

links:
https://docs.aws.amazon.com/AmazonECS/latest/developerguide/fargate-capacity-providers.html
