### PR TITLE
ci: re-run trivy workflow on failure

### DIFF
--- a/.github/workflows/.analysis.yml
+++ b/.github/workflows/.analysis.yml
@@ -90,7 +90,7 @@ jobs:
           sarif_file: "trivy-results.sarif"
 
   # Retry the workflow due to Trivy flaky sarif-upload issue
-  retry-on-failure:
+  retry-trivy-on-failure:
     needs: trivy
     if: failure() || (needs.trivy.result != 'success' && fromJSON(github.run_attempt) < 3 && !cancelled())
     runs-on: ubuntu-latest

--- a/.github/workflows/.analysis.yml
+++ b/.github/workflows/.analysis.yml
@@ -92,7 +92,7 @@ jobs:
   # Retry the workflow due to Trivy flaky sarif-upload issue
   retry-trivy-on-failure:
     needs: trivy
-    if: failure() || (needs.trivy.result != 'success' && fromJSON(github.run_attempt) < 3 && !cancelled())
+    if: needs.trivy.result != 'success' && fromJSON(github.run_attempt) < 3 && !cancelled()
     runs-on: ubuntu-latest
     steps:
       - env:

--- a/.github/workflows/.analysis.yml
+++ b/.github/workflows/.analysis.yml
@@ -89,6 +89,18 @@ jobs:
         with:
           sarif_file: "trivy-results.sarif"
 
+  # Retry the workflow due to Trivy flaky sarif-upload issue
+  retry-on-failure:
+    needs: trivy
+    if: failure() || (fromJSON(github.run_attempt) < 3 && !cancelled())
+    runs-on: ubuntu-latest
+    steps:
+      - env:
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+          GH_DEBUG: api
+        run: gh workflow run retry-workflow.yml -F run_id=${{ github.run_id }}
+
   pre-commit:
     name: Pre-Commit Validation
     runs-on: ubuntu-24.04

--- a/.github/workflows/.analysis.yml
+++ b/.github/workflows/.analysis.yml
@@ -92,7 +92,7 @@ jobs:
   # Retry the workflow due to Trivy flaky sarif-upload issue
   retry-on-failure:
     needs: trivy
-    if: failure() || (fromJSON(github.run_attempt) < 3 && !cancelled())
+    if: failure() || (needs.trivy.result != 'success' && fromJSON(github.run_attempt) < 3 && !cancelled())
     runs-on: ubuntu-latest
     steps:
       - env:

--- a/.github/workflows/retry-workflow.yml
+++ b/.github/workflows/retry-workflow.yml
@@ -1,0 +1,18 @@
+name: Retry workflow
+
+on:
+  workflow_dispatch:
+    inputs:
+      run_id:
+        required: true
+jobs:
+  retry-on-failure:
+    runs-on: ubuntu-latest
+    steps:
+      - name: rerun ${{ inputs.run_id }}
+        env:
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh run watch ${{ inputs.run_id }} > /dev/null 2>&1
+          gh run rerun ${{ inputs.run_id }} --failed


### PR DESCRIPTION
Trivy sarif-upload is being flaky some days so using the `retry-workflow`. It's not an ideal solution though should mitigate some toil, we will keep an eye on this and perhaps come up with another solution if it still fails.

It should now retry 3 times before failing. Though workflows aren't available through the github cli before merging to main so I was unable to test this completely.