### PR TITLE
fix(search): add scroll behavior after loading more items

### DIFF
--- a/frontend/src/components/search/SearchPage.tsx
+++ b/frontend/src/components/search/SearchPage.tsx
@@ -59,13 +59,31 @@ const SearchPage = () => {
 
   const { pages: paginatedResults, totalCount } = searchResults;
 
-  const handleLoadMore = () => {
+  /**
+   * Handles loading the next page of search results.
+   *
+   * This function fetches the next page of results from the API and updates the
+   * search parameters in the URL. After fetching the new data, it smoothly
+   * scrolls the viewport to the last item of the previously loaded page.
+   */
+  const handleLoadMore = async () => {
+    // Store reference to last item of current list before loading more
+    const lastItem = document.querySelector(
+      '.search-container section',
+    )?.lastElementChild;
+
     const newSearchParams = {
       ...Object.fromEntries(searchParams),
       page: (Number(data?.currentPage || 1) + 1).toString(),
     };
     setSearchParams(newSearchParams);
-    fetchNextPage();
+
+    await fetchNextPage();
+
+    // scroll the last item of the previous list into view
+    setTimeout(() => {
+      lastItem?.scrollIntoView({ behavior: 'smooth' });
+    });
   };
 
   const handleLoadPrevious = () => {

--- a/frontend/src/service/queries/recreation-resource/recreationResourceQueries.ts
+++ b/frontend/src/service/queries/recreation-resource/recreationResourceQueries.ts
@@ -158,7 +158,6 @@ export const useSearchRecreationResourcesPaginated = (
     getPreviousPageParam,
     getNextPageParam,
     queryFn,
-    maxPages: 3,
     select,
     placeholderData: (previousData) => previousData,
   });


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

This PR addresses an issue with the search results pagination where newly loaded items weren't properly scrolled into view.

### Changes Made

- Implemented scroll behaviour after loading more search results where the page is automatically scrolled to the last item of the previous list.
- Added setTimeout to ensure DOM updates complete before scrolling