### PR TITLE
fix(test-env): enabled flyway clean to run in 'test' environment.

### DIFF
--- a/infrastructure/api/ecs.tf
+++ b/infrastructure/api/ecs.tf
@@ -81,6 +81,7 @@ module "flyway_task" {
       },
       {
         # This defaults to true, though we want to enable it only in dev to reset the database
+        # also needs an update in migrations/rst/entrypoint.sh file for the flyaway ecs task to run correctly
         name = "FLYWAY_CLEAN_DISABLED"
         value = contains(["dev", "test"], local.rds_app_env) ? "false" : "true"
       }

--- a/migrations/rst/entrypoint.sh
+++ b/migrations/rst/entrypoint.sh
@@ -3,8 +3,8 @@ set -e
 
 # Check APP_ENV and run flyway clean if it is set to 'dev'
 # FLYWAY_CLEAN_DISABLED will also have to be set to 'false' for this to work
-if [ "$APP_ENV" = "dev" ]; then
-  echo "APP_ENV is set to 'dev'. Running flyway clean..."
+if [ "$APP_ENV" = "dev" ] || [ "$APP_ENV" = "test" ]; then
+  echo "APP_ENV is set to $APP_ENV. Running flyway clean..."
   flyway clean
 else
   echo "APP_ENV is not 'dev'. Skipping flyway clean."


### PR DESCRIPTION
# Description

This pull request extends the functionality of Flyway's clean command to include an option for running in the 'test' environment.