### PR TITLE
fix: site status

### DIFF
--- a/backend/src/recreation-resource/constants/service.constants.ts
+++ b/backend/src/recreation-resource/constants/service.constants.ts
@@ -1,3 +1,7 @@
 export const EXCLUDED_ACTIVITY_CODES = [26];
 export const EXCLUDED_RECREATION_DISTRICTS = ["RDQC", "RDRM", "RDRN", "RDRS"];
 export const EXCLUDED_RESOURCE_TYPES = ["RR"];
+export const OPEN_STATUS = {
+  DESCRIPTION: "Open",
+  STATUS_CODE: 1,
+};

--- a/backend/src/recreation-resource/utils/formatRecreationResourceDetailResults.spec.ts
+++ b/backend/src/recreation-resource/utils/formatRecreationResourceDetailResults.spec.ts
@@ -132,4 +132,17 @@ describe("formatRecreationResourceDetailResults function", () => {
       "Cannot read properties of undefined (reading 'map')",
     );
   });
+
+  it("should return result with status as 'Open' if no status is provided", () => {
+    const results = formatRecreationResourceDetailResults(
+      { ...mockResponse, recreation_status: null },
+      mockSpatialResponse,
+    );
+
+    expect(results.recreation_status).toEqual({
+      comment: undefined,
+      description: "Open",
+      status_code: 1,
+    });
+  });
 });

--- a/backend/src/recreation-resource/utils/formatRecreationResourceDetailResults.ts
+++ b/backend/src/recreation-resource/utils/formatRecreationResourceDetailResults.ts
@@ -6,6 +6,7 @@ import { RecreationResourceImageDto } from "src/recreation-resource/dto/recreati
 import { RecreationResourceGetPayload } from "src/recreation-resource/service/types";
 import { getRecreationResourceSpatialFeatureGeometry } from "@prisma-generated-sql";
 import { RecreationResourceDocCode } from "src/recreation-resource/dto/recreation-resource-doc.dto";
+import { OPEN_STATUS } from "src/recreation-resource/constants/service.constants";
 
 // Format recreation resource detail results to match the RecreationResourceDetailDto
 export const formatRecreationResourceDetailResults = (
@@ -32,9 +33,12 @@ export const formatRecreationResourceDetailResults = (
         activity.recreation_activity.recreation_activity_code,
     })),
     recreation_status: {
-      description: result.recreation_status?.recreation_status_code.description,
+      description:
+        result.recreation_status?.recreation_status_code.description ??
+        OPEN_STATUS.DESCRIPTION,
       comment: result.recreation_status?.comment,
-      status_code: result.recreation_status?.status_code,
+      status_code:
+        result.recreation_status?.status_code ?? OPEN_STATUS.STATUS_CODE,
     },
     campsite_count: result._count?.recreation_defined_campsite,
     recreation_resource_images:

--- a/backend/src/recreation-resource/utils/formatSearchResults.spec.ts
+++ b/backend/src/recreation-resource/utils/formatSearchResults.spec.ts
@@ -57,4 +57,16 @@ describe("formatSearchResults function", () => {
       "recResources?.map is not a function",
     );
   });
+
+  it("should return sites with status as 'Open' if no status is provided", () => {
+    const results = formatSearchResults([
+      { ...response[0], recreation_status: null },
+    ]);
+
+    expect(results[0].recreation_status).toEqual({
+      comment: undefined,
+      description: "Open",
+      status_code: 1,
+    });
+  });
 });

--- a/backend/src/recreation-resource/utils/formatSearchResults.ts
+++ b/backend/src/recreation-resource/utils/formatSearchResults.ts
@@ -5,6 +5,7 @@ import {
   RecreationStructureDto,
 } from "src/recreation-resource/dto/recreation-resource.dto";
 import { RecreationResourceImageDto } from "src/recreation-resource/dto/recreation-resource-image.dto";
+import { OPEN_STATUS } from "src/recreation-resource/constants/service.constants";
 
 export type RecreationResourceSearchView = {
   rec_resource_id: string;
@@ -41,9 +42,11 @@ export const formatSearchResults = (
           recreation_activity_code: activity.recreation_activity_code,
         })) ?? [],
       recreation_status: {
-        description: resource.recreation_status?.description,
+        description:
+          resource.recreation_status?.description ?? OPEN_STATUS.DESCRIPTION,
         comment: resource.recreation_status?.comment,
-        status_code: resource.recreation_status?.status_code,
+        status_code:
+          resource.recreation_status?.status_code ?? OPEN_STATUS.STATUS_CODE,
       },
       recreation_resource_images: resource.recreation_resource_images ?? [],
     };

--- a/frontend/src/components/rec-resource/card/RecResourceCard.tsx
+++ b/frontend/src/components/rec-resource/card/RecResourceCard.tsx
@@ -66,7 +66,7 @@ const RecResourceCard: React.FC<RecResourceCardProps> = ({
           </div>
         </div>
         <div className="card-content-lower">
-          {hasActivities && <Activities activities={activities} />}
+          <span>{hasActivities && <Activities activities={activities} />}</span>
           <Status description={statusDescription} statusCode={status_code} />
         </div>
       </div>


### PR DESCRIPTION
Considered doing a view as a source of truth similar to `recreation_type` but I don't think that would work as unlike the type, the issue with status is that a lot of sites just don't have entries at all. Since prisma doesn't support `coalesce` I'm just handling it when we format the data.

- **fix: display rec resources with no status as open**
- **fix: rec resource card status alignment when no activities**


Also fixed the alignment when there were no activities, the status was on the left of the card:
<img width="794" alt="Screenshot 2025-04-14 at 4 11 40 PM" src="https://github.com/user-attachments/assets/83d9fc90-b9b4-4770-b421-eb4a2de0f55c" />

Fixed:
<img width="794" alt="Screenshot 2025-04-14 at 4 11 50 PM" src="https://github.com/user-attachments/assets/ed021a1b-a3e2-4409-8690-7d22d38488bd" />


