### PR TITLE
ci/rename db

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -229,6 +229,8 @@ venv.bak/
 
 # Terraform
 .terraform.lock.hcl
+.terraform/
+
 
 # nested terragrunt-cache
 **/.terragrunt-cache/**

--- a/infrastructure/api/vars.tf
+++ b/infrastructure/api/vars.tf
@@ -6,25 +6,23 @@ variable "app_env" {
   description = "The environment for the app, since multiple instances can be deployed to same dev environment of AWS, this represents whether it is PR or dev or test"
   type        = string
 }
-
 variable "db_name" {
   description = "The default database for Flyway"
   type        = string
   default     = "rst"
 }
-
 variable "db_schema" {
   description = "The default schema for Flyway"
   type        = string
   default     = "rst"
 }
 
+
 variable "subnet_app_a" {
   description = "Value of the name tag for a subnet in the APP security group"
   type = string
   default = "App_Dev_aza_net"
 }
-
 variable "subnet_app_b" {
   description = "Value of the name tag for a subnet in the APP security group"
   type = string
@@ -113,7 +111,6 @@ variable "fargate_base_capacity" {
   description = "value of the base capacity for the Fargate capacity provider, which is the minimum number of tasks to keep running and not interrupted"
   type = number
   default = 1
-
 }
 variable "fargate_base_weight" {
   description = "value of the base weight for the Fargate capacity provider, which is the weight of the base capacity provider"

--- a/infrastructure/api/vars.tf
+++ b/infrastructure/api/vars.tf
@@ -10,7 +10,7 @@ variable "app_env" {
 variable "db_name" {
   description = "The default database for Flyway"
   type        = string
-  default     = "app"
+  default     = "rst"
 }
 
 variable "db_schema" {

--- a/infrastructure/database/aurora-v2.tf
+++ b/infrastructure/database/aurora-v2.tf
@@ -110,4 +110,11 @@ module "aurora_postgresql_v2" {
   }
 
   enabled_cloudwatch_logs_exports = ["postgresql"]
+
+}
+
+resource "aws_rds_cluster_role_association" "s3_import" {
+  db_cluster_identifier = var.db_cluster_name
+  feature_name           = "s3Import"
+  role_arn               = aws_iam_role.s3_import.arn
 }

--- a/infrastructure/database/aurora-v2.tf
+++ b/infrastructure/database/aurora-v2.tf
@@ -1,3 +1,7 @@
+locals {
+  rds_app_env = (contains(["dev", "test", "prod"], var.app_env) ? var.app_env : "dev") # if app_env is not dev, test, or prod, default to dev
+}
+
 data "aws_kms_alias" "rds_key" {
   name = "alias/aws/rds"
 }
@@ -74,6 +78,8 @@ module "aurora_postgresql_v2" {
   engine_version    = data.aws_rds_engine_version.postgresql.version
   storage_encrypted = true
   database_name     = var.db_database_name
+
+  enable_http_endpoint = contains(["dev"], local.rds_app_env) ? true : false
 
   vpc_id                 = data.aws_vpc.main.id
   vpc_security_group_ids = [data.aws_security_group.data.id]

--- a/infrastructure/database/iam.tf
+++ b/infrastructure/database/iam.tf
@@ -1,0 +1,38 @@
+data "aws_iam_policy_document" "s3_import_assume" {
+  statement {
+    actions = [
+      "sts:AssumeRole",
+    ]
+
+    principals {
+      type        = "Service"
+      identifiers = ["rds.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "s3_import" {
+  name                  = "${var.app_env}-rds-s3-import-role"
+  description           = "IAM role to allow RDS to import CSV backup from S3"
+  assume_role_policy    = data.aws_iam_policy_document.s3_import_assume.json
+  force_detach_policies = true
+}
+
+data "aws_iam_policy_document" "s3_import" {
+  statement {
+    actions = [
+      "s3:GetObject",
+      "s3:ListBucket"
+    ]
+    effect = "Allow"
+    resources = [
+        "arn:aws:s3:::${var.fta_dataload_bucket}",
+        "arn:aws:s3:::${var.fta_dataload_bucket}/*"
+      ]
+  }
+}
+
+resource "aws_iam_role_policy" "s3_import" {
+  role   = aws_iam_role.s3_import.name
+  policy = data.aws_iam_policy_document.s3_import.json
+}

--- a/infrastructure/database/vars.tf
+++ b/infrastructure/database/vars.tf
@@ -11,7 +11,6 @@ variable "app_env" {
 variable "db_cluster_name" {
   description = "Name for the database cluster -- must be unique"
   type        = string
-
 }
 
 variable "db_master_username" {
@@ -25,4 +24,10 @@ variable "db_database_name" {
   description = "The name of the database"
   type        = string
   default     = "rst"
+}
+
+variable "fta_dataload_bucket" {
+  description = "The name of the S3 bucket for FTA CSV files"
+  type        = string
+  default     = "rst-fta-dataload-oracle"
 }

--- a/infrastructure/database/vars.tf
+++ b/infrastructure/database/vars.tf
@@ -24,5 +24,5 @@ variable "db_master_username" {
 variable "db_database_name" {
   description = "The name of the database"
   type        = string
-  default     = "app"
+  default     = "rst"
 }

--- a/infrastructure/migration/ecs.tf
+++ b/infrastructure/migration/ecs.tf
@@ -119,6 +119,24 @@ resource "aws_ecs_task_definition" "flyway_task" {
 
     echo "Flyway task completed at $(date)."
 
+    task_status=$(aws ecs describe-tasks --cluster ${data.aws_ecs_cluster.ecs_cluster.id} --tasks $task_arn --query 'tasks[0].lastStatus' --output text)
+    echo "Flyway task status: $task_status at $(date)."
+    log_stream_name=$(aws logs describe-log-streams \
+      --log-group-name "/ecs/${var.app_name}/flyway" \
+      --order-by "LastEventTime" \
+      --descending \
+      --limit 1 \
+      --query 'logStreams[0].logStreamName' \
+      --output text)
+
+    echo "Fetching logs from log stream: $log_stream_name"
+
+    aws logs get-log-events \
+      --log-group-name "/ecs/${var.app_name}/flyway" \
+      --log-stream-name $log_stream_name \
+      --limit 1000 \
+      --no-cli-pager
+
     # Fetch the task's exit code
     task_exit_code=$(aws ecs describe-tasks \
       --cluster ${data.aws_ecs_cluster.ecs_cluster.id} \
@@ -128,20 +146,6 @@ resource "aws_ecs_task_definition" "flyway_task" {
 
     if [ "$task_exit_code" != "0" ]; then
       echo "Flyway task failed with exit code: $task_exit_code"
-      log_stream_name=$(aws logs describe-log-streams \
-        --log-group-name "/ecs/${var.app_name}/flyway" \
-        --order-by "LastEventTime" \
-        --descending \
-        --limit 1 \
-        --query 'logStreams[0].logStreamName' \
-        --output text)
-
-      echo "Fetching logs from log stream: $log_stream_name"
-      aws logs get-log-events \
-        --log-group-name "/ecs/${var.app_name}/flyway" \
-        --log-stream-name $log_stream_name \
-        --limit 1000 \
-        --no-cli-pager
 
       exit 1
     fi

--- a/infrastructure/migration/vars.tf
+++ b/infrastructure/migration/vars.tf
@@ -11,7 +11,7 @@ variable "app_env" {
 variable "db_name" {
   description = "The default database for Flyway"
   type        = string
-  default     = "app"
+  default     = "rst"
 }
 
 variable "db_schema" {

--- a/migrations/fta/sql/V1.0.0__init.sql
+++ b/migrations/fta/sql/V1.0.0__init.sql
@@ -1,3 +1,5 @@
+begin;
+
 create extension if not exists "postgis";
 
 create schema if not exists fta;
@@ -1207,3 +1209,5 @@ comment on column fta.recreation_user_days_code.effective_date is 'Date the code
 comment on column fta.recreation_user_days_code.expiry_date is 'Date the code expires';
 
 comment on column fta.recreation_user_days_code.update_timestamp is 'The date and time the value was last modified.';
+
+commit;

--- a/migrations/fta/sql/V1.0.1__import_csv_from_s3.sql
+++ b/migrations/fta/sql/V1.0.1__import_csv_from_s3.sql
@@ -1,5 +1,7 @@
 create extension if not exists aws_s3 cascade;
 
+begin;
+
 select aws_s3.table_import_from_s3(
   'fta.recreation_project',
   '',
@@ -503,3 +505,5 @@ select aws_s3.table_import_from_s3(
   )',
   aws_commons.create_s3_uri('rst-fta-dataload-oracle', 'RECREATION_USER_DAYS_CODE.csv', 'ca-central-1')
 );
+
+commit;

--- a/migrations/fta/sql/V1.0.2__fta_to_rst.sql
+++ b/migrations/fta/sql/V1.0.2__fta_to_rst.sql
@@ -1,3 +1,5 @@
+begin;
+
 insert into rst.recreation_resource (rec_resource_id, name, description, site_location, display_on_public_site)
 select
     rp.forest_file_id,
@@ -46,3 +48,5 @@ from
     fta.recreation_comment
 where
     rec_comment_type_code = 'CLOS';
+
+commit;

--- a/migrations/rst/sql/V1.0.0__init.sql
+++ b/migrations/rst/sql/V1.0.0__init.sql
@@ -1,6 +1,5 @@
 begin;
 
-drop extension if exists "postgis";
 create extension if not exists "postgis";
 
 create schema if not exists rst;

--- a/migrations/rst/sql/V1.0.0__init.sql
+++ b/migrations/rst/sql/V1.0.0__init.sql
@@ -1,3 +1,6 @@
+begin;
+
+drop extension if exists "postgis";
 create extension if not exists "postgis";
 
 create schema if not exists rst;
@@ -40,3 +43,5 @@ comment on table rst.recreation_activity is 'The types of available activities f
 comment on column rst.recreation_activity.rec_resource_id is 'File identification assigned to Provincial Forest Use files. Assigned file number. Usually the Licence, Tenure or Private Mark number.';
 
 comment on column rst.recreation_activity.recreation_activity_code is 'Code describing the Recreation Activity.';
+
+commit;

--- a/migrations/rst/sql/V1.0.1__recreation_status.sql
+++ b/migrations/rst/sql/V1.0.1__recreation_status.sql
@@ -1,3 +1,5 @@
+begin;
+
 -- In the current FTA database the site status is saved in the recreation_comment table as a closure type comment with closure_ind = 'Y'.
 
 -- Creating a code table as there may be status other than open/closed in the future ie: open with advisories
@@ -15,4 +17,6 @@ create table if not exists rst.recreation_status (
     rec_resource_id varchar(200) not null references rst.recreation_resource (rec_resource_id) primary key,
     status_code varchar(3) not null references rst.recreation_status_code (status_code),
     comment varchar(5000) not null
-)
+);
+
+commit;


### PR DESCRIPTION
The database in AWS RDS dev is named app, seeing if it's easy to rename it `rst`

- Rename RDS database from app to rst
- Add s3 import role/policy to our terraform and add role to rds cluster
- Wrap migrations in transaction
- Get exit code and fail flyway ecs task if migration fails