### PR TITLE
ci: run e2e tests on dev after deployment

### DIFF
--- a/.github/workflows/.e2e.yml
+++ b/.github/workflows/.e2e.yml
@@ -1,21 +1,32 @@
-name: Playwright Tests
+name: Playwright e2e tests
 
 on:
   workflow_call:
     inputs:
+      environment:
+        description: 'The GitHub environment to run the tests in'
+        required: false
+        type: string
       tag:
         description: 'The tag of the containers to run tests on'
         required: true
         type: string
+      local:
+        description: 'Run locally using docker compose'
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   playwright-e2e:
     name: Playwright e2e
     timeout-minutes: 60
     runs-on: ubuntu-24.04
+    environment: ${{ inputs.environment }}
     steps:
     - uses: actions/checkout@v4
     - name: Run Docker compose
+      if: ${{ inputs.local }}
       env:
         BACKEND_IMAGE: ghcr.io/bcgov/nr-rec-resources/backend:${{ inputs.tag }}
         FLYWAY_IMAGE: ghcr.io/bcgov/nr-rec-resources/migrations/rst:${{ inputs.tag }}
@@ -49,7 +60,8 @@ jobs:
       env:
         HAPPO_API_KEY: ${{ secrets.HAPPO_API_KEY }}
         HAPPO_API_SECRET: ${{ secrets.HAPPO_API_SECRET }}
-        HAPPO_PROJECT: rst-public
+        HAPPO_PROJECT: ${{ secrets.HAPPO_PROJECT }}
+        E2E_BASE_URL: ${{ inputs.local && 'http://localhost:3000' || secrets.E2E_BASE_URL }}
     - name: Dump docker logs on failure
-      if: failure()
+      if: failure() && ${{ inputs.local }}
       uses: jwalton/gh-docker-logs@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,21 +38,22 @@ jobs:
         run: echo "At least one job has failed." && exit 1
       - run: echo "Success!"
 
-  tests-e2e:
-    name: Tests
+  tests-e2e-local:
+    name: Run E2E tests locally
     needs: build-containers
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}-e2e
+      group: ${{ github.workflow }}-${{ github.ref }}-e2e-local
       cancel-in-progress: true
     uses: ./.github/workflows/.e2e.yml
     with:
       tag: ${{ github.sha }}
+      local: true
     secrets: inherit
 
   deploy-to-aws-dev:
     if: github.ref_name == 'main' || github.head_ref == 'main'
     name: Deploys Application to AWS dev
-    needs: tests-e2e
+    needs: tests-e2e-local
     uses: ./.github/workflows/.deploy-app.yml
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}-deploy-to-aws-dev
@@ -64,10 +65,22 @@ jobs:
       tag: ${{ github.sha }}
     secrets: inherit
 
+  tests-e2e-dev-environment:
+    name: Run e2e tests on dev env
+    needs: deploy-to-aws-dev
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}-e2e-dev-environment
+      cancel-in-progress: true
+    uses: ./.github/workflows/.e2e.yml
+    with:
+      tag: ${{ github.sha }}
+      environment: dev
+    secrets: inherit
+
   # Separate review job since we can't use GitHub environments in reusable workflows
   review-test-deployment:
     name: Review Test Deployment
-    needs: [deploy-to-aws-dev]
+    needs: tests-e2e-dev-environment
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}-review-test-deployment
       cancel-in-progress: true
@@ -93,20 +106,32 @@ jobs:
       tag: ${{ github.sha }}
     secrets: inherit
 
+  tests-e2e-test-environment:
+    name: Run e2e tests on test env
+    needs: deploy-to-aws-test
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}-e2e-test-environment
+      cancel-in-progress: true
+    uses: ./.github/workflows/.e2e.yml
+    with:
+      tag: ${{ github.sha }}
+      environment: test
+    secrets: inherit
+
   release:
     name: Release
-    needs: [deploy-to-aws-test]
+    needs: tests-e2e-test-environment
     uses: ./.github/workflows/.release.yml
 
   promote:
     name: Promote
-    needs: [release]
+    needs: release
     uses: ./.github/workflows/.promote.yml
 
   # Separate review job since we can't use GitHub environments in reusable workflows
   review-prod-deployment:
     name: Review Prod Deployment
