### PR TITLE
fix: campsite conditional short circuit 0 error

### DIFF
--- a/frontend/src/components/rec-resource/RecResourcePage.tsx
+++ b/frontend/src/components/rec-resource/RecResourcePage.tsx
@@ -241,7 +241,7 @@ const RecResourcePage = () => {
             {description && (
               <SiteDescription
                 description={description}
-                maintenanceCode={String(maintenance_standard_code)}
+                maintenanceCode={maintenance_standard_code}
                 ref={siteDescriptionRef}
               />
             )}

--- a/frontend/src/components/rec-resource/section/Camping.tsx
+++ b/frontend/src/components/rec-resource/section/Camping.tsx
@@ -30,12 +30,12 @@ const Camping = forwardRef<HTMLElement, CampingProps>(
       <section id={id} ref={ref}>
         <h2 className="section-heading">{title}</h2>
 
-        {showCampsiteCount && campsite_count && (
+        {showCampsiteCount && campsite_count ? (
           <>
             <strong>Number of campsites</strong>
             <p>{campsite_count} campsites</p>
           </>
-        )}
+        ) : null}
 
         {fees.length > 0 ? (
           <RecreationFee data={fees} />

--- a/frontend/src/components/rec-resource/section/MapsAndLocation.tsx
+++ b/frontend/src/components/rec-resource/section/MapsAndLocation.tsx
@@ -42,7 +42,7 @@ const MapsAndLocation = forwardRef<HTMLElement, MapsAndLocationProps>(
           </article>
         )}
 
-        {accessTypes && (
+        {accessTypes && accessTypes?.length > 0 && (
           <section className="mb-4">
             <h3>Access Type{accessTypes.length > 1 && 's'}</h3>
             <ul className="list-unstyled">


### PR DESCRIPTION
Just a quick follow up PR, I got caught out by a classic short circuit conditional rendering bug since campsite_count is 0

Fixed types conditionals as well, I found a site that didn't have any and just showed the heading with nothing else.

<img width="325" alt="Screenshot 2025-03-31 at 3 39 17 PM" src="https://github.com/user-attachments/assets/894c0818-76a8-4a57-8941-7c1624c96b47" />
