### PR TITLE
chore: add make reset_project command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,5 +35,15 @@ load_fixtures:
 clean:
 	$(FLYWAY) -url=jdbc:postgresql://$(POSTGRES_HOST)/$(DB_NAME) -user=$(POSTGRES_USER) -password=$(POSTGRES_PASSWORD) -schemas=$(DB_SCHEMA) -locations=filesystem:$(MIGRATIONS_DIR) clean
 
+## Ensure that your backend isn't running and that there are no active connections to the database
 .PHONY: reset_db
 reset_db: drop_db create_db migrate load_fixtures
+
+# Reset the project, useful when switching branches with different packages and migrations
+.PHONY: reset_project
+reset_project:
+	@echo "Resetting the project..."
+	make reset_db
+	cd backend && npm install && npx prisma generate
+	cd frontend && npm install
+	@echo "Project reset completed."


### PR DESCRIPTION
Makefile helper to reset the database, regenerate prisma client and do npm install in frontend and backend directories. 

Hopefully useful when switching between branches with database changes.