### PR TITLE
chore: fix code scanning alerts

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,7 +71,7 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}-review-test-deployment
       cancel-in-progress: true
-    environment: test
+    environment: review-test-deployment
     runs-on: ubuntu-24.04
     steps:
       - name: Review Test Deployment
@@ -89,7 +89,7 @@ jobs:
     with:
       app_env: test
       command: apply
-      environment_name: review-test-deployment
+      environment_name: test
       tag: ${{ github.sha }}
     secrets: inherit
 

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -4,11 +4,12 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "backend",
       "license": "Apache-2.0",
       "dependencies": {
         "@nestjs/class-validator": "^0.13.4",
         "@nestjs/cli": "^11.0.2",
-        "@nestjs/common": "^11.0.6",
+        "@nestjs/common": "^11.0.14",
         "@nestjs/config": "^4.0.0",
         "@nestjs/core": "^11.0.6",
         "@nestjs/platform-express": "^11.0.6",
@@ -1544,9 +1545,9 @@
       }
     },
     "node_modules/@nestjs/common": {
-      "version": "11.0.12",
-      "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-11.0.12.tgz",
-      "integrity": "sha512-6PXxmDe2iYmb57xacnxzpW1NAxRZ7Gf+acMT7/hmRB/4KpZiFU/cNvLWwgbM2BL5QSzQulOwY6ny5bbKnPpB+A==",
+      "version": "11.0.14",
+      "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-11.0.14.tgz",
+      "integrity": "sha512-7MKloi0F0xh3S7gSH+reytC3axyhTEn1pJfs8Tp80aXCRYopA5zT/WO4CcmOsqmFt61jnlTFG6CeJ4limz/F7A==",
       "license": "MIT",
       "dependencies": {
         "iterare": "1.2.1",
@@ -9020,9 +9021,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.2.4",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.4.tgz",
-      "integrity": "sha512-veHMSew8CcRzhL5o8ONjy8gkfmFJAd5Ac16oxBUjlwgX3Gq2Wqr+qNC3TjPIpy7TPV/KporLga5GT9HqdrCizw==",
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.5.tgz",
+      "integrity": "sha512-j023J/hCAa4pRIUH6J9HemwYfjB5llR2Ps0CWeikOtdR8+pAURAk0DoJC5/mm9kd+UgdnIy7d6HE4EAvlYhPhA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@nestjs/class-validator": "^0.13.4",
     "@nestjs/cli": "^11.0.2",
-    "@nestjs/common": "^11.0.6",
+    "@nestjs/common": "^11.0.14",
     "@nestjs/config": "^4.0.0",
     "@nestjs/core": "^11.0.6",
     "@nestjs/platform-express": "^11.0.6",
@@ -62,8 +62,8 @@
     "tsconfig-paths": "^4.2.0",
     "typescript": "^5.7.3",
     "unplugin-swc": "^1.5.1",
-    "vitest": "^3.0.4",
-    "vite-tsconfig-paths": "^5.1.4"
+    "vite-tsconfig-paths": "^5.1.4",
+    "vitest": "^3.0.4"
   },
   "overrides": {
     "minimist@<1.2.6": "1.2.6"

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -59,7 +59,7 @@
         "msw": "^2.7.0",
         "sass-embedded": "^1.83.1",
         "typescript": "^5.7.3",
-        "vite": "^6.0.11",
+        "vite": "^6.2.5",
         "vite-tsconfig-paths": "^5.1.4",
         "vitest": "^3.0.0"
       },
@@ -5984,9 +5984,9 @@
       }
     },
     "node_modules/image-size": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.2.0.tgz",
-      "integrity": "sha512-4S8fwbO6w3GeCVN6OPtA9I5IGKkcDMPcKndtUlpJuCwu7JLjtj7JZpwqLuyY2nrmQT3AWsCJLSKPsc2mPBSl3w==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.2.1.tgz",
+      "integrity": "sha512-rH+46sQJ2dlwfjfhCyNx5thzrv+dtmBIhPHk0zgRUukHzZ/kRueTJXoYYsclBaKcSMBWuGbOFXtioLpzTb5euw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -67,7 +67,7 @@
     "msw": "^2.7.0",
     "sass-embedded": "^1.83.1",
     "typescript": "^5.7.3",
-    "vite": "^6.0.11",
+    "vite": "^6.2.5",
     "vite-tsconfig-paths": "^5.1.4",
     "vitest": "^3.0.0"
   },

--- a/infrastructure/api/ecs.tf
+++ b/infrastructure/api/ecs.tf
@@ -22,6 +22,11 @@ locals {
 
 resource "aws_ecs_cluster" "ecs_cluster" {
   name = "ecs-cluster-${var.app_name}"
+
+  setting {
+    name  = "containerInsights"
+    value = "enabled"
+  }
 }
 
 resource "aws_ecs_cluster_capacity_providers" "ecs_cluster_capacity_providers" {

--- a/infrastructure/database/aurora-v2.tf
+++ b/infrastructure/database/aurora-v2.tf
@@ -99,7 +99,7 @@ module "aurora_postgresql_v2" {
 
   deletion_protection = contains(["dev", "test"], local.rds_app_env) ? false : true
 
-  performance_insights_enabled	= contains(["dev", "test"], local.rds_app_env) ? false : true
+  performance_insights_enabled	= true
   performance_insights_kms_key_id = data.aws_kms_alias.rds_key.arn
 
   db_parameter_group_name         = aws_db_parameter_group.db_postgresql.id

--- a/infrastructure/database/aurora-v2.tf
+++ b/infrastructure/database/aurora-v2.tf
@@ -50,7 +50,6 @@ resource "aws_rds_cluster_parameter_group" "db_postgresql" {
   }
 }
 
-
 resource "aws_secretsmanager_secret" "db_mastercreds_secret" {
   name = "aurora-postgis-db-master-creds-${var.target_env}_${var.app_env}"
 
@@ -99,6 +98,9 @@ module "aurora_postgresql_v2" {
   auto_minor_version_upgrade = false
 
   deletion_protection = contains(["dev", "test"], local.rds_app_env) ? false : true
+
+  performance_insights_enabled	= contains(["dev", "test"], local.rds_app_env) ? false : true
+  performance_insights_kms_key_id = data.aws_kms_alias.rds_key.arn
 
   db_parameter_group_name         = aws_db_parameter_group.db_postgresql.id
   db_cluster_parameter_group_name = aws_rds_cluster_parameter_group.db_postgresql.id


### PR DESCRIPTION
Went through the alerts with Om and fixed the ones we thought were relevant:

- Enable RDS performance insights
- Enable ECS container insights
- RDS deletion protection for prod is handled in #544 
- Update Vite and NestJS
