### PR TITLE
fix: adjust resource image dimensions in search page cards

### DIFF
--- a/frontend/src/components/rec-resource/card/CardCarousel.tsx
+++ b/frontend/src/components/rec-resource/card/CardCarousel.tsx
@@ -2,8 +2,8 @@ import { useState } from 'react';
 import Carousel from 'react-bootstrap/Carousel';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import {
-  faCircleChevronRight,
   faCircleChevronLeft,
+  faCircleChevronRight,
 } from '@fortawesome/free-solid-svg-icons';
 
 type ImageList = { imageUrl: string }[];
@@ -51,6 +51,7 @@ const CardCarousel = ({ imageList }: CardCarouselProps) => {
               onFocus={() => setIsTabFocused(true)}
               onBlur={() => setIsTabFocused(false)}
               onKeyDown={(e) => handleKeyDown(e, imageList)}
+              className={'d-flex align-items-center justify-content-center'}
             >
               <img
                 alt="rec resource carousel"

--- a/frontend/src/components/rec-resource/card/RecResourceCard.scss
+++ b/frontend/src/components/rec-resource/card/RecResourceCard.scss
@@ -75,6 +75,7 @@
 
 .carousel-desktop-image {
   display: none;
+  object-fit: cover;
 
   @include media-breakpoint-up(sm) {
     display: block;
@@ -82,7 +83,6 @@
 }
 
 .carousel-mobile-image {
-  object-fit: cover;
   max-height: 300px;
   display: block;
 


### PR DESCRIPTION
# Description
Fix for resource image dimensions in search page cards.

Images with greater height appear distorted in desktop view due to improper sizing. Implemented object-fit: cover to maintain aspect ratio while properly filling the card space.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

#### before 
<img width="802" alt="image" src="https://github.com/user-attachments/assets/3209eecf-4b7f-4bfc-99de-938a449d7646" />

#### after
<img width="813" alt="image" src="https://github.com/user-attachments/assets/bed008b7-cb76-433d-abc1-d865e784001a" />


# How Has This Been Tested?
- [x] Verified proper image display across various screen sizes
- [x] Confirmed images maintain proper aspect ratio

