### PR TITLE
fix/filter counts

### DIFF
--- a/backend/src/recreation-resource/recreation-resource.service.spec.ts
+++ b/backend/src/recreation-resource/recreation-resource.service.spec.ts
@@ -130,10 +130,10 @@ describe("RecreationResourceService", () => {
         recreation_resource ?? recResourceArray,
         recreation_resource_total_ids ?? totalRecordIds,
         recreation_district_code ?? recreationDistrictCounts,
-      ])
-      .mockResolvedValueOnce([
         recreation_access_code ?? recreationAccessCounts,
         recreation_resource_type_code ?? recResourceTypeCounts,
+      ])
+      .mockResolvedValueOnce([
         recreation_activity_code ?? activityCounts,
         recreation_structure_toilet_count ?? 10,
         recreation_structure_table_count ?? 10,

--- a/backend/src/recreation-resource/recreation-resource.service.ts
+++ b/backend/src/recreation-resource/recreation-resource.service.ts
@@ -273,58 +273,50 @@ export class RecreationResourceService {
         facilityFilterQuery,
       ].filter(Boolean),
     };
-    const [recreationResources, totalRecordIds, recreationDistrictCounts] =
-      await this.prisma.$transaction([
-        // Fetch paginated records
-        this.prisma.recreation_resource.findMany({
-          where,
-          select: getRecreationResourceSelect(imageSizeCodes),
-          take,
-          skip,
-          orderBy,
-        }),
-        // Get all unpaginated but filtered rec_resource_ids for the records so we can group/count records for the filter sidebar
-        // This can be used to get the count of each many to many filter group
-        this.prisma.recreation_resource.findMany({
-          where,
-          select: { rec_resource_id: true },
-        }),
+    const [
+      recreationResources,
+      totalRecordIds,
+      recreationDistrictCounts,
+      recreationAccessCounts,
+      recResourceTypeCounts,
+    ] = await this.prisma.$transaction([
+      // Fetch paginated records
+      this.prisma.recreation_resource.findMany({
+        where,
+        select: getRecreationResourceSelect(imageSizeCodes),
+        take,
+        skip,
+        orderBy,
+      }),
+      // Get all unpaginated but filtered rec_resource_ids for the records so we can group/count records for the filter sidebar
+      // This can be used to get the count of each many to many filter group
+      this.prisma.recreation_resource.findMany({
+        where,
+        select: { rec_resource_id: true },
+      }),
 
-        // Get counts for all, unfiltered recreation_districts that are in the records
-        this.prisma.recreation_district_code.findMany({
-          select: {
-            district_code: true,
-            description: true,
-            _count: {
-              select: {
-                recreation_resource: {
-                  where: recResourceWhereConstants,
-                },
+      // Get counts for all, unfiltered recreation_districts that are in the records
+      this.prisma.recreation_district_code.findMany({
+        select: {
+          district_code: true,
+          description: true,
+          _count: {
+            select: {
+              recreation_resource: {
+                where: recResourceWhereConstants,
               },
             },
           },
-          where: {
-            district_code: {
-              notIn: excludedRecreationDistricts,
-            },
+        },
+        where: {
+          district_code: {
+            notIn: excludedRecreationDistricts,
           },
-          orderBy: {
-            description: Prisma.SortOrder.asc,
-          },
-        }),
-      ]);
-
-    const totalRecordIdsList = totalRecordIds.map(
-      (record) => record.rec_resource_id,
-    );
-
-    const [
-      recreationAccessCounts,
-      recResourceTypeCounts,
-      activityCounts,
-      toiletCount,
-      tableCount,
-    ] = await Promise.all([
+        },
+        orderBy: {
+          description: Prisma.SortOrder.asc,
+        },
+      }),
       this.prisma.recreation_access_code.findMany({
         select: {
           access_code: true,
@@ -373,6 +365,13 @@ export class RecreationResourceService {
           description: Prisma.SortOrder.desc,
         },
       }),
+    ]);
+
+    const totalRecordIdsList = totalRecordIds.map(
+      (record) => record.rec_resource_id,
+    );
+
+    const [activityCounts, toiletCount, tableCount] = await Promise.all([
       this.prisma.recreation_activity_code.findMany({
         select: {
           recreation_activity_code: true,

--- a/backend/src/recreation-resource/test/mock-data.test.ts
+++ b/backend/src/recreation-resource/test/mock-data.test.ts
@@ -792,6 +792,19 @@ const noSearchResultsFilterArray = [
   { ...accessFilterResolved },
 ];
 
+const recreationStructureCountsArray = [
+  { rec_resource_id: "REC001" },
+  { rec_resource_id: "REC002" },
+  { rec_resource_id: "REC003" },
+  { rec_resource_id: "REC004" },
+  { rec_resource_id: "REC005" },
+  { rec_resource_id: "REC006" },
+  { rec_resource_id: "REC007" },
+  { rec_resource_id: "REC008" },
+  { rec_resource_id: "REC009" },
+  { rec_resource_id: "REC010" },
+];
+
 const searchResultsFilterArray = [
   { ...districtFilterResolved },
   { ...recResourceTypeFilterResolved },
@@ -826,4 +839,5 @@ export {
   facilitiesFilterResolved,
   accessFilterResolved,
   searchResultsFilterArray,
+  recreationStructureCountsArray,
 };

--- a/migrations/fta/sql/V1.0.6__fta_to_rst_access.sql
+++ b/migrations/fta/sql/V1.0.6__fta_to_rst_access.sql
@@ -8,9 +8,14 @@ from
 
 insert into
     rst.recreation_access (rec_resource_id, access_code, sub_access_code)
-select
+select distinct -- distinct is used to avoid duplicate records that exist
     ra.forest_file_id as rec_resource_id,
     ra.recreation_access_code as access_code,
     ra.recreation_sub_access_code as sub_access_code
 from
-    fta.recreation_access ra;
+    fta.recreation_access ra
+on conflict (rec_resource_id, access_code, sub_access_code)
+do update
+set
+    access_code = excluded.access_code,
+    sub_access_code = excluded.sub_access_code;

--- a/migrations/rst/sql/V1.0.5__recreation_access.sql
+++ b/migrations/rst/sql/V1.0.5__recreation_access.sql
@@ -27,7 +27,8 @@ create table if not exists rst.recreation_access (
     id serial primary key, -- This is a surrogate key to make Prisma happy
     rec_resource_id varchar(20) not null references rst.recreation_resource (rec_resource_id),
     access_code varchar(3) not null references rst.recreation_access_code (access_code),
-    sub_access_code varchar(3) references rst.recreation_sub_access_code (sub_access_code)
+    sub_access_code varchar(3) references rst.recreation_sub_access_code (sub_access_code),
+    unique (rec_resource_id, access_code, sub_access_code)
 );
 
 comment on table rst.recreation_access is 'Recreation Resource Access types';


### PR DESCRIPTION
Fix for some of the new filter counts having different numbers than the results. Some of this was due me forgetting to filter rec resources by things like `display_on_public_site`, real world data being different than the dev fixtures as well as some duplicated data in `recreation_access` that was being imported. 

I've deployed this to test and ensured the counts line up with the results.

<img width="802" alt="Screenshot 2025-02-28 at 11 05 08 AM" src="https://github.com/user-attachments/assets/df348598-b440-4f25-af30-ad782080a50b" />
<img width="802" alt="Screenshot 2025-02-28 at 11 04 54 AM" src="https://github.com/user-attachments/assets/00e60a80-2df5-403b-a206-ceeba7f22c36" />
<img width="695" alt="Screenshot 2025-02-28 at 11 04 35 AM" src="https://github.com/user-attachments/assets/05acfde0-8d71-4360-ae48-f43c17878731" />

