### PR TITLE
chore: rename maintenance standard section to maintenance type

### DIFF
--- a/frontend/src/components/rec-resource/RecResourcePage.tsx
+++ b/frontend/src/components/rec-resource/RecResourcePage.tsx
@@ -156,7 +156,7 @@ const RecResourcePage = () => {
           title: SectionTitles.MAPS_AND_LOCATION,
         },
         {
-          href: SectionIds.CAMPING,
+          href: `#${SectionIds.CAMPING}`,
           title: SectionTitles.CAMPING,
         },
 

--- a/frontend/src/components/rec-resource/section/SiteDescription.test.tsx
+++ b/frontend/src/components/rec-resource/section/SiteDescription.test.tsx
@@ -29,7 +29,7 @@ describe('SiteDescription Component', () => {
     render(<SiteDescription description="" maintenanceCode="U" />);
 
     expect(
-      screen.getByRole('heading', { name: /maintenance standard/i }),
+      screen.getByRole('heading', { name: /maintenance type/i }),
     ).toBeInTheDocument();
     expect(
       screen.getByText(/limited maintenance services/i),
@@ -40,7 +40,7 @@ describe('SiteDescription Component', () => {
     render(<SiteDescription description="" maintenanceCode="M" />);
 
     expect(
-      screen.getByRole('heading', { name: /maintenance standard/i }),
+      screen.getByRole('heading', { name: /maintenance type/i }),
     ).toBeInTheDocument();
     expect(screen.getByText(/This site is maintained/)).toBeInTheDocument();
   });
@@ -50,7 +50,7 @@ describe('SiteDescription Component', () => {
       <SiteDescription description="Test Description" />,
     );
 
-    expect(container).not.toHaveTextContent(/maintenance Standard/i);
+    expect(container).not.toHaveTextContent(/maintenance type/i);
   });
 
   it('should not render the maintenance section if an invalid maintenance code is provided', () => {
@@ -59,6 +59,6 @@ describe('SiteDescription Component', () => {
       <SiteDescription description="Test Description" maintenanceCode="X" />,
     );
 
-    expect(container).not.toHaveTextContent(/maintenance standard/i);
+    expect(container).not.toHaveTextContent(/maintenance type/i);
   });
 });

--- a/frontend/src/components/rec-resource/section/SiteDescription.tsx
+++ b/frontend/src/components/rec-resource/section/SiteDescription.tsx
@@ -39,7 +39,7 @@ const SiteDescription = forwardRef<HTMLElement, SiteDescriptionProps>(
 
         {maintenanceDescription && (
           <section className="mb-4">
-            <h3>Maintenance standard</h3>
+            <h3>Maintenance type</h3>
             <p>{maintenanceDescription}</p>
           </section>
         )}


### PR DESCRIPTION
Update the name `Maintenance standard` to `Maintenance type` as well as fix camping anchor tag bug