-    needs: [promote]
+    needs: promote
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}-review-prod-deployment
       cancel-in-progress: true

--- a/frontend/e2e/constants.ts
+++ b/frontend/e2e/constants.ts
@@ -2,7 +2,4 @@ import { MAX_VISIBLE_OPTIONS } from '@/components/search/filters/FilterGroup';
 
 export const BASE_URL = process.env.E2E_BASE_URL || 'http://localhost:3000';
 
-export const BASE_API_URL =
-  process.env.E2E_BASE_API_URL || 'http://localhost:8000/api';
-
 export const MAX_VISIBLE_FILTERS = MAX_VISIBLE_OPTIONS;

--- a/frontend/e2e/poms/pages/recResource.ts
+++ b/frontend/e2e/poms/pages/recResource.ts
@@ -6,16 +6,6 @@ import { waitForImagesToLoad } from 'e2e/utils';
 import { RecResource } from 'e2e/poms/pages/types';
 
 const MAP_CANVAS_SELECTOR = '#map-container';
-const REC_DOC_LINKS: { role: 'link'; name: string }[] = [
-  {
-    role: 'link',
-    name: 'Blue Lake Trail Map [PDF]',
-  },
-  {
-    role: 'link',
-    name: 'Morchuea Lake Map [PDF]',
-  },
-];
 
 export class RecreationResourcePOM {
   readonly page: Page;
@@ -26,7 +16,7 @@ export class RecreationResourcePOM {
     this.page = page;
   }
 
-  async route(resourceId: string = 'REC160773') {
+  async route(resourceId: string = 'REC203239') {
     await this.page.goto(`${this.baseUrl}/${resourceId}`);
     await waitForImagesToLoad(this.page);
   }
@@ -49,8 +39,10 @@ export class RecreationResourcePOM {
     );
     expect(headerText).toContain(rec_resource_type);
     expect(headerText).toContain(closest_community.toLowerCase());
-    expect(headerText).toContain(status);
     expect(headerText).toContain(rec_resource_id);
+    if (status) {
+      expect(headerText).toContain(status);
+    }
   }
 
   /**
@@ -77,10 +69,7 @@ export class RecreationResourcePOM {
   }
 
   async verifyPdfDocLinks() {
-    for (const exp of REC_DOC_LINKS) {
-      await expect(
-        this.page.getByRole(exp.role, { name: exp.name }),
-      ).toHaveAttribute('href', expect.stringMatching(/^https:\/\/.*\.pdf$/));
-    }
+    const pdfLink = this.page.getByRole('link', { name: /\[PDF\]/ });
+    await expect(pdfLink).toHaveAttribute('href', /.*\.pdf$/);
   }
 }

--- a/frontend/e2e/poms/pages/recResource.ts
+++ b/frontend/e2e/poms/pages/recResource.ts
@@ -28,20 +28,23 @@ export class RecreationResourcePOM {
     closest_community,
     status,
   }: RecResource) {
-    await this.page.waitForLoadState('networkidle');
     const recResourceHeader = this.page
       .locator('h1')
       .locator('..')
       .locator('..');
-    const headerText = await recResourceHeader.textContent();
-    expect(await recResourceHeader.locator('h1').textContent()).toBe(
-      rec_resource_name,
+
+    const headerTitle = recResourceHeader.locator('h1');
+    await recResourceHeader.waitFor({ state: 'visible' });
+    await headerTitle.waitFor({ state: 'visible' });
+    await expect(headerTitle).toHaveText(rec_resource_name);
+    await expect(recResourceHeader).toContainText(rec_resource_type);
+    await expect(recResourceHeader).toContainText(
+      closest_community.toLowerCase(),
     );
-    expect(headerText).toContain(rec_resource_type);
-    expect(headerText).toContain(closest_community.toLowerCase());
-    expect(headerText).toContain(rec_resource_id);
+    await expect(recResourceHeader).toContainText(rec_resource_id);
+
     if (status) {
-      expect(headerText).toContain(status);
+      await expect(recResourceHeader).toContainText(status);
     }
   }
 

--- a/frontend/e2e/poms/pages/search.ts
+++ b/frontend/e2e/poms/pages/search.ts
@@ -11,8 +11,6 @@ export class SearchPOM {
 
   readonly url: string = `${BASE_URL}/search`;
 
-  readonly initialResults: number = 51;
-
   readonly searchBtn: Locator;
 
   constructor(page: Page) {
@@ -64,22 +62,13 @@ export class SearchPOM {
     await this.clickLoadMore(SearchEnum.LOAD_PREV_LABEL);
   }
 
-  async verifyInitialResults() {
-    await this.resultsCount(this.initialResults);
-    await this.page
-      .getByRole('heading', {
-        name: '10 K Snowmobile Parking Lot',
-      })
-      .waitFor({ state: 'visible' });
-    await this.page
-      .getByRole('heading', {
-        name: '10k Cabin',
-      })
-      .waitFor({ state: 'visible' });
-  }
-
   async recResourceCardCount(count: number) {
     await expect(this.page.locator('.rec-resource-card')).toHaveCount(count);
+  }
+
+  async verifyInitialResults() {
+    await this.page.getByText(/result/i).waitFor({ state: 'visible' });
+    await this.recResourceCardCount(10);
   }
 
   async verifyRecResourceCardContent({
@@ -103,7 +92,9 @@ export class SearchPOM {
     await cardContainer
       .getByText(closest_community.toLowerCase())
       .waitFor({ state: 'visible' });
-    await cardContainer.getByText(status).waitFor({ state: 'visible' });
+    if (status) {
+      await cardContainer.getByText(status).waitFor({ state: 'visible' });
+    }
   }
 
   // Pass false to expectResults if testing for no results

--- a/frontend/e2e/poms/pages/types.ts
+++ b/frontend/e2e/poms/pages/types.ts
@@ -3,5 +3,5 @@ export interface RecResource {
   rec_resource_name: string;
   rec_resource_type: string;
   closest_community: string;
-  status: string;
+  status?: string;
 }

--- a/frontend/e2e/workflows/search/filter.spec.ts
+++ b/frontend/e2e/workflows/search/filter.spec.ts
@@ -20,6 +20,8 @@ test.describe('Search page filter menu workflows', () => {
     await filter.toggleFilterOn(filter.districtFilters, 'Chilliwack');
 
     await utils.checkExpectedUrlParams('district=RDCK');
+
+    await searchPage.waitForResults();
   });
 
   test('Use the filter menu to filter by multiple districts', async ({
@@ -45,7 +47,7 @@ test.describe('Search page filter menu workflows', () => {
 
     await utils.checkExpectedUrlParams('district=RDCK_RDKA_RDOS_RDSQ');
 
-    await searchPage.recResourceCardCount(10);
+    await searchPage.waitForResults();
   });
 
   test('Use the filter menu to filter by rec resource type', async ({
@@ -59,11 +61,13 @@ test.describe('Search page filter menu workflows', () => {
 
     await filter.verifyInitialFilterMenu();
 
+    await filter.verifyFilterResultsListener({ type: ['Recreation trail'] });
+
     await filter.toggleFilterOn(filter.typeFilters, RecResourceType.TRAIL);
 
     await utils.checkExpectedUrlParams('type=RTR');
 
-    await searchPage.recResourceCardCount(10);
+    await searchPage.waitForResults();
   });
 
   test('Use the filter menu to filter by multiple rec resource types', async ({
@@ -77,13 +81,21 @@ test.describe('Search page filter menu workflows', () => {
 
     await filter.verifyInitialFilterMenu();
 
+    await filter.verifyFilterResultsListener({ type: ['Recreation trail'] });
+
     await filter.toggleFilterOn(filter.typeFilters, RecResourceType.TRAIL);
+
+    await searchPage.waitForResults();
+
+    await filter.verifyFilterResultsListener({
+      type: ['Recreation trail', 'Recreation site'],
+    });
 
     await filter.toggleFilterOn(filter.typeFilters, RecResourceType.SITE);
 
     await utils.checkExpectedUrlParams('type=RTR_SIT');
 
-    await searchPage.recResourceCardCount(10);
+    await searchPage.waitForResults();
   });
 
   test('Use the filter menu to filter by things to do', async ({ page }) => {
@@ -95,11 +107,13 @@ test.describe('Search page filter menu workflows', () => {
 
     await filter.verifyInitialFilterMenu();
 
+    await filter.verifyFilterResultsListener({ activities: ['Camping'] });
+
     await filter.toggleFilterOn(filter.thingsToDoFilters, 'Camping');
 
     await utils.checkExpectedUrlParams('activities=32');
 
-    await searchPage.recResourceCardCount(10);
+    await searchPage.waitForResults();
   });
 
   test('Use the filter menu to filter by multiple things to do', async ({
@@ -119,9 +133,15 @@ test.describe('Search page filter menu workflows', () => {
 
     await filter.clickShowAllFilters(filter.thingsToDoFilters);
 
+    await filter.verifyFilterResultsListener({
+      activities: ['Angling', 'Camping', 'Hunting'],
+    });
+
     await filter.toggleFilterOn(filter.thingsToDoFilters, 'Hunting');
 
     await utils.checkExpectedUrlParams('activities=1_32_10');
+
+    await searchPage.waitForResults();
   });
 
   test('Use the filter menu to filter by Facilities', async ({ page }) => {
@@ -137,7 +157,7 @@ test.describe('Search page filter menu workflows', () => {
 
     await utils.checkExpectedUrlParams('facilities=toilet');
 
-    await searchPage.recResourceCardCount(10);
+    await searchPage.waitForResults();
   });
 
   test('Use the filter menu to filter by multiple Facilities', async ({
@@ -157,7 +177,7 @@ test.describe('Search page filter menu workflows', () => {
 
     await utils.checkExpectedUrlParams('facilities=toilet_table');
 
-    await searchPage.recResourceCardCount(10);
+    await searchPage.waitForResults();
   });
 
   test('Use the filter menu to filter by Access Type', async ({ page }) => {
@@ -172,6 +192,8 @@ test.describe('Search page filter menu workflows', () => {
     await filter.toggleFilterOn(filter.accessTypeFilters, 'Road Access');
 
     await utils.checkExpectedUrlParams('access=R');
+
+    await searchPage.waitForResults();
   });
 
   test('Use the filter menu to filter by multiple Access Types', async ({
@@ -189,15 +211,17 @@ test.describe('Search page filter menu workflows', () => {
 
     await filter.toggleFilterOn(filter.accessTypeFilters, 'Fly-in Access');
 
-    await searchPage.recResourceCardCount(10);
+    await searchPage.waitForResults();
 
     await filter.toggleFilterOn(filter.accessTypeFilters, 'Road Access');
 
-    await searchPage.recResourceCardCount(10);
+    await searchPage.waitForResults();
 
     await filter.toggleFilterOn(filter.accessTypeFilters, 'Trail Access');
 
     await utils.checkExpectedUrlParams('access=B_F_R_T');
+
+    await searchPage.waitForResults();
   });
 
   test('Use the filter menu to filter by multiple filter types', async ({
@@ -223,7 +247,13 @@ test.describe('Search page filter menu workflows', () => {
 
     await filter.toggleFilterOn(filter.facilitiesFilters, 'Toilets');
 
+    await filter.verifyFilterResultsListener({
+      type: ['Recreation site'],
+    });
+
     await filter.toggleFilterOn(filter.accessTypeFilters, 'Road Access');
+
+    await searchPage.waitForResults();
 
     await utils.checkExpectedUrlParams(
       'district=RDCK_RDKA_RDOS&page=1&type=SIT&facilities=toilet&access=R',
@@ -252,11 +282,13 @@ test.describe('Search page filter menu workflows', () => {
 
     await utils.checkExpectedUrlParams('district=RDCK');
 
+    await searchPage.waitForResults();
+
     await filter.clickClearFilters();
 
     await utils.checkExpectedUrlParams('page=1');
 
-    await searchPage.recResourceCardCount(10);
+    await searchPage.waitForResults();
   });
 
   test('Use the Clear Filters button to clear all filters', async ({
@@ -276,18 +308,16 @@ test.describe('Search page filter menu workflows', () => {
 
     await filter.toggleFilterOn(filter.typeFilters, RecResourceType.SITE);
 
-    await filter.toggleFilterOn(filter.facilitiesFilters, 'Tables');
-
     await filter.toggleFilterOn(filter.accessTypeFilters, 'Boat-in Access');
 
     await utils.checkExpectedUrlParams(
-      'district=RDKA&page=1&type=SIT&facilities=table&access=B',
+      'district=RDKA&page=1&type=SIT&access=B',
     );
 
     await filter.clickClearFilters();
 
     await utils.checkExpectedUrlParams('');
 
-    await searchPage.recResourceCardCount(10);
+    await searchPage.waitForResults();
   });
 });

--- a/frontend/e2e/workflows/search/filter.spec.ts
+++ b/frontend/e2e/workflows/search/filter.spec.ts
@@ -1,9 +1,7 @@
 import { test } from '@playwright/test';
 import { initHappo } from 'e2e/utils';
 import { FilterPOM, SearchPOM, UtilsPOM } from 'e2e/poms';
-import { RecResourceType, Status } from 'e2e/enum/recResource';
-
-const TOTAL_RESULTS = 51;
+import { RecResourceType } from 'e2e/enum/recResource';
 
 initHappo();
 
@@ -22,18 +20,6 @@ test.describe('Search page filter menu workflows', () => {
     await filter.toggleFilterOn(filter.districtFilters, 'Chilliwack');
 
     await utils.checkExpectedUrlParams('district=RDCK');
-
-    await searchPage.resultsCount(2);
-
-    await searchPage.recResourceCardCount(2);
-
-    await searchPage.verifyRecResourceCardContent({
-      rec_resource_id: 'REC265446',
-      rec_resource_name: 'Airy Area',
-      rec_resource_type: RecResourceType.SITE,
-      closest_community: 'Slocan',
-      status: Status.CLOSED,
-    });
   });
 
   test('Use the filter menu to filter by multiple districts', async ({
@@ -59,8 +45,6 @@ test.describe('Search page filter menu workflows', () => {
 
     await utils.checkExpectedUrlParams('district=RDCK_RDKA_RDOS_RDSQ');
 
-    await searchPage.resultsCount(26);
-
     await searchPage.recResourceCardCount(10);
   });
 
@@ -79,17 +63,7 @@ test.describe('Search page filter menu workflows', () => {
 
     await utils.checkExpectedUrlParams('type=RTR');
 
-    await searchPage.resultsCount(17);
-
     await searchPage.recResourceCardCount(10);
-
-    await searchPage.verifyRecResourceCardContent({
-      rec_resource_id: 'REC6866',
-      rec_resource_name: '1861 goldrush pack trail',
-      rec_resource_type: RecResourceType.TRAIL,
-      closest_community: 'Wells',
-      status: Status.OPEN,
-    });
   });
 
   test('Use the filter menu to filter by multiple rec resource types', async ({
@@ -107,11 +81,9 @@ test.describe('Search page filter menu workflows', () => {
 
     await filter.toggleFilterOn(filter.typeFilters, RecResourceType.SITE);
 
-    await searchPage.resultsCount(50);
+    await utils.checkExpectedUrlParams('type=RTR_SIT');
 
     await searchPage.recResourceCardCount(10);
-
-    await utils.checkExpectedUrlParams('type=RTR_SIT');
   });
 
   test('Use the filter menu to filter by things to do', async ({ page }) => {
@@ -127,17 +99,7 @@ test.describe('Search page filter menu workflows', () => {
 
     await utils.checkExpectedUrlParams('activities=32');
 
-    await searchPage.resultsCount(14);
-
     await searchPage.recResourceCardCount(10);
-
-    await searchPage.verifyRecResourceCardContent({
-      rec_resource_id: 'REC2206',
-      rec_resource_name: '7 Mile Lake',
-      rec_resource_type: RecResourceType.SITE,
-      closest_community: 'Cranbrook',
-      status: Status.CLOSED,
-    });
   });
 
   test('Use the filter menu to filter by multiple things to do', async ({
@@ -160,10 +122,6 @@ test.describe('Search page filter menu workflows', () => {
     await filter.toggleFilterOn(filter.thingsToDoFilters, 'Hunting');
 
     await utils.checkExpectedUrlParams('activities=1_32_10');
-
-    await searchPage.resultsCount(5);
-
-    await searchPage.recResourceCardCount(5);
   });
 
   test('Use the filter menu to filter by Facilities', async ({ page }) => {
@@ -179,17 +137,7 @@ test.describe('Search page filter menu workflows', () => {
 
     await utils.checkExpectedUrlParams('facilities=toilet');
 
-    await searchPage.resultsCount(13);
-
     await searchPage.recResourceCardCount(10);
-
-    await searchPage.verifyRecResourceCardContent({
-      rec_resource_id: 'REC203239',
-      rec_resource_name: '10 k snowmobile parking lot',
-      rec_resource_type: RecResourceType.SITE,
-      closest_community: 'Merritt',
-      status: Status.CLOSED,
-    });
   });
 
   test('Use the filter menu to filter by multiple Facilities', async ({
@@ -209,8 +157,6 @@ test.describe('Search page filter menu workflows', () => {
 
     await utils.checkExpectedUrlParams('facilities=toilet_table');
 
-    await searchPage.resultsCount(22);
-
     await searchPage.recResourceCardCount(10);
   });
 
@@ -226,18 +172,6 @@ test.describe('Search page filter menu workflows', () => {
     await filter.toggleFilterOn(filter.accessTypeFilters, 'Road Access');
 
     await utils.checkExpectedUrlParams('access=R');
-
-    await searchPage.resultsCount(9);
-
-    await searchPage.recResourceCardCount(9);
-
-    await searchPage.verifyRecResourceCardContent({
-      rec_resource_id: 'REC6866',
-      rec_resource_name: '1861 Goldrush Pack Trail',
-      rec_resource_type: RecResourceType.TRAIL,
-      closest_community: 'Wells',
-      status: Status.OPEN,
-    });
   });
 
   test('Use the filter menu to filter by multiple Access Types', async ({
@@ -255,13 +189,9 @@ test.describe('Search page filter menu workflows', () => {
 
     await filter.toggleFilterOn(filter.accessTypeFilters, 'Fly-in Access');
 
-    await searchPage.resultsCount(26);
-
     await searchPage.recResourceCardCount(10);
 
     await filter.toggleFilterOn(filter.accessTypeFilters, 'Road Access');
-
-    await searchPage.resultsCount(35);
 
     await searchPage.recResourceCardCount(10);
 
@@ -299,18 +229,6 @@ test.describe('Search page filter menu workflows', () => {
       'district=RDCK_RDKA_RDOS&page=1&type=SIT&facilities=toilet&access=R',
     );
 
-    await searchPage.resultsCount(1);
-
-    await searchPage.recResourceCardCount(1);
-
-    await searchPage.verifyRecResourceCardContent({
-      rec_resource_id: 'REC205035',
-      rec_resource_name: '99 mile xc keene road parking',
-      rec_resource_type: RecResourceType.SITE,
-      closest_community: '100 Mile House',
-      status: Status.CLOSED,
-    });
-
     await utils.screenshot(
       'Search page with multiple filters applied',
       'default',
@@ -334,15 +252,9 @@ test.describe('Search page filter menu workflows', () => {
 
     await utils.checkExpectedUrlParams('district=RDCK');
 
-    await searchPage.resultsCount(2);
-
-    await searchPage.recResourceCardCount(2);
-
     await filter.clickClearFilters();
 
     await utils.checkExpectedUrlParams('page=1');
-
-    await searchPage.resultsCount(TOTAL_RESULTS);
 
     await searchPage.recResourceCardCount(10);
   });
@@ -372,15 +284,9 @@ test.describe('Search page filter menu workflows', () => {
       'district=RDKA&page=1&type=SIT&facilities=table&access=B',
     );
 
-    await searchPage.resultsCount(2);
-
-    await searchPage.recResourceCardCount(2);
-
     await filter.clickClearFilters();
 
     await utils.checkExpectedUrlParams('');
-
-    await searchPage.resultsCount(TOTAL_RESULTS);
 
     await searchPage.recResourceCardCount(10);
   });

--- a/frontend/e2e/workflows/search/search.spec.ts
+++ b/frontend/e2e/workflows/search/search.spec.ts
@@ -38,6 +38,8 @@ test.describe('Search for a recreation site or trail workflows', () => {
 
     await utils.checkExpectedUrlParams('filter=10k&page=1');
 
+    await searchPage.verifySearchResults('10k');
+
     await utils.clickLinkByText('10k cabin');
 
     await recResourcePage.verifyRecResourceHeaderContent({
@@ -66,6 +68,8 @@ test.describe('Search for a recreation site or trail workflows', () => {
 
     await utils.checkExpectedUrlParams('filter=summerland&page=1');
 
+    await searchPage.verifySearchResults('summerland');
+
     await utils.clickLinkByText('Agur Lake');
 
     await recResourcePage.verifyRecResourceHeaderContent({
@@ -90,7 +94,7 @@ test.describe('Search for a recreation site or trail workflows', () => {
 
     await searchPage.searchFor('not a real place', false);
 
-    await searchPage.resultsCount(0);
+    await searchPage.waitForNoResults();
   });
 
   test('Use the load more button to view more results', async ({ page }) => {

--- a/frontend/e2e/workflows/search/search.spec.ts
+++ b/frontend/e2e/workflows/search/search.spec.ts
@@ -8,7 +8,7 @@ import {
   SearchPOM,
   UtilsPOM,
 } from 'e2e/poms';
-import { RecResourceType, Status } from 'e2e/enum/recResource';
+import { RecResourceType } from 'e2e/enum/recResource';
 
 initHappo();
 
@@ -34,20 +34,17 @@ test.describe('Search for a recreation site or trail workflows', () => {
 
     await searchPage.verifyInitialResults();
 
-    await searchPage.searchFor('alpine');
+    await searchPage.searchFor('10k');
 
-    await searchPage.resultsCount(2);
+    await utils.checkExpectedUrlParams('filter=10k&page=1');
 
-    await utils.checkExpectedUrlParams('filter=alpine&page=1');
-
-    await utils.clickLinkByText('Alpine Lake Trail');
+    await utils.clickLinkByText('10k cabin');
 
     await recResourcePage.verifyRecResourceHeaderContent({
-      rec_resource_id: 'REC1163',
-      rec_resource_name: 'Alpine Lake Trail',
+      rec_resource_id: 'REC160773',
+      rec_resource_name: '10k Cabin',
       rec_resource_type: RecResourceType.SITE,
-      closest_community: 'Trout Creek',
-      status: Status.OPEN,
+      closest_community: 'Merritt',
     });
   });
 
@@ -67,8 +64,6 @@ test.describe('Search for a recreation site or trail workflows', () => {
 
     await searchPage.searchFor('summerland');
 
-    await searchPage.resultsCount(1);
-
     await utils.checkExpectedUrlParams('filter=summerland&page=1');
 
     await utils.clickLinkByText('Agur Lake');
@@ -78,7 +73,6 @@ test.describe('Search for a recreation site or trail workflows', () => {
       rec_resource_name: 'Agur Lake',
       rec_resource_type: RecResourceType.SITE,
       closest_community: 'Summerland',
-      status: Status.CLOSED,
     });
   });
 


### PR DESCRIPTION
#337

### e2e ci changes:
- the e2e workflow can run e2e locally ie docker-compose or using a live base url passed in via environment secrets
- e2e tests now run against the dev environment after dev has been deployed
- e2e tests now run against the test environment after test has been deployed
- I may change this but both dev and test e2e use a new project `rst-dev`. Theoretically they should be the same so I think we can use the same one, but we will see how it goes and I can create another `rst-test` if needed

### Testing changes:
- Tests are rewritten to work against both the dev fixtures and the live data
- Instead of verifying specific results, or the number of results we are verifying that there are results
- Verifying that each search results card contains the text that was searched for
- For filters, we are intercepting the response and validating that the responses include the expected data - this only works for types and activities filters as the others we aren't actually fetching the data for each rec reserve