### PR TITLE
chore: ci cancel-in-progress except on main branch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref_name != 'main' }}
 
 jobs:
   build-containers:


### PR DESCRIPTION
To prevent cancelled deployments from multiple merges to main in succession we are conditionally setting `cancel-in-progress: true`.