### PR TITLE
feat: add placeholder images in search page cards

### DIFF
--- a/frontend/src/components/RSTSVGLogo/RSTSVGLogo.scss
+++ b/frontend/src/components/RSTSVGLogo/RSTSVGLogo.scss
@@ -1,0 +1,14 @@
+@import '@/styles/global';
+@import '~bootstrap/scss/mixins';
+
+.rst-svg-logo-container {
+  background: $colorBlue;
+
+  .bc-logo {
+    width: 40%;
+  }
+
+  .rst-logo {
+    width: 60%;
+  }
+}

--- a/frontend/src/components/RSTSVGLogo/RSTSVGLogo.test.tsx
+++ b/frontend/src/components/RSTSVGLogo/RSTSVGLogo.test.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { RSTSVGLogo } from './RSTSVGLogo';
+import '@testing-library/jest-dom';
+
+vi.mock('@/images/BC_nav_logo.svg', () => ({ default: 'bc-logo-mock' }));
+vi.mock('@/images/RST_nav_logo.svg', () => ({ default: 'rst-logo-mock' }));
+
+describe('RSTSVGLogo', () => {
+  it('renders both logos with correct alt text', () => {
+    render(<RSTSVGLogo />);
+
+    const bcLogo = screen.getByAltText('British Columbia Logo');
+    expect(bcLogo).toBeInTheDocument();
+    expect(bcLogo).toHaveAttribute('src', 'bc-logo-mock');
+
+    const rstLogo = screen.getByAltText('Recreation Sites and Trails BC Logo');
+    expect(rstLogo).toBeInTheDocument();
+    expect(rstLogo).toHaveAttribute('src', 'rst-logo-mock');
+  });
+});

--- a/frontend/src/components/RSTSVGLogo/RSTSVGLogo.tsx
+++ b/frontend/src/components/RSTSVGLogo/RSTSVGLogo.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import BCLogo from '@/images/BC_nav_logo.svg';
+import RSTLogo from '@/images/RST_nav_logo.svg';
+import '@/components/RSTSVGLogo/RSTSVGLogo.scss';
+
+export const RSTSVGLogo: React.FC = () => {
+  return (
+    <div
+      className={
+        'rst-svg-logo-container d-flex align-items-center justify-content-center px-4 w-100 h-100'
+      }
+    >
+      <img className={'bc-logo'} src={BCLogo} alt="British Columbia Logo" />
+      <img
+        className={'rst-logo'}
+        src={RSTLogo}
+        alt="Recreation Sites and Trails BC Logo"
+      />
+    </div>
+  );
+};

--- a/frontend/src/components/rec-resource/RecResourcePage.test.tsx
+++ b/frontend/src/components/rec-resource/RecResourcePage.test.tsx
@@ -25,7 +25,7 @@ const mockResource = {
     {
       caption: 'test image',
       recreation_resource_image_variants: [
-        { size_code: 'llc', url: 'preview-url' },
+        { size_code: 'scr', url: 'preview-url' },
         { size_code: 'original', url: 'full-url' },
       ],
     },

--- a/frontend/src/components/rec-resource/card/RecResourceCard.scss
+++ b/frontend/src/components/rec-resource/card/RecResourceCard.scss
@@ -16,12 +16,23 @@
     height: 200px;
   }
 
+  .card-image-container {
+    width: 30%;
+    min-width: 250px;
+    height: 200px;
+
+    @include media-breakpoint-down(sm) {
+      width: 100%;
+      height: 300px;
+    }
+  }
+
   .rec-resource-card-content {
     display: flex;
     flex-direction: column;
     justify-content: space-between;
     padding: 16px;
-    width: 100%;
+    width: 70%;
   }
 
   .rec-resource-card-info {

--- a/frontend/src/components/rec-resource/card/RecResourceCard.tsx
+++ b/frontend/src/components/rec-resource/card/RecResourceCard.tsx
@@ -1,11 +1,12 @@
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faCircleChevronRight } from '@fortawesome/free-solid-svg-icons';
 import Activities from '@/components/rec-resource/card/Activities';
-import CardCarousel from '@/components/rec-resource/card/CardCarousel';
 import Status from '@/components/rec-resource/Status';
 import '@/components/rec-resource/card/RecResourceCard.scss';
 import { RecreationResourceDto } from '@/service/recreation-resource';
 import { getImageList } from '@/components/rec-resource/card/helpers';
+import { RSTSVGLogo } from '@/components/RSTSVGLogo/RSTSVGLogo';
+import CardCarousel from '@/components/rec-resource/card/CardCarousel';
 
 interface RecResourceCardProps {
   recreationResource: RecreationResourceDto;
@@ -22,13 +23,16 @@ const RecResourceCard: React.FC<RecResourceCardProps> = ({
     recreation_status: { status_code, description: statusDescription },
     rec_resource_type,
   } = recreationResource;
-  const isActivities = activities.length > 0;
 
   const imageList = getImageList(recreationResource);
+  const hasActivities = activities.length > 0;
+  const hasImages = imageList.length > 0;
 
   return (
     <div className="rec-resource-card" key={rec_resource_id}>
-      <CardCarousel imageList={imageList} />
+      <div className={'card-image-container'}>
+        {hasImages ? <CardCarousel imageList={imageList} /> : <RSTSVGLogo />}
+      </div>
       <div className="rec-resource-card-content">
         <div className="rec-resource-card-info">
           <a href={`/resource/${rec_resource_id}`}>
@@ -58,7 +62,7 @@ const RecResourceCard: React.FC<RecResourceCardProps> = ({
           </div>
         </div>
         <div className="card-content-lower">
-          {isActivities ? <Activities activities={activities} /> : <div />}
+          {hasActivities && <Activities activities={activities} />}
           <Status description={statusDescription} statusCode={status_code} />
         </div>
       </div>

--- a/frontend/vitest.config.mts
+++ b/frontend/vitest.config.mts
@@ -15,6 +15,7 @@ export default defineConfig({
     coverage: {
       provider: 'v8',
       reporter: ['lcov', 'text'],
+      include: ['src'],
       exclude: ['src/service/recreation-resource/**'],
     },
   },


### PR DESCRIPTION

# Description

added placeholder images in the search cards for recreation resources that dont have any images

#### Desktop view
<img width="811" alt="image" src="https://github.com/user-attachments/assets/359ca7e1-922f-40e9-b7e8-7d67f191959e" />

#### Mobile view
<img width="366" alt="image" src="https://github.com/user-attachments/assets/6d696b33-fdaa-49d8-b63d-5fb21e3baa31" />

