### PR TITLE
chore(ci): revert shared workflow update

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -13,7 +13,7 @@ jobs:
   # https://github.com/bcgov/quickstart-openshift-helpers
   schema-spy:
     name: SchemaSpy Documentation
-    uses: bcgov/quickstart-openshift-helpers/.github/workflows/.schema-spy.yml@v0.10.0
+    uses: bcgov/quickstart-openshift-helpers/.github/workflows/.schema-spy.yml@v0.9.0
     with:
       flyway_locations: migrations/rst
       schemaspy_schema: rst


### PR DESCRIPTION
The update from v0.9.0 to v0.10.0 for bcgov/quickstart-openshift-helpers was sent out in error.  It was listed as a pre-release, but still sent out by bcgov/renovate-config.  Steps are being taken to prevent this from happening again.  Please accept this PR rolling back that update.