### PR TITLE
ci: fix sonarcloud path

### DIFF
--- a/.github/workflows/.analysis.yml
+++ b/.github/workflows/.analysis.yml
@@ -47,7 +47,7 @@ jobs:
           sonar_args: >
             -Dsonar.exclusions=**/coverage/**,**/node_modules/**,**/*spec.ts
             -Dsonar.organization=bcgov-sonarcloud
-            -Dsonar.projectKey=nr-rec-resources_${{ matrix.dir }}
+            -Dsonar.projectKey=nr-rec-resources-${{ matrix.dir }}
             -Dsonar.sources=src
             -Dsonar.tests.inclusions=**/*spec.ts
             -Dsonar.javascript.lcov.reportPaths=./coverage/lcov.info


### PR DESCRIPTION
Not sure why this is passing sometimes, it seems like the scan doesn't start. Though this should fix it according to sonarcloud - `sonar.projectKey=bcgov-sonarcloud_nr-rec-resources-backend`. 

If not I will make a `sonarcloud.properties` file like normal.