### PR TITLE
feat(header-nav): added link to interactive map

### DIFF
--- a/frontend/e2e/poms/layout.ts
+++ b/frontend/e2e/poms/layout.ts
@@ -16,7 +16,9 @@ export class LayoutPOM {
       header.getByRole('link', { name: 'Find a site or trail' }),
     ).toBeVisible();
 
-    await expect(header.getByRole('link', { name: 'Contact' })).toBeVisible();
+    await expect(
+      header.getByRole('link', { name: 'Interactive map' }),
+    ).toBeVisible();
   }
 
   async verifyFooterContent() {

--- a/frontend/src/components/layout/Header.scss
+++ b/frontend/src/components/layout/Header.scss
@@ -29,7 +29,6 @@
 
     & a {
       color: $colorWhite;
-      margin-right: 32px;
 
       &:hover {
         text-decoration: underline;

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -3,6 +3,10 @@ import RSTLogo from '@/images/RST_nav_logo.svg';
 import '@/components/layout/Header.scss';
 import BetaBanner from './BetaBanner';
 import { ROUTE_PATHS } from '@/routes';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faExternalLink } from '@fortawesome/free-solid-svg-icons';
+import { Stack } from 'react-bootstrap';
+import { EXTERNAL_LINKS } from '@/data/urls';
 
 const Header = () => {
   return (
@@ -35,8 +39,19 @@ const Header = () => {
           aria-label="Secondary header site navigation"
           className="header-nav sub"
         >
-          <a href="/search">Find a site or trail</a>
-          <a href="/">Contact</a>
+          <Stack direction="horizontal" gap={3}>
+            <a href="/search">Find a site or trail</a>
+            <a
+              target="_blank"
+              href={EXTERNAL_LINKS.RST_ARCGIS_MAP_FULL_SCREEN}
+              rel="noreferrer"
+            >
+              <Stack direction={'horizontal'} gap={1}>
+                Interactive map
+                <FontAwesomeIcon icon={faExternalLink} />
+              </Stack>
+            </a>
+          </Stack>
         </nav>
       </div>
     </header>

--- a/frontend/src/data/urls.ts
+++ b/frontend/src/data/urls.ts
@@ -16,4 +16,6 @@ export const EXTERNAL_LINKS = {
     'https://www2.gov.bc.ca/gov/content/sports-culture/recreation/camping-hiking/sites-trails#research-opportunities',
   ORV_TRAIL:
     'https://www2.gov.bc.ca/gov/content/sports-culture/recreation/camping-hiking/sites-trails/orv-trail-fund',
+  RST_ARCGIS_MAP_FULL_SCREEN:
+    'https://governmentofbc.maps.arcgis.com/apps/webappviewer/index.html?id=4e9f5f3a722b45c8a86696f6c91d09c6',
 } as const;


### PR DESCRIPTION
# Description
Made changes to the header nav component as per the new figma design:
1. Added link to interactive map view. 
2. Removed `Contact` link 

# Screenshots

<img width="1783" alt="image" src="https://github.com/user-attachments/assets/8a67dc44-5d02-424b-b327-27168d96b137" />
<img width="2456" alt="image" src="https://github.com/user-attachments/assets/8ca24630-b024-441d-81d1-406c2596aaf6" />

