### PR TITLE
chore: add no results component button

### DIFF
--- a/frontend/src/components/recreation-search-form/RecreationSearchForm.test.tsx
+++ b/frontend/src/components/recreation-search-form/RecreationSearchForm.test.tsx
@@ -4,6 +4,17 @@ import userEvent from '@testing-library/user-event';
 import * as SearchHooks from './useSearchInput';
 import { vi } from 'vitest';
 
+import { MemoryRouter } from 'react-router-dom';
+
+const renderWithRouter = (
+  component: React.ReactElement,
+  initialEntries: string[] = ['/'],
+) => {
+  return render(
+    <MemoryRouter initialEntries={initialEntries}>{component}</MemoryRouter>,
+  );
+};
+
 describe('RecreationSearchForm', () => {
   const mockHooks = {
     inputValue: '',
@@ -26,7 +37,7 @@ describe('RecreationSearchForm', () => {
   afterEach(() => vi.restoreAllMocks());
 
   it('renders default form', () => {
-    render(<RecreationSearchForm />);
+    renderWithRouter(<RecreationSearchForm />);
     expect(
       screen.getByPlaceholderText('Search by name or community'),
     ).toBeInTheDocument();
@@ -35,7 +46,7 @@ describe('RecreationSearchForm', () => {
 
   it('renders with custom props', () => {
     setup({ inputValue: 'test' });
-    render(
+    renderWithRouter(
       <RecreationSearchForm
         initialValue="test"
         buttonText="Find"
@@ -53,7 +64,7 @@ describe('RecreationSearchForm', () => {
 
   it('handles user interactions', async () => {
     const { setInputValue, handleSearch, handleClear } = setup();
-    render(<RecreationSearchForm />);
+    renderWithRouter(<RecreationSearchForm />);
 
     // Test input change
     fireEvent.change(screen.getByTestId('search-input'), {
@@ -67,18 +78,32 @@ describe('RecreationSearchForm', () => {
 
     // Test clear
     setup({ inputValue: 'test' });
-    render(<RecreationSearchForm />);
+    renderWithRouter(<RecreationSearchForm />);
     await userEvent.click(screen.getByLabelText('Clear search'));
     expect(handleClear).toHaveBeenCalled();
   });
 
   it('handles form submission', async () => {
     const { handleSearch } = setup();
-    render(<RecreationSearchForm />);
+    renderWithRouter(<RecreationSearchForm />);
 
     const form = screen.getByTestId('search-form');
     fireEvent.submit(form);
 
     expect(handleSearch).toHaveBeenCalledTimes(1);
+  });
+
+  it('clears the search input if no filter search params', () => {
+    const { setInputValue } = setup();
+    renderWithRouter(<RecreationSearchForm />, ['/search']);
+
+    expect(setInputValue).toHaveBeenCalledWith('');
+  });
+
+  it('does not clear the search input if filter search params exist', () => {
+    const { setInputValue } = setup();
+    renderWithRouter(<RecreationSearchForm />, ['/search?filter=test']);
+
+    expect(setInputValue).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/components/recreation-search-form/RecreationSearchForm.tsx
+++ b/frontend/src/components/recreation-search-form/RecreationSearchForm.tsx
@@ -1,4 +1,4 @@
-import { FC, FormEvent } from 'react';
+import { FC, FormEvent, useEffect } from 'react';
 import {
   Button,
   ButtonProps,
@@ -8,6 +8,7 @@ import {
   InputGroup,
   Row,
 } from 'react-bootstrap';
+import { useSearchParams } from 'react-router-dom';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faSearch, faTimes } from '@fortawesome/free-solid-svg-icons';
 import './RecreationSearchForm.scss';
@@ -28,6 +29,8 @@ export const RecreationSearchForm: FC<RecreationSearchFormProps> = ({
   searchButtonProps,
   showSearchIcon = false,
 }) => {
+  const [searchParams] = useSearchParams();
+  const filter = searchParams.get('filter');
   const { inputValue, setInputValue, handleSearch, handleClear } =
     useSearchInput({ initialValue });
 
@@ -35,6 +38,12 @@ export const RecreationSearchForm: FC<RecreationSearchFormProps> = ({
     e.preventDefault();
     handleSearch();
   };
+
+  useEffect(() => {
+    if (!filter) {
+      setInputValue('');
+    }
+  }, [filter, setInputValue]);
 
   return (
     <Form

--- a/frontend/src/components/search/NoResults.test.tsx
+++ b/frontend/src/components/search/NoResults.test.tsx
@@ -1,0 +1,38 @@
+import { vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import NoResults from 'src/components/search/NoResults';
+import { MemoryRouter, useSearchParams } from 'react-router-dom';
+
+vi.mock('react-router-dom', async () => {
+  const originalModule = await vi.importActual('react-router-dom');
+  return {
+    ...originalModule,
+    useSearchParams: vi.fn(),
+  };
+});
+
+it('clears the search parameters when the "Go back to the full list" button is clicked', () => {
+  const mockSetSearchParams = vi.fn();
+  const mockUseSearchParams = useSearchParams as any;
+
+  mockUseSearchParams.mockReturnValue([
+    new URLSearchParams(),
+    mockSetSearchParams,
+  ]);
+
+  render(
+    <MemoryRouter initialEntries={['/search?filter=test']}>
+      <NoResults />
+    </MemoryRouter>,
+  );
+
+  const clearButton = screen.getByText('Go back to the full list');
+  fireEvent.click(clearButton);
+
+  expect(mockSetSearchParams).toHaveBeenCalledWith(expect.any(Function));
+
+  const setParamsFunction = mockSetSearchParams.mock.calls[0][0];
+  const newParams = setParamsFunction(new URLSearchParams());
+
+  expect(newParams).toEqual(new URLSearchParams());
+});

--- a/frontend/src/components/search/NoResults.tsx
+++ b/frontend/src/components/search/NoResults.tsx
@@ -1,21 +1,38 @@
-const NoResults = () => (
-  <div>
-    <p> Sorry, no sites or trails matched your search.</p>
-    <b>You could:</b>
-    <ul>
-      <li>Try a different search term</li>
-      <li>Check your spelling</li>
-      <li>
-        Clear your search and use the filters to help find what you’re looking
-        for
-      </li>
-      <li>Go back to the full list</li>
-    </ul>
-    <p>
-      We’re working on making our search better as we continue to develop our
-      new website - check back soon for more improvements!
-    </p>
-  </div>
-);
+import { useSearchParams } from 'react-router-dom';
+
+const NoResults = () => {
+  const [_, setSearchParams] = useSearchParams();
+
+  const handleClear = () => {
+    setSearchParams(() => new URLSearchParams());
+  };
+
+  return (
+    <div>
+      <p> Sorry, no sites or trails matched your search.</p>
+      <b>You could:</b>
+      <ul>
+        <li>Try a different search term</li>
+        <li>Check your spelling</li>
+        <li>
+          Clear your search and use the filters to help find what you’re looking
+          for
+        </li>
+        <li>
+          <button
+            className="btn-link p-0 text-decoration-underline"
+            onClick={handleClear}
+          >
+            Go back to the full list
+          </button>
+        </li>
+      </ul>
+      <p>
+        We’re working on making our search better as we continue to develop our
+        new website - check back soon for more improvements!
+      </p>
+    </div>
+  );
+};
 
 export default NoResults;


### PR DESCRIPTION
Add a `Go back to the full list` button I missed in the 'no search results' component. Initially I had just added a link back to `/search` though since it was the same page and triggered a full page load it caused some weird flashing. 

I did it the proper way and cleared the search params, making for a smoother ux.

<img width="796" alt="Screenshot 2025-04-25 at 11 42 22 AM" src="https://github.com/user-attachments/assets/5f01980f-14a9-4479-8b93-553773748fc8" />
