### PR TITLE
feat: add rec resource type to the search cards

### DIFF
--- a/frontend/src/components/rec-resource/card/RecResourceCard.test.tsx
+++ b/frontend/src/components/rec-resource/card/RecResourceCard.test.tsx
@@ -1,0 +1,80 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import RecResourceCard from './RecResourceCard';
+import '@testing-library/jest-dom';
+import { RecreationResourceDto } from '@/service/recreation-resource';
+
+// Mock the components used in RecResourceCard
+vi.mock('@/components/rec-resource/card/Activities', () => ({
+  default: () => <div data-testid="activities-component" />,
+}));
+
+vi.mock('@/components/rec-resource/card/CardCarousel', () => ({
+  default: () => <div data-testid="card-carousel-component" />,
+}));
+
+vi.mock('@/components/rec-resource/Status', () => ({
+  default: () => <div data-testid="status-component" />,
+}));
+
+vi.mock('@/components/rec-resource/card/helpers', () => ({
+  getImageList: vi.fn().mockReturnValue([]),
+}));
+
+describe('RecResourceCard', () => {
+  const mockRecreationResource = {
+    rec_resource_id: '123',
+    name: 'Test Resource',
+    recreation_activity: [{ id: '1', name: 'Hiking' }],
+    closest_community: 'Test Community',
+    recreation_status: {
+      status_code: 'OPEN',
+      description: 'Open for public',
+    },
+    rec_resource_type: 'Park',
+  } as unknown as RecreationResourceDto;
+
+  it('renders the card with all components', () => {
+    render(<RecResourceCard recreationResource={mockRecreationResource} />);
+
+    // Check if the name is rendered and transformed to lowercase
+    expect(screen.getByText('test resource')).toBeInTheDocument();
+
+    // Check if the community name is rendered and transformed to lowercase
+    expect(screen.getByText('test community')).toBeInTheDocument();
+
+    // Check if the resource type is rendered
+    expect(screen.getByText('Park')).toBeInTheDocument();
+
+    // Check if the required components are rendered
+    expect(screen.getByTestId('card-carousel-component')).toBeInTheDocument();
+    expect(screen.getByTestId('activities-component')).toBeInTheDocument();
+    expect(screen.getByTestId('status-component')).toBeInTheDocument();
+  });
+
+  it('renders without activities when none are provided', () => {
+    const noActivitiesResource = {
+      ...mockRecreationResource,
+      recreation_activity: [],
+    } as unknown as RecreationResourceDto;
+
+    render(<RecResourceCard recreationResource={noActivitiesResource} />);
+
+    // Activities component should not be rendered
+    expect(
+      screen.queryByTestId('activities-component'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders without resource type when none is provided', () => {
+    const noTypeResource = {
+      ...mockRecreationResource,
+      rec_resource_type: null,
+    } as unknown as RecreationResourceDto;
+
+    render(<RecResourceCard recreationResource={noTypeResource} />);
+
+    // Resource type should not be rendered
+    expect(screen.queryByText('Park')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/rec-resource/card/RecResourceCard.tsx
+++ b/frontend/src/components/rec-resource/card/RecResourceCard.tsx
@@ -20,6 +20,7 @@ const RecResourceCard: React.FC<RecResourceCardProps> = ({
     recreation_activity: activities,
     closest_community,
     recreation_status: { status_code, description: statusDescription },
+    rec_resource_type,
   } = recreationResource;
   const isActivities = activities.length > 0;
 
@@ -39,7 +40,22 @@ const RecResourceCard: React.FC<RecResourceCardProps> = ({
               />
             </h2>
           </a>
-          <p className="capitalize">{closest_community?.toLowerCase()}</p>
+
+          <div className="d-flex flex-column flex-md-row align-items-md-center align-items-start mb-2 mb-md-0">
+            <span className="fs-6 fw-normal capitalize">
+              {closest_community.toLowerCase()}
+            </span>
+            {rec_resource_type && (
+              <>
+                <span className="fs-5 fw-normal mx-2 d-none d-md-inline">
+                  |
+                </span>
+                <span className="fs-6 fw-normal fst-italic">
+                  {rec_resource_type}
+                </span>
+              </>
+            )}
+          </div>
         </div>
         <div className="card-content-lower">
           {isActivities ? <Activities activities={activities} /> : <div />}


### PR DESCRIPTION


# Description

Added rec resource type to the search cards in Search Page.

#### Desktop view
<img width="822" alt="image" src="https://github.com/user-attachments/assets/5c9a5a26-a66d-4d21-841a-6284e9b23a7b" />

#### Mobile view
<img width="379" alt="image" src="https://github.com/user-attachments/assets/784a8c14-ee0a-4948-9e0a-73e72eef903e" />

