### PR TITLE
feat(accessibility): add "Skip to main content" link for keyboard navigation

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,6 +4,8 @@ import Header from '@/components/layout/Header';
 import { BrowserRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '~/@tanstack/react-query';
 
+const MAIN_CONTENT_ID = 'main-content';
+
 const App = () => {
   const queryClient = new QueryClient({
     defaultOptions: {
@@ -16,11 +18,16 @@ const App = () => {
 
   return (
     <>
+      <a className="visually-hidden-focusable" href={`#${MAIN_CONTENT_ID}`}>
+        Skip to main content
+      </a>
       <Header />
       <main>
         <QueryClientProvider client={queryClient}>
           <BrowserRouter>
-            <AppRoutes />
+            <div id={MAIN_CONTENT_ID}>
+              <AppRoutes />
+            </div>
           </BrowserRouter>
         </QueryClientProvider>
       </main>


### PR DESCRIPTION
### Summary

Addressed an accessibility issue where keyboard users were unable to bypass repeated content (e.g., headers, navigation) to quickly reach the main content of the page. This was a failure of [WCAG 2.1 Success Criterion 2.4.1 – Bypass Blocks](https://www.w3.org/WAI/WCAG21/Understanding/bypass-blocks.html).

---

### Changes Introduced

- Added a "Skip to main content" link at the top of the page
- Styled the link to be visually hidden and only visible when focused (accessible via keyboard)
- Linked the skip link to the `#main-content` anchor on the primary content container

---

### Testing

1. Navigate to the page using only the keyboard (Tab key).
2. On page load, the first focusable element should be a "Skip to main content" link.
3. Activating the link (Enter/Return) should move focus directly to the main content.