### PR TITLE
chore: add db schema/api demo code

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -10,12 +10,13 @@ datasource db {
 }
 
 model recreation_resource {
-  rec_resource_id        String                @id @db.VarChar(200)
-  name                   String?               @db.VarChar(200)
-  description            String?               @db.VarChar(5000)
-  site_location          String?               @db.VarChar(200)
-  display_on_public_site Boolean?              @default(false)
+  rec_resource_id        String                   @id @db.VarChar(200)
+  name                   String?                  @db.VarChar(200)
+  description            String?                  @db.VarChar(5000)
+  site_location          String?                  @db.VarChar(200)
+  display_on_public_site Boolean?                 @default(false)
   recreation_activity    recreation_activity[]
+  recreation_map_feature recreation_map_feature[]
   recreation_status      recreation_status?
 }
 
@@ -47,4 +48,18 @@ model recreation_status_code {
   status_code       String              @id @db.VarChar(3)
   description       String              @db.VarChar(120)
   recreation_status recreation_status[]
+}
+
+model recreation_map_feature {
+  id                          Int                         @id @default(autoincrement())
+  rec_resource_id             String                      @db.VarChar(200)
+  recreation_map_feature_code String                      @db.VarChar(3)
+  recreation_resource         recreation_resource         @relation(fields: [rec_resource_id], references: [rec_resource_id], onDelete: NoAction, onUpdate: NoAction)
+  with_description            recreation_map_feature_code @relation("map_feature_with_description", fields: [recreation_map_feature_code], references: [recreation_map_feature_code], onDelete: NoAction, onUpdate: NoAction)
+}
+
+model recreation_map_feature_code {
+  recreation_map_feature_code String                   @id @db.VarChar(3)
+  description                 String?                  @db.VarChar(120)
+  with_description            recreation_map_feature[] @relation("map_feature_with_description")
 }

--- a/backend/src/recreation-resource/dto/recreation-resource.dto.ts
+++ b/backend/src/recreation-resource/dto/recreation-resource.dto.ts
@@ -37,4 +37,12 @@ export class RecreationResourceDto {
     comment: string;
     description: string;
   };
+
+  @ApiProperty({
+    description: "The Recreation Map Feature",
+  })
+  recreation_map_feature: {
+    description: string;
+    recreation_map_feature_code: string;
+  };
 }

--- a/backend/src/recreation-resource/recreation-resource.service.ts
+++ b/backend/src/recreation-resource/recreation-resource.service.ts
@@ -23,6 +23,10 @@ interface RecreationResource {
     comment: string;
     status_code: string;
   };
+  recreation_map_feature: {
+    rec_resource_id: string;
+    recreation_map_feature_code: string;
+  };
 }
 
 @Injectable()
@@ -42,6 +46,11 @@ export class RecreationResourceService {
         with_description: true,
       },
     },
+    recreation_map_feature: {
+      select: {
+        with_description: true,
+      },
+    },
     recreation_status: {
       select: {
         recreation_status_code: {
@@ -57,6 +66,7 @@ export class RecreationResourceService {
 
   // Format the results to match the DTO
   formatResults(recResources: RecreationResource[]): RecreationResourceDto[] {
+    console.log(recResources[0].recreation_map_feature);
     return recResources?.map((resource) => ({
       ...resource,
       recreation_activity: resource.recreation_activity?.map(
@@ -71,6 +81,13 @@ export class RecreationResourceService {
           resource.recreation_status?.recreation_status_code.description,
         comment: resource.recreation_status?.comment,
         status_code: resource.recreation_status?.status_code,
+      },
+      recreation_map_feature: {
+        description:
+          resource.recreation_map_feature[0]?.with_description.description,
+        recreation_map_feature_code:
+          resource.recreation_map_feature[0]?.with_description
+            .recreation_map_feature_code,
       },
     }));
   }

--- a/frontend/src/components/rec-resource/RecResourcePage.tsx
+++ b/frontend/src/components/rec-resource/RecResourcePage.tsx
@@ -59,6 +59,7 @@ const RecResourcePage = () => {
       .get(`/v1/recreation-resource/${id}`)
       .then((response: AxiosResponse) => {
         setRecResource(response.data);
+        console.log(response.data);
         return response.data;
       })
       .catch((error) => {
@@ -70,6 +71,7 @@ const RecResourcePage = () => {
 
   const {
     recreation_activity,
+    recreation_map_feature,
     description,
     name,
     rec_resource_id,
@@ -80,6 +82,8 @@ const RecResourcePage = () => {
       comment: statusComment,
     } = {},
   } = recResource || {};
+
+  const { description: mapDescription } = recreation_map_feature || {};
 
   const formattedName = name?.toLowerCase();
 
@@ -132,7 +136,7 @@ const RecResourcePage = () => {
             <div>
               <h1 className="capitalize">{formattedName}</h1>
               <p className="bc-color-blue-dk mb-4">
-                <span>Recreation site |</span> {rec_resource_id}
+                <span>{mapDescription} |</span> {rec_resource_id}
               </p>
             </div>
             <div className="icon-container mb-4">

--- a/migrations/fixtures/sql/V1.0.4__recreation_map_feature_code.sql
+++ b/migrations/fixtures/sql/V1.0.4__recreation_map_feature_code.sql
@@ -1,0 +1,9 @@
+insert into
+    rst.recreation_map_feature (rec_resource_id, recreation_map_feature_code)
+values
+    ('REC204117', 'IF'),
+    ('REC1222', 'RR'),
+    ('REC1222', 'RTR'),
+    ('REC1222', 'SIT'),
+    ('REC1222', 'RR'),
+    ('REC1222', 'IF');

--- a/migrations/rst/sql/V1.0.0__init.sql
+++ b/migrations/rst/sql/V1.0.0__init.sql
@@ -40,3 +40,23 @@ comment on table rst.recreation_activity is 'The types of available activities f
 comment on column rst.recreation_activity.rec_resource_id is 'File identification assigned to Provincial Forest Use files. Assigned file number. Usually the Licence, Tenure or Private Mark number.';
 
 comment on column rst.recreation_activity.recreation_activity_code is 'Code describing the Recreation Activity.';
+
+create table if not exists rst.recreation_map_feature_code (
+    recreation_map_feature_code varchar(3) primary key,
+    description varchar(120)
+);
+
+insert into rst.recreation_map_feature_code (recreation_map_feature_code, description)
+values
+    ('IF', 'Interpretive Forest'),
+    ('RR', 'Recreation Reserve'),
+    ('RTR', 'Recreation Trail'),
+    ('SIT', 'Recreation Site');
+
+
+
+create table if not exists rst.recreation_map_feature (
+    id serial primary key, -- This is a surrogate key to make Prisma happy
+    rec_resource_id varchar(200) not null references rst.recreation_resource (rec_resource_id),
+    recreation_map_feature_code varchar(3) not null references rst.recreation_map_feature_code (recreation_map_feature_code)
+);


### PR DESCRIPTION
Not to be used for the rec resource type issue, this was a demo. Sounds like we won't keep the recreation_map_feature_code in the recreation_map_feature table. Also likely name `recreation_map_feature_code` to something more clear like `recreation_resource_type`?

Commands to update Prisma schema and regenerate Prisma client:
```
npx prisma db pull
npx prisma generate
```

Still todo:
- Add sql statement to insert prod data from fst schema to our new table in rst schema in `/migrations/fta/sql/V1.0.2__fta_to_rst.sql`
- Won't do it for this demo PR but you can see in the changed files that the tests need to be updated since we are expecting new fields
