### PR TITLE
chore: update page menu mobile styling

### DIFF
--- a/frontend/src/components/layout/PageMenu.scss
+++ b/frontend/src/components/layout/PageMenu.scss
@@ -1,9 +1,9 @@
 @import '@/styles/variables.scss';
 
-.page-menu--desktop {
+.page-menu {
   padding-right: 20px;
   font-size: 0.875rem;
-  padding-left: 0px;
+  margin-top: 64px;
   margin-bottom: 80px;
   max-width: 260px;
   align-self: flex-start;
@@ -20,18 +20,15 @@
     max-width: 100%;
   }
 
-  .navbar {
-    padding: 0;
-  }
-
   a {
     width: 100%;
     color: $colorBlueMed;
     font-size: 1rem;
-    text-decoration: none;
+    text-decoration: underline;
     border-radius: 0px;
     margin-top: 15px;
-    padding: 6px 12px;
+    padding: 6px 12px 6px 0;
+
     &:hover,
     &:focus-visible {
       color: $colorBlue;
@@ -43,57 +40,34 @@
       outline-offset: 0px;
       border-radius: 4px;
     }
-    &:first-of-type {
-      margin-top: 64px;
+
+    @media (min-width: $mdBreakpoint) {
+      padding: 6px 12px;
+      text-decoration: none;
     }
   }
+
+  ul {
+    @media (min-width: $mdBreakpoint) {
+      list-style: none;
+      padding-left: 0;
+    }
+  }
+
+  .menu-header {
+    font-size: 1.25rem;
+    font-weight: 600;
+  }
 }
-.page-menu--desktop[section-count='1'] {
+.page-menu[section-count='1'] {
   display: none;
 }
 
-.page-menu--desktop .active {
+.page-menu .active {
   @media (min-width: $mdBreakpoint) {
     color: $colorBlue;
     font-weight: bold;
     box-sizing: border-box;
     border-left: $colorBlue solid 3px;
-  }
-}
-
-.page-menu--mobile {
-  top: 0px;
-  position: sticky;
-  position: -webkit-sticky;
-  z-index: 1024;
-  background: #fff;
-  width: 100%;
-  margin-top: 32px;
-
-  .section-select-container {
-    position: relative;
-    &::after {
-      position: absolute;
-      content: '\f078';
-      top: calc(50% - 8px);
-      right: 22px;
-      color: $colorBlue;
-      font-weight: 900;
-      font-size: 12px;
-      text-decoration: none;
-      -webkit-font-smoothing: antialiased;
-    }
-
-    .section-select {
-      width: 100%;
-      height: 68px;
-      border-left: none;
-      border-right: none;
-      padding: 0px 20px;
-      color: $colorBlue;
-      background: #fff;
-      text-overflow: ellipsis;
-      appearance: none;
-    }
   }
 }

--- a/frontend/src/components/layout/PageMenu.tsx
+++ b/frontend/src/components/layout/PageMenu.tsx
@@ -9,79 +9,36 @@ type PageSection = {
 type PageMenuProps = {
   pageSections: PageSection[];
   activeSection: number;
-  menuStyle: 'nav' | 'select';
 };
 
-const PageMenu: React.FC<PageMenuProps> = ({
-  pageSections,
-  activeSection,
-  menuStyle,
-}) => {
-  if (menuStyle === 'nav') {
-    return (
-      <nav
-        id="section-navbar"
-        aria-label="Page section navigation"
-        className="navbar"
-      >
+const PageMenu: React.FC<PageMenuProps> = ({ pageSections, activeSection }) => {
+  return (
+    <nav
+      id="section-navbar"
+      aria-label="Page section navigation"
+      className="page-menu"
+    >
+      <span className="menu-header">On this page</span>
+      <ul>
         {pageSections.map((section) => {
           const { href, sectionIndex, title } = section;
           return (
-            <a
-              className={`nav-link ${activeSection === sectionIndex ? 'active' : ''}`}
-              data-active-section={
-                activeSection === sectionIndex ? 'true' : 'false'
-              }
-              key={href}
-              href={href}
-            >
-              {title}
-            </a>
+            <li key={href}>
+              <a
+                className={`nav-link ${activeSection === sectionIndex ? 'active' : ''}`}
+                data-active-section={
+                  activeSection === sectionIndex ? 'true' : 'false'
+                }
+                href={href}
+              >
+                {title}
+              </a>
+            </li>
           );
         })}
-      </nav>
-    );
-  }
-
-  if (menuStyle === 'select') {
-    const handleSectionChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-      const index = e.target.value;
-      const selectedSection = pageSections.find(
-        (section) => section.sectionIndex === Number(index),
-      );
-      if (
-        selectedSection?.href &&
-        window.location.hash !== `#${selectedSection.href}`
-      ) {
-        window.location.hash = encodeURIComponent(selectedSection.href);
-      }
-    };
-
-    return (
-      <div className="section-select-container">
-        <select
-          className="section-select"
-          value={activeSection}
-          onChange={handleSectionChange}
-          title="mobile-navigation"
-        >
-          <option value="" disabled>
-            Table of Contents
-          </option>
-          {pageSections.map((section) => {
-            const { title, sectionIndex } = section;
-            return (
-              <option key={title} value={sectionIndex}>
-                {title}
-              </option>
-            );
-          })}
-        </select>
-      </div>
-    );
-  }
-
-  return null;
+      </ul>
+    </nav>
+  );
 };
 
 export default PageMenu;

--- a/frontend/src/components/rec-resource/RecResourcePage.tsx
+++ b/frontend/src/components/rec-resource/RecResourcePage.tsx
@@ -265,13 +265,10 @@ const RecResourcePage = () => {
             </div>
           )}
           <div className="row no-gutters">
-            <div className="page-menu--desktop">
-              <PageMenu
-                pageSections={pageSections}
-                activeSection={activeSection ?? 0}
-                menuStyle="nav"
-              />
-            </div>
+            <PageMenu
+              pageSections={pageSections}
+              activeSection={activeSection ?? 0}
+            />
             <div className="rec-content-container">
               {isClosures && (
                 <Closures


### PR DESCRIPTION
#530 

This issue was originally meant to add a dropdown menu for mobile though we noticed that bcparks.ca got rid of that. Now we are more closely aligning with their menu with the `On this page` header and the mobile styling.

Desktop:
<img width="246" alt="Screenshot 2025-04-23 at 11 48 57 AM" src="https://github.com/user-attachments/assets/5fbf987d-5579-4383-812e-450f94c243c5" />

Mobile:
<img width="246" alt="Screenshot 2025-04-23 at 11 49 05 AM" src="https://github.com/user-attachments/assets/c9cf3a55-4697-40e7-8b7b-350f56fc4825" />

