### PR TITLE
fix: center the map on the rec resource feature geometry once map is rendered

### DIFF
--- a/frontend/src/components/StyledVectorFeatureMap/hooks/useAddVectorLayerToMap.ts
+++ b/frontend/src/components/StyledVectorFeatureMap/hooks/useAddVectorLayerToMap.ts
@@ -45,8 +45,10 @@ export const useAddVectorLayerToMap = ({
     map.addLayer(layer);
 
     // call the callback function with the extent
-    const extent = source.getExtent();
-    onLayerAdded?.(extent);
+    map.once('rendercomplete', () => {
+      const extent = source.getExtent();
+      onLayerAdded?.(extent);
+    });
 
     // Cleanup function to remove layer
     return () => {


### PR DESCRIPTION
# Bug fix

Bug: Map Centering 
The map sometimes fails to center on the recreation resource's feature geometry.

Root cause: sometimes the extent of the new vector layer (rec site/trial) is fit before the map has finished rendering

Solution: We now center the map after confirming full render completion.