### PR TITLE
refactor: rename recreation_resources site_location to closest_community

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -13,7 +13,7 @@ model recreation_resource {
   rec_resource_id        String                @id @db.VarChar(200)
   name                   String?               @db.VarChar(200)
   description            String?               @db.VarChar(5000)
-  site_location          String?               @db.VarChar(200)
+  closest_community      String?               @db.VarChar(200)
   display_on_public_site Boolean?              @default(false)
   rec_resource_type      String?               @db.VarChar(50)
   recreation_activity    recreation_activity[]

--- a/backend/src/recreation-resource/dto/recreation-resource.dto.spec.ts
+++ b/backend/src/recreation-resource/dto/recreation-resource.dto.spec.ts
@@ -46,7 +46,7 @@ describe("Recreation DTOs", () => {
         name: "Evergreen Valley Campground",
         description:
           "A scenic campground nestled in the heart of Evergreen Valley",
-        site_location: "123 Forest Road, Mountain View, CA 94043",
+        closest_community: "123 Forest Road, Mountain View, CA 94043",
         recreation_activity: [
           {
             recreation_activity_code: 1,
@@ -72,7 +72,7 @@ describe("Recreation DTOs", () => {
         rec_resource_id: "rec-123-abc",
         name: "Test Resource",
         description: null,
-        site_location: "Test Location",
+        closest_community: "Test Location",
         recreation_activity: [],
         recreation_status: {
           status_code: 1,

--- a/backend/src/recreation-resource/dto/recreation-resource.dto.ts
+++ b/backend/src/recreation-resource/dto/recreation-resource.dto.ts
@@ -61,7 +61,7 @@ export class RecreationResourceDto {
     description: "Physical location of the Recreation Resource",
     example: "123 Forest Road, Mountain View, CA 94043",
   })
-  site_location: string;
+  closest_community: string;
 
   @ApiProperty({
     description: "List of recreational activities available at this resource",

--- a/backend/src/recreation-resource/recreation-resource.controller.spec.ts
+++ b/backend/src/recreation-resource/recreation-resource.controller.spec.ts
@@ -78,7 +78,7 @@ describe("RecreationResourceController", () => {
             rec_resource_id: "REC0001",
             name: "Rec site 1",
             description: "Rec site 1 description",
-            site_location: "Rec site 1 location",
+            closest_community: "Rec site 1 location",
             recreation_activity: [],
             recreation_status: {
               description: "Active",

--- a/backend/src/recreation-resource/recreation-resource.controller.spec.ts
+++ b/backend/src/recreation-resource/recreation-resource.controller.spec.ts
@@ -46,7 +46,7 @@ describe("RecreationResourceController", () => {
         rec_resource_id: "REC0001",
         name: "Rec site 1",
         description: "Rec site 1 description",
-        site_location: "Rec site 1 location",
+        closest_community: "Rec site 1 location",
         recreation_activity: [],
         display_on_public_site: true,
         recreation_status: {

--- a/backend/src/recreation-resource/recreation-resource.service.spec.ts
+++ b/backend/src/recreation-resource/recreation-resource.service.spec.ts
@@ -6,7 +6,7 @@ const recreationResource1 = {
   rec_resource_id: "REC0001",
   name: "Rec site 1",
   description: "Rec site 1 description",
-  site_location: "Rec site 1 location",
+  closest_community: "Rec site 1 location",
   display_on_public_site: true,
   recreation_activity: [
     {
@@ -46,7 +46,7 @@ const recreationResource2 = {
   rec_resource_id: "REC0002",
   name: "Rec site 2",
   description: "Rec site 2 description",
-  site_location: "Rec site 2 location",
+  closest_community: "Rec site 2 location",
   display_on_public_site: true,
   recreation_activity: [],
   recreation_status: {
@@ -74,7 +74,7 @@ const recreationResource3 = {
   rec_resource_id: "REC0003",
   name: "A testing orderBy",
   description: "Rec site 3 description",
-  site_location: "Rec site 3 location",
+  closest_community: "Rec site 3 location",
   display_on_public_site: true,
   recreation_activity: [
     {
@@ -114,7 +114,7 @@ const recreationResource4 = {
   rec_resource_id: "REC0004",
   name: "Z testing orderBy",
   description: "Rec site 4 description",
-  site_location: "Rec site 4 location",
+  closest_community: "Rec site 4 location",
   display_on_public_site: false,
   recreation_activity: [
     {

--- a/backend/src/recreation-resource/recreation-resource.service.ts
+++ b/backend/src/recreation-resource/recreation-resource.service.ts
@@ -8,7 +8,7 @@ const recreationResourceSelect = {
   rec_resource_id: true,
   description: true,
   name: true,
-  site_location: true,
+  closest_community: true,
   display_on_public_site: true,
   rec_resource_type: true,
 

--- a/backend/src/recreation-resource/recreation-resource.service.ts
+++ b/backend/src/recreation-resource/recreation-resource.service.ts
@@ -171,7 +171,7 @@ export class RecreationResourceService {
       OR: [
         { name: { contains: filter, mode: Prisma.QueryMode.insensitive } },
         {
-          site_location: {
+          closest_community: {
             contains: filter,
             mode: Prisma.QueryMode.insensitive,
           },

--- a/frontend/src/components/rec-resource/RecResourcePage.test.tsx
+++ b/frontend/src/components/rec-resource/RecResourcePage.test.tsx
@@ -10,7 +10,7 @@ const mockResource = {
   rec_resource_id: 'REC1234',
   name: 'Resource Name',
   description: 'Resource Description',
-  site_location: 'Resource Location',
+  closest_community: 'Resource Location',
   recreation_activity: [
     {
       recreation_activity_code: 1,

--- a/frontend/src/components/rec-resource/RecResourcePage.tsx
+++ b/frontend/src/components/rec-resource/RecResourcePage.tsx
@@ -76,8 +76,8 @@ const RecResourcePage = () => {
     description,
     name,
     rec_resource_id,
-    site_location,
     rec_resource_type,
+    closest_community,
     recreation_status: {
       status_code: statusCode,
       description: statusDescription,
@@ -187,7 +187,9 @@ const RecResourcePage = () => {
                 height={24}
                 width={24}
               />{' '}
-              <span className="capitalize">{site_location?.toLowerCase()}</span>
+              <span className="capitalize">
+                {closest_community?.toLowerCase()}
+              </span>
             </div>
             {statusCode && statusDescription && (
               <Status description={statusDescription} statusCode={statusCode} />

--- a/frontend/src/components/rec-resource/card/RecResourceCard.tsx
+++ b/frontend/src/components/rec-resource/card/RecResourceCard.tsx
@@ -19,7 +19,7 @@ const RecResourceCard: React.FC<RecResourceCardProps> = ({
     rec_resource_id,
     name,
     recreation_activity: activities,
-    site_location,
+    closest_community,
     recreation_status: { status_code, description: statusDescription },
   } = recreationResource;
   const isActivities = activities.length > 0;
@@ -37,7 +37,7 @@ const RecResourceCard: React.FC<RecResourceCardProps> = ({
               />
             </h2>
           </a>
-          <p className="capitalize">{site_location?.toLowerCase()}</p>
+          <p className="capitalize">{closest_community?.toLowerCase()}</p>
         </div>
         <div className="card-content-lower">
           {isActivities ? <Activities activities={activities} /> : <div />}

--- a/frontend/src/components/rec-resource/types.ts
+++ b/frontend/src/components/rec-resource/types.ts
@@ -14,6 +14,6 @@ export interface RecreationResource {
   name: string;
   rec_resource_id: string;
   recreation_activity: Activity[];
-  site_location: string;
+  closest_community: string;
   recreation_status: RecreationStatus;
 }

--- a/frontend/src/components/search/SearchPage.test.tsx
+++ b/frontend/src/components/search/SearchPage.test.tsx
@@ -21,7 +21,7 @@ const mockResources = {
       {
         rec_resource_id: 'REC204117',
         name: '0 K SNOWMOBILE PARKING LOT',
-        site_location: 'MERRITT',
+        closest_community: 'MERRITT',
         recreation_activity: [
           {
             description: 'Snowmobiling',
@@ -33,7 +33,7 @@ const mockResources = {
       {
         rec_resource_id: 'REC203239',
         name: '10 K SNOWMOBILE PARKING LOT',
-        site_location: 'MERRITT',
+        closest_community: 'MERRITT',
         recreation_activity: [
           {
             description: 'Snowmobiling',
@@ -45,7 +45,7 @@ const mockResources = {
       {
         rec_resource_id: 'REC1222',
         name: '100 ROAD BRIDGE',
-        site_location: 'PRINCE GEORGE',
+        closest_community: 'PRINCE GEORGE',
         recreation_activity: [
           {
             description: 'Picnicking',
@@ -61,7 +61,7 @@ const mockResources = {
       {
         rec_resource_id: 'REC160773',
         name: '10K CABIN',
-        site_location: 'MERRITT',
+        closest_community: 'MERRITT',
         recreation_activity: [
           {
             description: 'Snowmobiling',
@@ -73,7 +73,7 @@ const mockResources = {
       {
         rec_resource_id: 'REC203900',
         name: '18 Mile',
-        site_location: 'REVELSTOKE',
+        closest_community: 'REVELSTOKE',
         recreation_activity: [
           {
             description: 'Boating',
@@ -101,7 +101,7 @@ const mockResources = {
       {
         rec_resource_id: 'REC6866',
         name: '1861 GOLDRUSH PACK TRAIL',
-        site_location: 'WELLS',
+        closest_community: 'WELLS',
         recreation_activity: [
           {
             description: 'Ski Touring',
@@ -121,7 +121,7 @@ const mockResources = {
       {
         rec_resource_id: 'REC160432',
         name: '24 KM SHELTER',
-        site_location: 'MERRITT',
+        closest_community: 'MERRITT',
         recreation_activity: [
           {
             description: 'Snowmobiling',
@@ -133,7 +133,7 @@ const mockResources = {
       {
         rec_resource_id: 'REC6739',
         name: '24 MILE SNOWMOBILE AREA',
-        site_location: 'CASTLEGAR',
+        closest_community: 'CASTLEGAR',
         recreation_activity: [
           {
             description: 'Snowmobiling',
@@ -145,7 +145,7 @@ const mockResources = {
       {
         rec_resource_id: 'REC16158',
         name: '27 Swithbacks',
-        site_location: 'WHISTLER',
+        closest_community: 'WHISTLER',
         recreation_activity: [
           {
             description: 'Mountain Biking',
@@ -161,7 +161,7 @@ const mockResources = {
       {
         rec_resource_id: 'REC2094',
         name: '40 Mile CAMP / BULL River',
-        site_location: 'FERNIE',
+        closest_community: 'FERNIE',
         recreation_activity: [
           {
             description: 'Angling',

--- a/frontend/src/service/recreation-resource/models/RecreationResourceDto.ts
+++ b/frontend/src/service/recreation-resource/models/RecreationResourceDto.ts
@@ -57,7 +57,7 @@ export interface RecreationResourceDto {
    * @type {string}
    * @memberof RecreationResourceDto
    */
-  site_location: string;
+  closest_community: string;
   /**
    * List of recreational activities available at this resource
    * @type {Array<RecreationActivityDto>}
@@ -85,7 +85,10 @@ export function instanceOfRecreationResourceDto(
   if (!('name' in value) || value['name'] === undefined) return false;
   if (!('description' in value) || value['description'] === undefined)
     return false;
-  if (!('site_location' in value) || value['site_location'] === undefined)
+  if (
+    !('closest_community' in value) ||
+    value['closest_community'] === undefined
+  )
     return false;
   if (
     !('recreation_activity' in value) ||
@@ -117,8 +120,8 @@ export function RecreationResourceDtoFromJSONTyped(
     rec_resource_id: json['rec_resource_id'],
     name: json['name'],
     description: json['description'],
-    site_location: json['site_location'],
     rec_resource_type: json['rec_resource_type'],
+    closest_community: json['closest_community'],
     recreation_activity: (json['recreation_activity'] as Array<any>).map(
       RecreationActivityDtoFromJSON,
     ),
@@ -142,7 +145,7 @@ export function RecreationResourceDtoToJSONTyped(
     rec_resource_id: value['rec_resource_id'],
     name: value['name'],
     description: value['description'],
-    site_location: value['site_location'],
+    closest_community: value['closest_community'],
     recreation_activity: (value['recreation_activity'] as Array<any>).map(
       RecreationActivityDtoToJSON,
     ),

--- a/frontend/src/service/recreation-resource/models/RecreationResourceDto.ts
+++ b/frontend/src/service/recreation-resource/models/RecreationResourceDto.ts
@@ -70,7 +70,11 @@ export interface RecreationResourceDto {
    * @memberof RecreationResourceDto
    */
   recreation_status: RecreationStatusDto;
-
+  /**
+   * Code representing a specific feature associated with the recreation resource
+   * @type {string}
+   * @memberof RecreationResourceDto
+   */
   rec_resource_type: string;
 }
 
@@ -100,6 +104,11 @@ export function instanceOfRecreationResourceDto(
     value['recreation_status'] === undefined
   )
     return false;
+  if (
+    !('rec_resource_type' in value) ||
+    value['rec_resource_type'] === undefined
+  )
+    return false;
   return true;
 }
 
@@ -120,12 +129,12 @@ export function RecreationResourceDtoFromJSONTyped(
     rec_resource_id: json['rec_resource_id'],
     name: json['name'],
     description: json['description'],
-    rec_resource_type: json['rec_resource_type'],
     closest_community: json['closest_community'],
     recreation_activity: (json['recreation_activity'] as Array<any>).map(
       RecreationActivityDtoFromJSON,
     ),
     recreation_status: RecreationStatusDtoFromJSON(json['recreation_status']),
+    rec_resource_type: json['rec_resource_type'],
   };
 }
 
@@ -150,5 +159,6 @@ export function RecreationResourceDtoToJSONTyped(
       RecreationActivityDtoToJSON,
     ),
     recreation_status: RecreationStatusDtoToJSON(value['recreation_status']),
+    rec_resource_type: value['rec_resource_type'],
   };
 }

--- a/migrations/fixtures/sql/V1.0.0__recreation_resource.sql
+++ b/migrations/fixtures/sql/V1.0.0__recreation_resource.sql
@@ -1,53 +1,418 @@
-insert into rst.recreation_resource (rec_resource_id, name, description, site_location, display_on_public_site, rec_resource_type)
+insert into
+  rst.recreation_resource (
+    rec_resource_id,
+    name,
+    description,
+    closest_community,
+    display_on_public_site,
+    rec_resource_type
+  )
 values
-('REC204117', '0 K SNOWMOBILE PARKING LOT', 'The Zero K Tulameen Snowmobile Parking Lot is an area managed for snowmobilers who use the Mt. Henning and 10 K Area Snowmobile Trails in the vicinity. The parking lot and the trail network it supports is managed under a partnership agreement with the Coquihalla Summit Snowmobile Club during the snowmobile season and has an informative kiosk, outhouse and fee collection hut complete with a heated change room. Fees are applicable for the use of the snowmobile trails which are frequently groomed.', 'MERRITT', true, 'RTR'),
-('REC1222', '100 ROAD BRIDGE', 'Site not currently being managed. Pending disestablishment (Jan 2009) - Sept 2021 Update: Site should have updated inspection. Site was never disestablished and is well used by the public.', 'PRINCE GEORGE', true, 'RTR'),
-('REC160773', '10K CABIN', 'This snowmobile emergency cabin is located north of Coquihalla Mountain and is accessed via the Mt. Henning and 10 k Area Snowmobile Trails. The cabin is maintained under management agreement with the Coquihalla Summit Snowmobile Club and is intended for emergency use only. Please respect this cabin by keeping it clean and vandalism free. An avalanche terrain map and trail map is located within the cabin to advise snowmobilers of the types of avalanche terrain encountered in the area and the avalanche danger rating system.', 'MERRITT', true, 'RTR'),
-('REC203239', '10 K SNOWMOBILE PARKING LOT', 'A 1 hectare gravel parking lot located at 10.2 km of the Tulameen Forest Service Road. Managed in partnership with the Coquihalla Summit Snowmobile Club this parking lot can be used by sledders who generally access the Coquihalla Mountain area near where the 10 k Cabin is located. The parking lot may be ploughed some winter seasons while other seasons it will not be ploughed depending upon whether the industrial road is being used and machinery can then access the lot for ploughing. Best to check the club website for more details at Coqsnow.com', 'MERRITT', true, 'RTR'),
-('REC6866', '1861 GOLDRUSH PACK TRAIL', 'Come and hike the original route used by Goldrush miners as they travelled overland from the Coast into the Goldfields of the Barkerville area. The trailhead is in Barkerville and travels up and over Yanks Peak (French Snowshoe Mountain) and down to Weaver Creek where it joins the current road system. There are numerous historic sites along the trail as well as several rustic campsites. Visit www.barkerville.bc.ca for more details. Non Motorized Use Only', 'WELLS', true, 'RTR'),
-('REC203900', '18 Mile', '18 mile camping area sits at an elevation +/- 587 meters on Revelstoke Lake with changing shore lines, Revelstoke Lake is a lake created by hydro electric power generation.', 'REVELSTOKE', true, 'RTR'),
-('REC160432', '24 KM SHELTER', 'An area set aside for any future snowmobile parking lot or shelter location which is currently managed under a snowmobile trail maintenance agreement with the Merritt Snowmobile Club. Currently has only an outhouse on location.', 'MERRITT', true, 'RTR'),
-('REC6739', '24 MILE SNOWMOBILE AREA', 'The West Kootenay Snow Goers manage about 30 Km of groomed trail in the area with 2 day use warming huts. The groomed trails are easy riding and the whole area is generally for beginner to moderate sledding skills with some areas of advanced terrain around the Mount Shields area.', 'CASTLEGAR', true, 'RTR'),
-('REC16158', '27 Swithbacks', 'Forested Mtn Bike', 'WHISTLER', true, 'RTR'),
-('REC2094', '40 Mile CAMP / BULL River', 'A small scenic site at the confluence of Quinn Creek and the Bull River.', 'FERNIE', true, 'RR'),
-('REC6897', '70 Mile Green Lake Trail', 'The trail starts at 70 Mile House BC and connects to a vast network of snowmobile and ATV trails around south Green Lake. From 70 Mile House, it is also possible to connect to the Gold Rush Recreation Trail, allowing users to travel as far north as Horsefly, and as far south as Clinton.', '70 MILE HOUSE', true, 'RR'),
-('REC2206', '7 MILE LAKE', 'This is a small site, semi-forested with mature Larch and Lodgepole Pine trees, with a central grassy, open area. Most of the sites are well-shaded, as the recreation site is nestled in a valley bottom. The site is located adjacent to Seven Mile Lake, a small shallow, weedy lake which is the headwaters of Caven Creek. The lake has a steep shoreline and is treed right to the water on the south shore, but a rough trail along the north side of the lake provides access to the deeper portion of the lake which is suitable for fishing. The lake is stocked with Cutthroat trout every other year. The site is located right on the main FSR but traffic is not excessive at this point.', 'CRANBROOK', true, 'RR'),
-('REC206043', '8 Mile Cabin Telegraph Trail', 'These are historic cabin/shelters sites, and may not be an actual functioning shelter.', 'Bob Quinn Lake', true, 'RTR'),
-('REC166903', '99 Mile Cross-Country Ski Trails', 'The 99 Mile Cross Country Ski Trails are groomed and maintained by the 100 Mile Nordic Ski Society. Please visit their website at 100 Mile Nordics for more information regarding seasons passes, day passes, lodge operating hours, and ski conditions. The trail network boasts 45 km of groomed ski trails, 5 km of lit trails for night skiing and 6.5 km of snowshoe trails.', '100 MILE HOUSE', true, 'RTR'),
-('REC32013', '99 Mile Mountain Bike Trails', 'These trails wind their way through stands of Douglas-fir and lodgepole pine above the community of 100 Mile House. The 99 Mile Hill is home to several trail networks for a variety of recreation activities, including cross-country skiing, snowmobiling, and horseback riding. The area also provides opportunities for the public to tour through a demonstration forest with interpretative signs.', '100 MILE HOUSE', true, 'RTR'),
-('REC261475', '99 Mile Off Road Motorcycle', 'off-road motorcycle trails (singletrack)', '100 MILE HOUSE', true, 'RTR'),
-('REC166942', '99 Mile Parking Oval', 'This is a parking area for those enjoying the recreation trails.', '100 Mile House', true, 'RTR'),
-('REC2792', '99 MILE SKI TRAILS', 'These Trails are a short Drive outside of 100 Mile house', '100 Mile House', true, 'RTR'),
-('REC230522', '99 Mile Snowshoe Trails', 'These snowshoe trails are near the 99 Mile Cross Country Ski Trails network. There are 2 snowshoe trail loops available: the Bear Paw trail and the Beanstalk Cabin trail. The Bear Paw trail is the shorter and easier loop, while the Beanstalk Cabin trail is the longer and more challenging trail. Please do not walk or snowshoe along the set cross-country ski trails in the area.', '100 MILE HOUSE', true, 'RTR'),
-('REC205035', '99 Mile XC Keene Road Parking', 'Parking area', '100 Mile House', true, 'RTR'),
-('REC2566', 'ABBOTT CREEK', 'Looking for sun on the beach? Abbott Creek is the spot. A mid-sized rec site along the North Shore of Quesnel Lake with the majority of the sites set back in the shade of the Cottonwood trees along the large gravel beach. Boat launch is across the beach, 4x4 may be required. This also makes an excellent spot to start a boat trip on Quesnel Lake. Please park in the upper parking area and not a campsite if you intend to be away from the site for an extended period.', 'LIKELY', true, 'RTR'),
-('REC1735', 'ABBOTT LAKE', 'This small 3 vehicle somewhat remote recreation site is located in a semi open area on the north east side of Abbott Lake and is popular for fishing and boating. The camping spots are suitable for small truck campers and tenters and not for anything towed due to the rough access.', 'MERRITT', true, 'RTR'),
-('REC2978', 'ABBOTT LAKE TRAIL', 'This is a 400m access trail to the south shore of Abbott Lake. There are no facilities other than a parking area off of the Horsefly Road. There is no boat launching access via this trail.', 'HORSEFLY', true, 'RTR'),
-('REC136003', 'Aberdeen Columns', 'Aberdeen Columns is a climbing area in central BC. The Basalt columns are an ancient artifact of volcanic activity long ago over the Aberdeen plateau. Rock climbing is a dangerous activity carrying a significant risk to your personal safety and should be undertaken with a full understanding of all inherent risks.', 'LAVINGTON', true, 'RTR'),
-('REC265901', 'Aberdeen Columns Trail', 'Aberdeen columns are basalt rock formations. The Okanagan valley formed 60 million years ago as a result from a rift. 40 million years ago the valley was a wash with gushing volcanoes. Some of which are Knox Mountain, Dilworth and Mount Boucherie. The valley didn''t exist when dinosaurs roamed the earth. The result today is a popular climbing area.', 'LAVINGTON', true, 'RTR'),
-('REC1585', 'ABERDEEN LAKE', 'This semi-open site on a medium sized fishing lake is subject to significant water level fluctuations. The access is very rough for 2 km before the site.', 'LAVINGTON', true, 'RTR'),
-('REC262200', 'Aberdeen Snowshoe', NULL, 'LAVINGTON', true, 'RTR'),
-('REC265549', 'Aberdeen Snowshoe Trails', 'Snowshoe and hiking trails, XC trails short drive from Lavington BC', 'LUMBY', true, 'SIT'),
-('REC270155', 'Abiotic Factor', 'Forested Trail', 'SILVERTON', true, 'SIT'),
-('REC0587', 'AGATE POINT', 'A small day-use site with 3 tables and 1 outhouse. Located on the north shore of Tchesinkut Lake.', 'BURNS LAKE', true, 'SIT'),
-('REC166367', 'Agnes Lake Trail', 'This trail provides access to a small secluded lake with excellent fishing. Agnes Lake is situated in a lodgepole pine & spruce forest in the foothills of the Coast Range of mountains at an elevation of 1300 m. The trail is only 600 m long and provides easy access to Agnes Lake. Travel time is about 15 minutes by foot. There are no facilities at the lake. The trail and surrounding area was heavily impacted by wildfire in 2017, but the trail has been cleared and marked with trail markers in September of 2019.', 'TATLA LAKE', true, 'SIT'),
-('REC1621', 'AGUR LAKE', 'Agur Lake is a small lake West of Summerland. The shores of the lake are marshy.', 'SUMMERLAND', true, 'RTR'),
-('REC1164', 'AHBAU LAKE', 'This semi-remote site is located on the northern shores of beautiful Ahbau Lake, near the border of the Prince George and Quesnel Forest Districts. This site has camping pads to accommodate 10 larger units as well as another 10 smaller sites on the upper loop road. There is access to a lake via a concrete boat launch. The lake is popular for kayaking and boating, and offers opportunities for angling of wild fish (rainbow trout and coarse fish species). The site offers the basic amenities of fire rings, tables and pit toilets.', 'QUESNEL', true, 'RTR'),
-('REC5763', 'AHDATAY', 'Sand beach, boat access only, user maintained.', 'FORT ST. JAMES', true, 'RTR'),
-('REC4519', 'AILEEN LAKE', 'This site is on a small fishing lake. There is 1 table and outhouse on site. Access is poor and requires a 4wd vehicle. Campers and trailers will have a difficult time getting into Aileen Lake due to water bars along the roads through cutblocks, and large water puddles and the ingrown forest for the last 800m. Best suited for the day fisherman in a pickup truck.', 'WINFIELD', true, 'RTR'),
-('REC265446', 'Airy Area', 'Wilderness area, alpine hiking', 'SLOCAN', true, 'RTR'),
-('REC262362', 'Aitken Falls', 'Water falls', 'HOUSTON', true, 'RTR'),
-('REC192109', 'Alamo Hiking Trail', 'Are trails at the base of Idaho Peak with an elevation 2282 m / 7486 ft. The trail winds its way through forested areas.', 'NEW DENVER', true, 'RTR'),
-('REC204480', 'Albright Trail', 'Albright Trail', 'Tumbler Ridge', true, 'IF'),
-('REC0180', 'ALDER GROVE', 'A small shady site on an old railgrade with a short trail to the lakeshore.', 'CAMPBELL RIVER', true, 'IF'),
-('REC97746', 'Aldridge Creek Trail', 'In conjunction with the Great Divide Trail and the Hornaday Wilderness Society, the trail was rebuilt in 2015.', 'ELKFORD', true, 'IF'),
-('REC2047', 'ALDRIDGE CR WEST', 'A small, heavily treed site on the Elk River.', 'ELKFORD', true, 'IF'),
-('REC2054', 'ALEXANDER CK #1', 'A small, partially treed site on Alexander Creek.', 'SPARWOOD', true, 'IF'),
-('REC0108', 'ALEXANDER CREEK', 'A small, partly treed site.', 'SPARWOOD', true, 'IF'),
-('REC13876', 'ALFRED LAKE', 'A small and remote lake, surrounded by trees, with a boat launch.', 'POWELL RIVER', true, 'RTR'),
-('REC1605', 'ALPINE LAKE', 'A small, scenic lake with fishing opportunities.', 'PENTICTON', true, 'RTR'),
-('REC1163', 'ALPINE LAKE TRAIL', 'A short but steep hike through alpine meadows to the scenic Alpine Lake.', 'TROUT CREEK', true, 'RTR'),
-('REC5973', 'ALTA LAKE', 'A small mountain lake in Whistler', 'WHISTLER', true, 'RTR'),
-('REC1298', 'ALTA LAKE PARKING LOT', 'A parking area for the nearby Alta Lake Trail.', 'WHISTLER', true, 'RTR'),
-('REC5951', 'ALTA LAKE TRAIL', 'A trail that runs along the shore of Alta Lake, offering scenic views.', 'WHISTLER', true, 'RTR'),
-('REC3176', 'ALTA SNOWMOBILE PARKING LOT', 'A snowmobile parking area located off Alta Lake Road.', 'WHISTLER', true, 'RR');
+  (
+    'REC204117',
+    '0 K SNOWMOBILE PARKING LOT',
+    'The Zero K Tulameen Snowmobile Parking Lot is an area managed for snowmobilers who use the Mt. Henning and 10 K Area Snowmobile Trails in the vicinity. The parking lot and the trail network it supports is managed under a partnership agreement with the Coquihalla Summit Snowmobile Club during the snowmobile season and has an informative kiosk, outhouse and fee collection hut complete with a heated change room. Fees are applicable for the use of the snowmobile trails which are frequently groomed.',
+    'MERRITT',
+    true,
+    'RTR'
+  ),
+  (
+    'REC1222',
+    '100 ROAD BRIDGE',
+    'Site not currently being managed. Pending disestablishment (Jan 2009) - Sept 2021 Update: Site should have updated inspection. Site was never disestablished and is well used by the public.',
+    'PRINCE GEORGE',
+    true,
+    'RTR'
+  ),
+  (
+    'REC160773',
+    '10K CABIN',
+    'This snowmobile emergency cabin is located north of Coquihalla Mountain and is accessed via the Mt. Henning and 10 k Area Snowmobile Trails. The cabin is maintained under management agreement with the Coquihalla Summit Snowmobile Club and is intended for emergency use only. Please respect this cabin by keeping it clean and vandalism free. An avalanche terrain map and trail map is located within the cabin to advise snowmobilers of the types of avalanche terrain encountered in the area and the avalanche danger rating system.',
+    'MERRITT',
+    true,
+    'RTR'
+  ),
+  (
+    'REC203239',
+    '10 K SNOWMOBILE PARKING LOT',
+    'A 1 hectare gravel parking lot located at 10.2 km of the Tulameen Forest Service Road. Managed in partnership with the Coquihalla Summit Snowmobile Club this parking lot can be used by sledders who generally access the Coquihalla Mountain area near where the 10 k Cabin is located. The parking lot may be ploughed some winter seasons while other seasons it will not be ploughed depending upon whether the industrial road is being used and machinery can then access the lot for ploughing. Best to check the club website for more details at Coqsnow.com',
+    'MERRITT',
+    true,
+    'RTR'
+  ),
+  (
+    'REC6866',
+    '1861 GOLDRUSH PACK TRAIL',
+    'Come and hike the original route used by Goldrush miners as they travelled overland from the Coast into the Goldfields of the Barkerville area. The trailhead is in Barkerville and travels up and over Yanks Peak (French Snowshoe Mountain) and down to Weaver Creek where it joins the current road system. There are numerous historic sites along the trail as well as several rustic campsites. Visit www.barkerville.bc.ca for more details. Non Motorized Use Only',
+    'WELLS',
+    true,
+    'RTR'
+  ),
+  (
+    'REC203900',
+    '18 Mile',
+    '18 mile camping area sits at an elevation +/- 587 meters on Revelstoke Lake with changing shore lines, Revelstoke Lake is a lake created by hydro electric power generation.',
+    'REVELSTOKE',
+    true,
+    'RTR'
+  ),
+  (
+    'REC160432',
+    '24 KM SHELTER',
+    'An area set aside for any future snowmobile parking lot or shelter location which is currently managed under a snowmobile trail maintenance agreement with the Merritt Snowmobile Club. Currently has only an outhouse on location.',
+    'MERRITT',
+    true,
+    'RTR'
+  ),
+  (
+    'REC6739',
+    '24 MILE SNOWMOBILE AREA',
+    'The West Kootenay Snow Goers manage about 30 Km of groomed trail in the area with 2 day use warming huts. The groomed trails are easy riding and the whole area is generally for beginner to moderate sledding skills with some areas of advanced terrain around the Mount Shields area.',
+    'CASTLEGAR',
+    true,
+    'RTR'
+  ),
+  (
+    'REC16158',
+    '27 Swithbacks',
+    'Forested Mtn Bike',
+    'WHISTLER',
+    true,
+    'RTR'
+  ),
+  (
+    'REC2094',
+    '40 Mile CAMP / BULL River',
+    'A small scenic site at the confluence of Quinn Creek and the Bull River.',
+    'FERNIE',
+    true,
+    'RR'
+  ),
+  (
+    'REC6897',
+    '70 Mile Green Lake Trail',
+    'The trail starts at 70 Mile House BC and connects to a vast network of snowmobile and ATV trails around south Green Lake. From 70 Mile House, it is also possible to connect to the Gold Rush Recreation Trail, allowing users to travel as far north as Horsefly, and as far south as Clinton.',
+    '70 MILE HOUSE',
+    true,
+    'RR'
+  ),
+  (
+    'REC2206',
+    '7 MILE LAKE',
+    'This is a small site, semi-forested with mature Larch and Lodgepole Pine trees, with a central grassy, open area. Most of the sites are well-shaded, as the recreation site is nestled in a valley bottom. The site is located adjacent to Seven Mile Lake, a small shallow, weedy lake which is the headwaters of Caven Creek. The lake has a steep shoreline and is treed right to the water on the south shore, but a rough trail along the north side of the lake provides access to the deeper portion of the lake which is suitable for fishing. The lake is stocked with Cutthroat trout every other year. The site is located right on the main FSR but traffic is not excessive at this point.',
+    'CRANBROOK',
+    true,
+    'RR'
+  ),
+  (
+    'REC206043',
+    '8 Mile Cabin Telegraph Trail',
+    'These are historic cabin/shelters sites, and may not be an actual functioning shelter.',
+    'Bob Quinn Lake',
+    true,
+    'RTR'
+  ),
+  (
+    'REC166903',
+    '99 Mile Cross-Country Ski Trails',
+    'The 99 Mile Cross Country Ski Trails are groomed and maintained by the 100 Mile Nordic Ski Society. Please visit their website at 100 Mile Nordics for more information regarding seasons passes, day passes, lodge operating hours, and ski conditions. The trail network boasts 45 km of groomed ski trails, 5 km of lit trails for night skiing and 6.5 km of snowshoe trails.',
+    '100 MILE HOUSE',
+    true,
+    'RTR'
+  ),
+  (
+    'REC32013',
+    '99 Mile Mountain Bike Trails',
+    'These trails wind their way through stands of Douglas-fir and lodgepole pine above the community of 100 Mile House. The 99 Mile Hill is home to several trail networks for a variety of recreation activities, including cross-country skiing, snowmobiling, and horseback riding. The area also provides opportunities for the public to tour through a demonstration forest with interpretative signs.',
+    '100 MILE HOUSE',
+    true,
+    'RTR'
+  ),
+  (
+    'REC261475',
+    '99 Mile Off Road Motorcycle',
+    'off-road motorcycle trails (singletrack)',
+    '100 MILE HOUSE',
+    true,
+    'RTR'
+  ),
+  (
+    'REC166942',
+    '99 Mile Parking Oval',
+    'This is a parking area for those enjoying the recreation trails.',
+    '100 Mile House',
+    true,
+    'RTR'
+  ),
+  (
+    'REC2792',
+    '99 MILE SKI TRAILS',
+    'These Trails are a short Drive outside of 100 Mile house',
+    '100 Mile House',
+    true,
+    'RTR'
+  ),
+  (
+    'REC230522',
+    '99 Mile Snowshoe Trails',
+    'These snowshoe trails are near the 99 Mile Cross Country Ski Trails network. There are 2 snowshoe trail loops available: the Bear Paw trail and the Beanstalk Cabin trail. The Bear Paw trail is the shorter and easier loop, while the Beanstalk Cabin trail is the longer and more challenging trail. Please do not walk or snowshoe along the set cross-country ski trails in the area.',
+    '100 MILE HOUSE',
+    true,
+    'RTR'
+  ),
+  (
+    'REC205035',
+    '99 Mile XC Keene Road Parking',
+    'Parking area',
+    '100 Mile House',
+    true,
+    'RTR'
+  ),
+  (
+    'REC2566',
+    'ABBOTT CREEK',
+    'Looking for sun on the beach? Abbott Creek is the spot. A mid-sized rec site along the North Shore of Quesnel Lake with the majority of the sites set back in the shade of the Cottonwood trees along the large gravel beach. Boat launch is across the beach, 4x4 may be required. This also makes an excellent spot to start a boat trip on Quesnel Lake. Please park in the upper parking area and not a campsite if you intend to be away from the site for an extended period.',
+    'LIKELY',
+    true,
+    'RTR'
+  ),
+  (
+    'REC1735',
+    'ABBOTT LAKE',
+    'This small 3 vehicle somewhat remote recreation site is located in a semi open area on the north east side of Abbott Lake and is popular for fishing and boating. The camping spots are suitable for small truck campers and tenters and not for anything towed due to the rough access.',
+    'MERRITT',
+    true,
+    'RTR'
+  ),
+  (
+    'REC2978',
+    'ABBOTT LAKE TRAIL',
+    'This is a 400m access trail to the south shore of Abbott Lake. There are no facilities other than a parking area off of the Horsefly Road. There is no boat launching access via this trail.',
+    'HORSEFLY',
+    true,
+    'RTR'
+  ),
+  (
+    'REC136003',
+    'Aberdeen Columns',
+    'Aberdeen Columns is a climbing area in central BC. The Basalt columns are an ancient artifact of volcanic activity long ago over the Aberdeen plateau. Rock climbing is a dangerous activity carrying a significant risk to your personal safety and should be undertaken with a full understanding of all inherent risks.',
+    'LAVINGTON',
+    true,
+    'RTR'
+  ),
+  (
+    'REC265901',
+    'Aberdeen Columns Trail',
+    'Aberdeen columns are basalt rock formations. The Okanagan valley formed 60 million years ago as a result from a rift. 40 million years ago the valley was a wash with gushing volcanoes. Some of which are Knox Mountain, Dilworth and Mount Boucherie. The valley didn''t exist when dinosaurs roamed the earth. The result today is a popular climbing area.',
+    'LAVINGTON',
+    true,
+    'RTR'
+  ),
+  (
+    'REC1585',
+    'ABERDEEN LAKE',
+    'This semi-open site on a medium sized fishing lake is subject to significant water level fluctuations. The access is very rough for 2 km before the site.',
+    'LAVINGTON',
+    true,
+    'RTR'
+  ),
+  (
+    'REC262200',
+    'Aberdeen Snowshoe',
+    null,
+    'LAVINGTON',
+    true,
+    'RTR'
+  ),
+  (
+    'REC265549',
+    'Aberdeen Snowshoe Trails',
+    'Snowshoe and hiking trails, XC trails short drive from Lavington BC',
+    'LUMBY',
+    true,
+    'SIT'
+  ),
+  (
+    'REC270155',
+    'Abiotic Factor',
+    'Forested Trail',
+    'SILVERTON',
+    true,
+    'SIT'
+  ),
+  (
+    'REC0587',
+    'AGATE POINT',
+    'A small day-use site with 3 tables and 1 outhouse. Located on the north shore of Tchesinkut Lake.',
+    'BURNS LAKE',
+    true,
+    'SIT'
+  ),
+  (
+    'REC166367',
+    'Agnes Lake Trail',
+    'This trail provides access to a small secluded lake with excellent fishing. Agnes Lake is situated in a lodgepole pine & spruce forest in the foothills of the Coast Range of mountains at an elevation of 1300 m. The trail is only 600 m long and provides easy access to Agnes Lake. Travel time is about 15 minutes by foot. There are no facilities at the lake. The trail and surrounding area was heavily impacted by wildfire in 2017, but the trail has been cleared and marked with trail markers in September of 2019.',
+    'TATLA LAKE',
+    true,
+    'SIT'
+  ),
+  (
+    'REC1621',
+    'AGUR LAKE',
+    'Agur Lake is a small lake West of Summerland. The shores of the lake are marshy.',
+    'SUMMERLAND',
+    true,
+    'RTR'
+  ),
+  (
+    'REC1164',
+    'AHBAU LAKE',
+    'This semi-remote site is located on the northern shores of beautiful Ahbau Lake, near the border of the Prince George and Quesnel Forest Districts. This site has camping pads to accommodate 10 larger units as well as another 10 smaller sites on the upper loop road. There is access to a lake via a concrete boat launch. The lake is popular for kayaking and boating, and offers opportunities for angling of wild fish (rainbow trout and coarse fish species). The site offers the basic amenities of fire rings, tables and pit toilets.',
+    'QUESNEL',
+    true,
+    'RTR'
+  ),
+  (
+    'REC5763',
+    'AHDATAY',
+    'Sand beach, boat access only, user maintained.',
+    'FORT ST. JAMES',
+    true,
+    'RTR'
+  ),
+  (
+    'REC4519',
+    'AILEEN LAKE',
+    'This site is on a small fishing lake. There is 1 table and outhouse on site. Access is poor and requires a 4wd vehicle. Campers and trailers will have a difficult time getting into Aileen Lake due to water bars along the roads through cutblocks, and large water puddles and the ingrown forest for the last 800m. Best suited for the day fisherman in a pickup truck.',
+    'WINFIELD',
+    true,
+    'RTR'
+  ),
+  (
+    'REC265446',
+    'Airy Area',
+    'Wilderness area, alpine hiking',
+    'SLOCAN',
+    true,
+    'RTR'
+  ),
+  (
+    'REC262362',
+    'Aitken Falls',
+    'Water falls',
+    'HOUSTON',
+    true,
+    'RTR'
+  ),
+  (
+    'REC192109',
+    'Alamo Hiking Trail',
+    'Are trails at the base of Idaho Peak with an elevation 2282 m / 7486 ft. The trail winds its way through forested areas.',
+    'NEW DENVER',
+    true,
+    'RTR'
+  ),
+  (
+    'REC204480',
+    'Albright Trail',
+    'Albright Trail',
+    'Tumbler Ridge',
+    true,
+    'IF'
+  ),
+  (
+    'REC0180',
+    'ALDER GROVE',
+    'A small shady site on an old railgrade with a short trail to the lakeshore.',
+    'CAMPBELL RIVER',
+    true,
+    'IF'
+  ),
+  (
+    'REC97746',
+    'Aldridge Creek Trail',
+    'In conjunction with the Great Divide Trail and the Hornaday Wilderness Society, the trail was rebuilt in 2015.',
+    'ELKFORD',
+    true,
+    'IF'
+  ),
+  (
+    'REC2047',
+    'ALDRIDGE CR WEST',
+    'A small, heavily treed site on the Elk River.',
+    'ELKFORD',
+    true,
+    'IF'
+  ),
+  (
+    'REC2054',
+    'ALEXANDER CK #1',
+    'A small, partially treed site on Alexander Creek.',
+    'SPARWOOD',
+    true,
+    'IF'
+  ),
+  (
+    'REC0108',
+    'ALEXANDER CREEK',
+    'A small, partly treed site.',
+    'SPARWOOD',
+    true,
+    'IF'
+  ),
+  (
+    'REC13876',
+    'ALFRED LAKE',
+    'A small and remote lake, surrounded by trees, with a boat launch.',
+    'POWELL RIVER',
+    true,
+    'RTR'
+  ),
+  (
+    'REC1605',
+    'ALPINE LAKE',
+    'A small, scenic lake with fishing opportunities.',
+    'PENTICTON',
+    true,
+    'RTR'
+  ),
+  (
+    'REC1163',
+    'ALPINE LAKE TRAIL',
+    'A short but steep hike through alpine meadows to the scenic Alpine Lake.',
+    'TROUT CREEK',
+    true,
+    'RTR'
+  ),
+  (
+    'REC5973',
+    'ALTA LAKE',
+    'A small mountain lake in Whistler',
+    'WHISTLER',
+    true,
+    'RTR'
+  ),
+  (
+    'REC1298',
+    'ALTA LAKE PARKING LOT',
+    'A parking area for the nearby Alta Lake Trail.',
+    'WHISTLER',
+    true,
+    'RTR'
+  ),
+  (
+    'REC5951',
+    'ALTA LAKE TRAIL',
+    'A trail that runs along the shore of Alta Lake, offering scenic views.',
+    'WHISTLER',
+    true,
+    'RTR'
+  ),
+  (
+    'REC3176',
+    'ALTA SNOWMOBILE PARKING LOT',
+    'A snowmobile parking area located off Alta Lake Road.',
+    'WHISTLER',
+    true,
+    'RR'
+  );

--- a/migrations/fta/sql/V1.0.2__fta_to_rst.sql
+++ b/migrations/fta/sql/V1.0.2__fta_to_rst.sql
@@ -1,4 +1,12 @@
-insert into rst.recreation_resource (rec_resource_id, name, description, site_location, display_on_public_site, rec_resource_type)
+insert into
+    rst.recreation_resource (
+        rec_resource_id,
+        name,
+        description,
+        closest_community,
+        display_on_public_site,
+        rec_resource_type
+    )
 select
     rp.forest_file_id,
     rp.project_name as name,
@@ -6,7 +14,7 @@ select
         when rc.rec_comment_type_code = 'DESC' then rc.project_comment
         else ''
     end as description,
-    rp.site_location,
+    rp.closest_community,
     case
         when rp.recreation_view_ind = 'Y' then true
         else false
@@ -14,25 +22,19 @@ select
     rmf.recreation_map_feature_code
 from
     fta.recreation_project rp
-left join
-    fta.recreation_comment rc
-on
-    rp.forest_file_id = rc.forest_file_id
-left join
-    fta.recreation_map_feature rmf
-on
-    rp.forest_file_id = rmf.forest_file_id
-on conflict do nothing;
+    left join fta.recreation_comment rc on rp.forest_file_id = rc.forest_file_id
+    left join fta.recreation_map_feature rmf on rp.forest_file_id = rmf.forest_file_id on conflict do nothing;
 
--- insert into rst.recreation_activity_code (recreation_activity_code, description)
--- select
---     rac.recreation_activity_code,
---     rac.description as description
--- from
---     fta.recreation_activity_code rac;
+insert into
+    rst.recreation_activity_code (recreation_activity_code, description)
+select
+    rac.recreation_activity_code,
+    rac.description as description
+from
+    fta.recreation_activity_code rac;
 
-
-insert into rst.recreation_activity (rec_resource_id, recreation_activity_code)
+insert into
+    rst.recreation_activity (rec_resource_id, recreation_activity_code)
 select
     ra.forest_file_id as rec_resource_id,
     -- Convert strings codes ie '01', '02' to integers
@@ -40,7 +42,8 @@ select
 from
     fta.recreation_activity ra;
 
-insert into rst.recreation_status (rec_resource_id, status_code, comment)
+insert into
+    rst.recreation_status (rec_resource_id, status_code, comment)
 select
     forest_file_id,
     case

--- a/migrations/rst/sql/V1.0.0__init.sql
+++ b/migrations/rst/sql/V1.0.0__init.sql
@@ -6,7 +6,7 @@ create table if not exists rst.recreation_resource (
     rec_resource_id varchar(200) not null primary key,
     name varchar(200),
     description varchar(5000),
-    site_location varchar(200),
+    closest_community varchar(200),
     display_on_public_site boolean default false,
     rec_resource_type varchar(50)
 );
@@ -17,6 +17,6 @@ comment on column rst.recreation_resource.rec_resource_id is 'Identification man
 
 comment on column rst.recreation_resource.name is 'Name of the Recreation Project.';
 
-comment on column rst.recreation_resource.site_location is 'A text description generally describing the closest community or, for more isolated sites and trails, it could be a geographic feature to a recreation site or trail. e.g. VERNON, KELOWNA, PRINCE GEORGE.';
+comment on column rst.recreation_resource.closest_community is 'A text description generally describing the closest community or, for more isolated sites and trails, it could be a geographic feature to a recreation site or trail. e.g. VERNON, KELOWNA, PRINCE GEORGE.';
 
 comment on column rst.recreation_resource.rec_resource_type is 'Code representing a specific feature associated with the recreation resource.';


### PR DESCRIPTION
[#331](https://github.com/bcgov/nr-rec-resources/issues/331)

Renaming the `recreation_resource` column `site_location` to `closest_community` to better align with business logic.