### PR TITLE
feat/search page progress bar

### DIFF
--- a/frontend/src/components/search/SearchPage.test.tsx
+++ b/frontend/src/components/search/SearchPage.test.tsx
@@ -250,7 +250,7 @@ describe('SearchPage', () => {
       </MemoryRouter>,
     );
 
-    expect(screen.getByText('Loading...')).toBeInTheDocument();
+    expect(screen.getByText('Searching...')).toBeInTheDocument();
   });
 
   it('should not display "Loading..." text when not fetching data', () => {
@@ -268,6 +268,6 @@ describe('SearchPage', () => {
       </MemoryRouter>,
     );
 
-    expect(screen.queryByText('Loading...')).not.toBeInTheDocument();
+    expect(screen.queryByText('Searching...')).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/components/search/SearchPage.test.tsx
+++ b/frontend/src/components/search/SearchPage.test.tsx
@@ -198,4 +198,76 @@ describe('SearchPage', () => {
 
     expect(screen.getByText('No results found')).toBeInTheDocument();
   });
+
+  it('should display the progress bar when fetching data', () => {
+    vi.spyOn(
+      recreationResourceQueries,
+      'useSearchRecreationResourcesPaginated',
+    ).mockReturnValue({
+      ...mockQueryResult,
+      isFetching: true,
+    } as any);
+
+    render(
+      <MemoryRouter>
+        <SearchPage />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByRole('progressbar')).toBeInTheDocument();
+  });
+
+  it('should not display the progress bar when not fetching data', () => {
+    vi.spyOn(
+      recreationResourceQueries,
+      'useSearchRecreationResourcesPaginated',
+    ).mockReturnValue({
+      ...mockQueryResult,
+      isFetching: false,
+    } as any);
+
+    render(
+      <MemoryRouter>
+        <SearchPage />
+      </MemoryRouter>,
+    );
+
+    expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
+  });
+
+  it('should display "Loading..." text when fetching data', () => {
+    vi.spyOn(
+      recreationResourceQueries,
+      'useSearchRecreationResourcesPaginated',
+    ).mockReturnValue({
+      ...mockQueryResult,
+      isFetching: true,
+    } as any);
+
+    render(
+      <MemoryRouter>
+        <SearchPage />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText('Loading...')).toBeInTheDocument();
+  });
+
+  it('should not display "Loading..." text when not fetching data', () => {
+    vi.spyOn(
+      recreationResourceQueries,
+      'useSearchRecreationResourcesPaginated',
+    ).mockReturnValue({
+      ...mockQueryResult,
+      isFetching: false,
+    } as any);
+
+    render(
+      <MemoryRouter>
+        <SearchPage />
+      </MemoryRouter>,
+    );
+
+    expect(screen.queryByText('Loading...')).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/components/search/SearchPage.tsx
+++ b/frontend/src/components/search/SearchPage.tsx
@@ -92,7 +92,7 @@ const SearchPage = () => {
             </button>
             <div className="search-results-count">
               {isFetching ? (
-                <div>Loading...</div>
+                <div>Searching...</div>
               ) : (
                 <div>
                   {resultsTotal ? (

--- a/frontend/src/components/search/SearchPage.tsx
+++ b/frontend/src/components/search/SearchPage.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import RecResourceCard from '@/components/rec-resource/card/RecResourceCard';
 import SearchBanner from '@/components/search/SearchBanner';
+import ProgressBar from 'react-bootstrap/ProgressBar';
 import FilterMenu from '@/components/search/filters/FilterMenu';
 import FilterMenuMobile from '@/components/search/filters/FilterMenuMobile';
 import {
@@ -24,6 +25,7 @@ const SearchPage = () => {
     hasNextPage,
     hasPreviousPage,
     fetchPreviousPage,
+    isFetching,
   } = useSearchRecreationResourcesPaginated({
     limit: 10,
     filter: searchParams.get('filter') ?? undefined,
@@ -89,16 +91,20 @@ const SearchPage = () => {
               Filter
             </button>
             <div className="search-results-count">
-              <div>
-                {resultsTotal ? (
-                  <span>
-                    <strong>{resultsTotal.toLocaleString()}</strong>
-                    {` ${resultsTotal === 1 ? 'Result' : 'Results'}`}
-                  </span>
-                ) : (
-                  'No results found'
-                )}
-              </div>
+              {isFetching ? (
+                <div>Loading...</div>
+              ) : (
+                <div>
+                  {resultsTotal ? (
+                    <span>
+                      <strong>{resultsTotal.toLocaleString()}</strong>
+                      {` ${resultsTotal === 1 ? 'Result' : 'Results'}`}
+                    </span>
+                  ) : (
+                    'No results found'
+                  )}
+                </div>
+              )}
               {isFilters && (
                 <button
                   type="button"
@@ -121,15 +127,19 @@ const SearchPage = () => {
               </div>
             )}
             <section>
-              {data?.pages?.map((pageData: PaginatedRecreationResourceDto) =>
-                pageData.data.map(
-                  (recreationResource: RecreationResourceDto) => (
-                    <RecResourceCard
-                      key={recreationResource.rec_resource_id}
-                      recreationResource={recreationResource}
-                    />
+              {isFetching ? (
+                <ProgressBar animated now={100} className="mb-4" />
+              ) : (
+                data?.pages?.map((pageData: PaginatedRecreationResourceDto) =>
+                  pageData.data.map(
+                    (recreationResource: RecreationResourceDto) => (
+                      <RecResourceCard
+                        key={recreationResource.rec_resource_id}
+                        recreationResource={recreationResource}
+                      />
+                    ),
                   ),
-                ),
+                )
               )}
             </section>
             {hasNextPage && (


### PR DESCRIPTION
#304

To test this set throttling to 3g in your network tab

I'm wondering if we should use react query `isLoading` instead of `isFetching` to prevent this from flashing after the initial page load. 

<img width="1057" alt="Screenshot 2025-03-04 at 1 41 52 PM" src="https://github.com/user-attachments/assets/6dbe07fe-5674-4494-9946-6c0a9a0d8e61" />


