### PR TITLE
chore: change make db migration commands to use flyway

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,38 +5,35 @@ include ./backend/.env
 PSQL=psql -h localhost
 DB_NAME=${POSTGRES_DATABASE}
 DB_SCHEMA=${POSTGRES_SCHEMA}
+FLYWAY=flyway
+MIGRATIONS_DIR=migrations/rst
+FIXTURES_DIR=migrations/fixtures
+MIGRATION_TABLE=flyway_schema_history
+FIXTURE_TABLE=flyway_fixture_schema_history
 
 .PHONY: create_db
-create_db: ## Ensure that the $(DB_NAME) database exists
 create_db:
 	@$(PSQL) -d postgres -tc "SELECT count(*) FROM pg_database WHERE datname = '$(DB_NAME)'" | \
 		grep -q 1 || \
 		$(PSQL) -d postgres -c "CREATE DATABASE $(DB_NAME)";
 
 .PHONY: drop_db
-drop_db: ## Drop the $(DB_NAME) database if it exists
 drop_db:
 	@$(PSQL) -d postgres -tc "SELECT count(*) FROM pg_database WHERE datname = '$(DB_NAME)'" | \
 		grep -q 0 || \
 		$(PSQL) -d postgres -c "DROP DATABASE $(DB_NAME)";
 
 .PHONY: migrate
-migrate: ## create the migrations
 migrate:
-	## TODO:: this is a very basic setup, we should use flyway for migrations
-	for file in ./migrations/rst/sql/*.sql; do \
-		printf "Applying migration: ${DB_NAME}/$$(basename $$file)\n"; \
-		$(PSQL) -d $(DB_NAME) -f $$file; \
-	done
+	$(FLYWAY) -url=jdbc:postgresql://$(POSTGRES_HOST)/$(DB_NAME) -user=$(POSTGRES_USER) -password=$(POSTGRES_PASSWORD) -schemas=$(DB_SCHEMA) -locations=filesystem:$(MIGRATIONS_DIR) -table=$(MIGRATION_TABLE) -baselineOnMigrate=true migrate
 
 .PHONY: load_fixtures
-load_fixtures: ## Load the fixtures
 load_fixtures:
-	for file in ./migrations/fixtures/sql/*.sql; do \
-		printf "Applying fixture: ${DB_NAME}/$$(basename $$file)\n"; \
-		$(PSQL) -d $(DB_NAME) -f $$file; \
-	done
+	$(FLYWAY) -url=jdbc:postgresql://$(POSTGRES_HOST)/$(DB_NAME) -user=$(POSTGRES_USER) -password=$(POSTGRES_PASSWORD) -locations=filesystem:$(FIXTURES_DIR) -table=$(FIXTURE_TABLE) -baselineOnMigrate=true migrate
+
+.PHONY: clean
+clean:
+	$(FLYWAY) -url=jdbc:postgresql://$(POSTGRES_HOST)/$(DB_NAME) -user=$(POSTGRES_USER) -password=$(POSTGRES_PASSWORD) -schemas=$(DB_SCHEMA) -locations=filesystem:$(MIGRATIONS_DIR) clean
 
 .PHONY: reset_db
-reset_db: ## Drop and recreate the $(DB_NAME) database, migrate and load fixtures
 reset_db: drop_db create_db migrate load_fixtures

--- a/Makefile
+++ b/Makefile
@@ -25,11 +25,11 @@ drop_db:
 
 .PHONY: migrate
 migrate:
-	$(FLYWAY) -url=jdbc:postgresql://$(POSTGRES_HOST)/$(DB_NAME) -user=$(POSTGRES_USER) -password=$(POSTGRES_PASSWORD) -schemas=$(DB_SCHEMA) -locations=filesystem:$(MIGRATIONS_DIR) -table=$(MIGRATION_TABLE) -baselineOnMigrate=true migrate
+	$(FLYWAY) -url=jdbc:postgresql://$(POSTGRES_HOST)/$(DB_NAME) -user=$(POSTGRES_USER) -password=$(POSTGRES_PASSWORD) -schemas=$(DB_SCHEMA) -locations=filesystem:$(MIGRATIONS_DIR) -table=$(MIGRATION_TABLE) -baselineOnMigrate=true -validateMigrationNaming=true migrate
 
 .PHONY: load_fixtures
 load_fixtures:
-	$(FLYWAY) -url=jdbc:postgresql://$(POSTGRES_HOST)/$(DB_NAME) -user=$(POSTGRES_USER) -password=$(POSTGRES_PASSWORD) -locations=filesystem:$(FIXTURES_DIR) -table=$(FIXTURE_TABLE) -baselineOnMigrate=true migrate
+	$(FLYWAY) -url=jdbc:postgresql://$(POSTGRES_HOST)/$(DB_NAME) -user=$(POSTGRES_USER) -password=$(POSTGRES_PASSWORD) -locations=filesystem:$(FIXTURES_DIR) -table=$(FIXTURE_TABLE) -baselineOnMigrate=true -validateMigrationNaming=true migrate
 
 .PHONY: clean
 clean:

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@
   - [Docker Compose](#docker-compose)
   - [Installing and running the application locally](#installing-and-running-the-application-locally)
   - [Database](#database)
+    - [Flyway](#flyway)
+    - [Running migrations](#running-migrations)
   - [Backend](#backend)
   - [Frontend](#frontend)
   - [Generate API Client Library](#generate-api-client-library)
@@ -69,6 +71,7 @@
 - Node.js
 - npm
 - Docker OR PostgreSQL 16
+- Flyway
 
 ### Docker Compose
 
@@ -90,7 +93,23 @@ directory to install eslint and plugins to ensure linting is working correctly.
 ### Database
 
 To run this on your local machine, you will need a working installation of
-PostgreSQL 16.
+PostgreSQL 16 and Flyway.
+
+#### Flyway
+
+Flyway is a database migration tool that is used to manage the database schema.
+
+To install flyway locally on macOS or Linux, if you have Homebrew installed, you
+can run:
+
+```bash
+brew install flyway
+```
+
+Alternatively you can manually download the latest version of Flyway from the
+[Flyway website](https://flywaydb.org/download/).
+
+#### Running migrations
 
 Create an `.env` file in the `backend` directory using the example in
 `backend/.env.example` as a template.


### PR DESCRIPTION
As discussed at standup, changed the Makefile to use flyway for migration.Hopefully better catch migration versioning errors earlier. 

Perhaps in the future we can also add a check in ci.