### PR TITLE
feat(search-filters): implement dynamic filter aggregation logic

### DIFF
--- a/backend/src/recreation-resource/service/recreation-resource-search.service.ts
+++ b/backend/src/recreation-resource/service/recreation-resource-search.service.ts
@@ -1,22 +1,21 @@
 import { Injectable } from "@nestjs/common";
-import { Prisma } from "@prisma/client";
 import { PrismaService } from "src/prisma.service";
 import { buildFilterMenu } from "src/recreation-resource/utils/buildFilterMenu";
 import { buildSearchFilterQuery } from "src/recreation-resource/utils/buildSearchFilterQuery";
 import { formatSearchResults } from "src/recreation-resource/utils/formatSearchResults";
 import { PaginatedRecreationResourceDto } from "src/recreation-resource/dto/paginated-recreation-resource.dto";
 import {
-  EXCLUDED_ACTIVITY_CODES,
-  EXCLUDED_RECREATION_DISTRICTS,
-  EXCLUDED_RESOURCE_TYPES,
-} from "src/recreation-resource/constants/service.constants";
-import {
-  CombinedRecordCount,
-  CombinedStaticCount,
+  AggregatedRecordCount,
+  FilterTypes,
 } from "src/recreation-resource/service/types";
+import { buildFilterOptionCountsQuery } from "../utils/buildSearchFilterOptionCountsQuery";
+import { buildRecreationResourcePageQuery } from "../utils/buildRecreationResourcePageQuery";
 
 @Injectable()
 export class RecreationResourceSearchService {
+  private static readonly MAX_PAGE_SIZE = 10;
+  private static readonly MAX_PAGE_NUMBER = 10;
+
   constructor(private readonly prisma: PrismaService) {}
 
   async searchRecreationResources(
@@ -31,25 +30,27 @@ export class RecreationResourceSearchService {
     lat?: number,
     lon?: number,
   ): Promise<PaginatedRecreationResourceDto> {
-    // 10 page limit - max 100 records since if no limit we fetch page * limit
-    if (page > 10 && !limit) {
-      throw new Error("Maximum page limit is 10 when no limit is provided");
-    }
+    // Validate pagination parameters
+    this.validatePaginationParams(page, limit);
 
-    // 10 is the maximum limit
-    if (limit && limit > 10) {
-      limit = 10;
-    }
+    // Normalize pagination values
+    const take = this.normalizeTake(limit);
+    const skip = this.calculateSkip(page, take);
+
+    // Detect filter types
+    const filterTypes = this.getFilterTypes({
+      activities,
+      type,
+      district,
+      access,
+      facilities,
+    });
 
     if ((lat && !lon) || (lon && !lat)) {
       throw new Error("Both lat and lon must be provided");
     }
 
-    // If only page is provided, we will return all records up to the end of that page
-    // If limit is provided, we will return that many paginated records for lazy loading
-    const take = limit ? limit : 10;
-    const skip = (page - 1) * take;
-
+    // Build the where clause for filtering
     const whereClause = buildSearchFilterQuery({
       filter,
       activities,
@@ -61,99 +62,85 @@ export class RecreationResourceSearchService {
       lon,
     });
 
-    const hasLocation = typeof lat === "number" && typeof lon === "number";
+    const recreationResourcePageQuerySql = buildRecreationResourcePageQuery({
+      whereClause,
+      take,
+      skip,
+      lat,
+      lon,
+    });
 
-    // Distance is used for sorting and is only calculated if lat/lon are provided
-    const distanceSql = hasLocation
-      ? Prisma.sql`, public.ST_Distance(
-      public.ST_Transform(public.ST_SetSRID(recreation_site_point, 3005), 3005),
-      public.ST_Transform(public.ST_SetSRID(public.ST_MakePoint(${lon}, ${lat}), 4326), 3005)
-    ) as distance`
-      : Prisma.empty;
+    const filterOptionCountsQuerySql = buildFilterOptionCountsQuery(
+      whereClause,
+      filterTypes,
+    );
 
-    const orderBySql = hasLocation
-      ? Prisma.sql`order by distance asc, name asc`
-      : Prisma.sql`order by name asc`;
+    const [recreationResources, aggregatedCounts] = await Promise.all([
+      this.prisma.$queryRaw<any[]>(recreationResourcePageQuerySql),
+      this.prisma.$queryRaw<AggregatedRecordCount[]>(
+        filterOptionCountsQuerySql,
+      ),
+    ]);
 
-    const [recreationResources, combinedRecordCounts, combinedStaticCounts] =
-      await this.prisma.$transaction([
-        this.prisma.$queryRaw<any[]>`
-        select
-          rec_resource_id,
-          name,
-          closest_community,
-          display_on_public_site,
-          recreation_resource_type,
-          recreation_resource_type_code,
-          recreation_activity,
-          recreation_status,
-          recreation_resource_images,
-          district_code,
-          district_description,
-          access_code,
-          access_description,
-          recreation_structure,
-          has_toilets,
-          has_tables
-          ${distanceSql}
-        from recreation_resource_search_view
-        ${whereClause}
-        ${orderBySql}
-        limit ${take}
-        ${skip ? Prisma.sql`offset ${skip}` : Prisma.empty};`,
+    return this.formatResults(
+      recreationResources,
+      aggregatedCounts,
+      page,
+      take,
+    );
+  }
 
-        // Query filter menu content and counts that change based on search results
-        this.prisma.$queryRaw<CombinedRecordCount[]>`
-        with filtered_resources as (
-          select rec_resource_id, has_toilets, has_tables
-          from recreation_resource_search_view
-          ${whereClause}
-        ),
-        structure_counts as (
-          select
-            cast(count(case when has_toilets = true then rec_resource_id end) as int) as total_toilet_count,
-            cast(count(case when has_tables = true then rec_resource_id end) as int) as total_table_count
-          from filtered_resources
-        )
-        select
-          rac.recreation_activity_code,
-          rac.description,
-          cast(count(distinct case when fra.rec_resource_id is not null then fra.rec_resource_id end) as int) as recreation_activity_count,
-          (select total_toilet_count from structure_counts) as total_toilet_count,
-          (select total_table_count from structure_counts) as total_table_count,
-          cast((select count(*) from filtered_resources) as int) as total_count
-        from rst.recreation_activity_code rac
-          left join rst.recreation_activity ra on ra.recreation_activity_code = rac.recreation_activity_code
-          left join filtered_resources fra on fra.rec_resource_id = ra.rec_resource_id
-        where rac.recreation_activity_code not in (${Prisma.join(EXCLUDED_ACTIVITY_CODES)})
-        group by rac.recreation_activity_code, rac.description
-        order by rac.description asc;`,
+  private validatePaginationParams(page: number, limit?: number): void {
+    if (page > RecreationResourceSearchService.MAX_PAGE_NUMBER && !limit) {
+      throw new Error(
+        `Maximum page limit is ${RecreationResourceSearchService.MAX_PAGE_NUMBER} when no limit is provided`,
+      );
+    }
+  }
 
-        // Query filter menu content and counts that remain static
-        this.prisma.$queryRaw<CombinedStaticCount[]>`
-          (select 'district' as type, district_code as code, description, cast(resource_count as integer) as count
-          from recreation_resource_district_count_view
-          where district_code not in (${Prisma.join(EXCLUDED_RECREATION_DISTRICTS)}))
-        union all
-      (select 'access' as type, access_code as code, access_description as description, cast(count as integer) as count
-          from recreation_resource_access_count_view
-          where access_code not in (${Prisma.join(EXCLUDED_RESOURCE_TYPES)}))
-        union all
-      (select 'type' as type, rec_resource_type_code as code, description, cast(count as integer) as count
-          from recreation_resource_type_count_view
-          where rec_resource_type_code not in (${Prisma.join(EXCLUDED_RESOURCE_TYPES)}))
-        order by description asc; `,
-      ]);
+  private normalizeTake(limit?: number): number {
+    if (!limit || limit > RecreationResourceSearchService.MAX_PAGE_SIZE) {
+      return RecreationResourceSearchService.MAX_PAGE_SIZE;
+    }
+    return limit;
+  }
 
+  private calculateSkip(page: number, take: number): number {
+    return (page - 1) * take;
+  }
+
+  private formatResults(
+    recreationResources: any[],
+    aggregatedRecordCounts: AggregatedRecordCount[],
+    page: number,
+    limit?: number,
+  ): PaginatedRecreationResourceDto {
     return {
       data: formatSearchResults(recreationResources),
       page,
       limit,
-      total: combinedRecordCounts?.[0]?.total_count ?? 0,
-      filters: buildFilterMenu({
-        combinedRecordCounts,
-        combinedStaticCounts,
-      }),
+      total: recreationResources?.[0]?.total_count ?? 0,
+      filters: buildFilterMenu(aggregatedRecordCounts),
+    };
+  }
+
+  private getFilterTypes(params: {
+    activities?: string;
+    type?: string;
+    district?: string;
+    access?: string;
+    facilities?: string;
+  }): FilterTypes {
+    const { activities, type, district, access, facilities } = params;
+    const hasNoOtherFilters = !activities && !facilities;
+
+    return {
+      isOnlyAccessFilter:
+        Boolean(access) && !type && !district && hasNoOtherFilters,
+      isOnlyDistrictFilter:
+        Boolean(district) && !type && !access && hasNoOtherFilters,
+      isOnlyTypeFilter:
+        Boolean(type) && !district && !access && hasNoOtherFilters,
     };
   }
 }

--- a/backend/src/recreation-resource/service/types.ts
+++ b/backend/src/recreation-resource/service/types.ts
@@ -6,17 +6,14 @@ export type RecreationResourceGetPayload =
     select: ReturnType<typeof getRecreationResourceSelect>;
   }>;
 
-export interface CombinedRecordCount {
-  recreation_activity_code: number;
-  description: string;
-  recreation_activity_count: number;
-  total_toilet_count: number;
-  total_table_count: number;
-  total_count: number;
+export interface FilterTypes {
+  isOnlyAccessFilter: boolean;
+  isOnlyDistrictFilter: boolean;
+  isOnlyTypeFilter: boolean;
 }
 
-export interface CombinedStaticCount {
-  type: "district" | "access" | "type";
+export interface AggregatedRecordCount {
+  type: "district" | "access" | "type" | "facilities" | "activity";
   code: string;
   description: string;
   count: number;

--- a/backend/src/recreation-resource/utils/buildFilterMenu.spec.ts
+++ b/backend/src/recreation-resource/utils/buildFilterMenu.spec.ts
@@ -1,113 +1,107 @@
-import { buildFilterMenu } from "src/recreation-resource/utils/buildFilterMenu";
-import { FilterDto } from "src/recreation-resource/dto/paginated-recreation-resource.dto";
-import {
-  CombinedRecordCount,
-  CombinedStaticCount,
-} from "src/recreation-resource/service/types";
+import { buildFilterMenu } from "./buildFilterMenu";
+import { FilterDto } from "../dto/paginated-recreation-resource.dto";
+import { AggregatedRecordCount } from "../service/types";
 
 describe("buildFilterMenu", () => {
-  it("generates correct filter menu with valid data", () => {
-    const combinedRecordCounts: CombinedRecordCount[] = [
-      {
-        recreation_activity_code: 1,
-        description: "Hiking",
-        recreation_activity_count: 12,
-        total_toilet_count: 5,
-        total_table_count: 8,
-        total_count: 20,
-      },
-    ];
+  const mockAggregatedCounts: AggregatedRecordCount[] = [
+    { type: "district", code: "D1", description: "District A", count: 10 },
+    { type: "type", code: "T1", description: "Park", count: 15 },
+    { type: "activity", code: "A1", description: "Hiking", count: 12 },
+    { type: "facilities", code: "table", description: "Tables", count: 8 },
+    { type: "facilities", code: "toilet", description: "Toilets", count: 5 },
+    { type: "access", code: "ACC1", description: "Wheelchair", count: 4 },
+  ];
 
-    const combinedStaticCounts: CombinedStaticCount[] = [
-      { type: "district", code: "1", description: "District A", count: 10 },
-      { type: "access", code: "1", description: "Wheelchair", count: 4 },
-      { type: "type", code: "1", description: "Park", count: 15 },
-    ];
+  describe("when provided with complete data", () => {
+    it("should generate a complete filter menu with all categories", () => {
+      const result = buildFilterMenu(mockAggregatedCounts);
 
-    const result = buildFilterMenu({
-      combinedRecordCounts,
-      combinedStaticCounts,
+      const expectedFilters: FilterDto[] = [
+        {
+          type: "multi-select",
+          label: "District",
+          param: "district",
+          options: [{ id: "D1", description: "District A", count: 10 }],
+        },
+        {
+          type: "multi-select",
+          label: "Type",
+          param: "type",
+          options: [{ id: "T1", description: "Park", count: 15 }],
+        },
+        {
+          type: "multi-select",
+          label: "Things to do",
+          param: "activities",
+          options: [{ id: "A1", description: "Hiking", count: 12 }],
+        },
+        {
+          type: "multi-select",
+          label: "Facilities",
+          param: "facilities",
+          options: [
+            { id: "table", description: "Tables", count: 8 },
+            { id: "toilet", description: "Toilets", count: 5 },
+          ],
+        },
+        {
+          type: "multi-select",
+          label: "Access type",
+          param: "access",
+          options: [{ id: "ACC1", description: "Wheelchair access", count: 4 }],
+        },
+      ];
+
+      expect(result).toEqual(expectedFilters);
     });
-
-    expect(result).toEqual<FilterDto[]>([
-      {
-        type: "multi-select",
-        label: "District",
-        param: "district",
-        options: [{ id: "1", description: "District A", count: 10 }],
-      },
-      {
-        type: "multi-select",
-        label: "Type",
-        param: "type",
-        options: [{ id: "1", description: "Park", count: 15 }],
-      },
-      {
-        type: "multi-select",
-        label: "Things to do",
-        param: "activities",
-        options: [{ id: "1", description: "Hiking", count: 12 }],
-      },
-      {
-        type: "multi-select",
-        label: "Facilities",
-        param: "facilities",
-        options: [
-          { id: "table", description: "Tables", count: 8 },
-          { id: "toilet", description: "Toilets", count: 5 },
-        ],
-      },
-      {
-        type: "multi-select",
-        label: "Access type",
-        param: "access",
-        options: [{ id: "1", description: "Wheelchair access", count: 4 }],
-      },
-    ]);
   });
 
-  it("returns correct counts when only combinedRecordCounts are provided", () => {
-    const combinedRecordCounts: CombinedRecordCount[] = [
-      {
-        recreation_activity_code: 202,
-        description: "Biking",
-        recreation_activity_count: 7,
-        total_toilet_count: 3,
-        total_table_count: 6,
-        total_count: 15,
-      },
-    ];
-    const combinedStaticCounts: CombinedStaticCount[] = [];
+  describe("when provided with partial data", () => {
+    it("should handle missing categories", () => {
+      const partialData: AggregatedRecordCount[] = [
+        { type: "activity", code: "A1", description: "Hiking", count: 12 },
+        { type: "facilities", code: "table", description: "Tables", count: 8 },
+      ];
 
-    const result = buildFilterMenu({
-      combinedRecordCounts,
-      combinedStaticCounts,
+      const result = buildFilterMenu(partialData);
+
+      expect(result).toHaveLength(5); // Should still return all filter categories
+      expect(result[0].options).toHaveLength(0); // Empty district
+      expect(result[1].options).toHaveLength(0); // Empty type
+      expect(result[2].options).toHaveLength(1); // Activities
+      expect(result[3].options).toHaveLength(2); // Facilities (always shows both - tables and toilets)
+      expect(result[4].options).toHaveLength(0); // Empty access
     });
 
-    expect(result[2].options).toEqual([
-      { id: "202", description: "Biking", count: 7 },
-    ]);
-    expect(result[3].options).toEqual([
-      { id: "table", description: "Tables", count: 6 },
-      { id: "toilet", description: "Toilets", count: 3 },
-    ]);
-  });
+    it("should handle empty input", () => {
+      const result = buildFilterMenu([]);
 
-  it("returns reversed order for type filters", () => {
-    const combinedRecordCounts: CombinedRecordCount[] = [];
-    const combinedStaticCounts: CombinedStaticCount[] = [
-      { type: "type", code: "1", description: "Park", count: 15 },
-      { type: "type", code: "2", description: "Campground", count: 8 },
-    ];
-
-    const result = buildFilterMenu({
-      combinedRecordCounts,
-      combinedStaticCounts,
+      expect(result).toHaveLength(5);
+      result.forEach((filter) => {
+        if (filter.param === "facilities") {
+          expect(filter.options).toEqual([
+            { id: "table", description: "Tables", count: 0 },
+            { id: "toilet", description: "Toilets", count: 0 },
+          ]);
+        } else {
+          expect(filter.options).toHaveLength(0);
+        }
+      });
     });
 
-    expect(result[1].options).toEqual([
-      { id: "2", description: "Campground", count: 8 },
-      { id: "1", description: "Park", count: 15 },
-    ]);
+    it("should properly transform access descriptions", () => {
+      const accessData: AggregatedRecordCount[] = [
+        { type: "access", code: "ACC1", description: "Wheelchair", count: 4 },
+        { type: "access", code: "ACC2", description: "Vehicle", count: 6 },
+      ];
+
+      const result = buildFilterMenu(accessData);
+      const accessFilter = result.find((f) => f.param === "access");
+
+      expect(accessFilter?.options).toEqual([
+        { id: "ACC1", description: "Wheelchair access", count: 4 },
+        { id: "ACC2", description: "Vehicle access", count: 6 },
+      ]);
+    });
   });
 });

--- a/backend/src/recreation-resource/utils/buildRecreationResourcePageQuery.spec.ts
+++ b/backend/src/recreation-resource/utils/buildRecreationResourcePageQuery.spec.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import { Prisma } from "@prisma/client";
+import { buildRecreationResourcePageQuery } from "./buildRecreationResourcePageQuery";
+
+const type = "park";
+const baseWhereClause = Prisma.sql`where type = ${type}`;
+
+describe("buildRecreationResourcePageQuery", () => {
+  describe("without valid location parameters", () => {
+    it("builds a basic paginated query", () => {
+      const take = 10;
+      const skip = 20;
+      const query = buildRecreationResourcePageQuery({
+        whereClause: baseWhereClause,
+        take,
+        skip,
+      });
+      const queryStr = query.sql;
+
+      expect(queryStr).toContain("select rec_resource_id");
+      expect(queryStr).toContain("from recreation_resource_search_view");
+      expect(queryStr).toContain("where type =");
+      expect(queryStr).toContain("order by name asc");
+      expect(queryStr).toContain("limit");
+      expect(queryStr).toContain("offset");
+      expect(queryStr).not.toContain("ST_Distance");
+
+      expect(query.values).toEqual([type, take, skip]);
+    });
+
+    it("ignores incomplete location parameters", () => {
+      const take = 10;
+      const skip = 0;
+      const lat = 49.2827; // Missing lon
+      const query = buildRecreationResourcePageQuery({
+        whereClause: baseWhereClause,
+        take,
+        skip,
+        lat,
+      });
+      const queryStr = query.sql;
+
+      expect(queryStr).not.toContain("ST_Distance");
+      expect(queryStr).toContain("order by name asc");
+      expect(query.values).toEqual([type, take, skip]);
+    });
+  });
+
+  describe("with valid location parameters", () => {
+    it("builds a query with location parameters", () => {
+      const take = 10;
+      const skip = 0;
+      const lat = 49.2827;
+      const lon = -123.1207;
+      const query = buildRecreationResourcePageQuery({
+        whereClause: baseWhereClause,
+        take,
+        skip,
+        lat,
+        lon,
+      });
+      const queryStr = query.sql;
+
+      expect(queryStr).toContain("ST_Distance");
+      expect(queryStr).toContain("ST_MakePoint");
+      expect(queryStr).toContain("as distance");
+      expect(queryStr).toContain("order by distance asc, name asc");
+
+      expect(query.values).toEqual([lon, lat, type, take, skip]);
+    });
+  });
+});

--- a/backend/src/recreation-resource/utils/buildRecreationResourcePageQuery.ts
+++ b/backend/src/recreation-resource/utils/buildRecreationResourcePageQuery.ts
@@ -1,0 +1,55 @@
+import { Prisma } from "@prisma/client";
+
+interface RecreationResourcePageQueryParams {
+  whereClause: Prisma.Sql;
+  take: number;
+  skip: number;
+  lat?: number;
+  lon?: number;
+}
+
+export function buildRecreationResourcePageQuery({
+  whereClause,
+  take,
+  skip,
+  lat,
+  lon,
+}: RecreationResourcePageQueryParams): Prisma.Sql {
+  const hasLocation = typeof lat === "number" && typeof lon === "number";
+
+  // Distance is used for sorting and is only calculated if lat/lon are provided
+  const distanceSql = hasLocation
+    ? Prisma.sql`, public.ST_Distance(
+      public.ST_Transform(public.ST_SetSRID(recreation_site_point, 3005), 3005),
+      public.ST_Transform(public.ST_SetSRID(public.ST_MakePoint(${lon}, ${lat}), 4326), 3005)
+    ) as distance`
+    : Prisma.empty;
+
+  const orderBySql = hasLocation
+    ? Prisma.sql`order by distance asc, name asc`
+    : Prisma.sql`order by name asc`;
+
+  return Prisma.sql`
+    select rec_resource_id,
+           name,
+           closest_community,
+           display_on_public_site,
+           recreation_resource_type,
+           recreation_resource_type_code,
+           recreation_activity,
+           recreation_status,
+           recreation_resource_images,
+           district_code,
+           district_description,
+           access_code,
+           access_description,
+           recreation_structure,
+           has_toilets,
+           has_tables,
+           count(*) over()::int AS total_count
+           ${distanceSql}
+    from recreation_resource_search_view ${whereClause} ${orderBySql}
+    limit ${take}
+    offset ${skip};
+  `;
+}

--- a/backend/src/recreation-resource/utils/buildSearchFilterOptionCountsQuery.spec.ts
+++ b/backend/src/recreation-resource/utils/buildSearchFilterOptionCountsQuery.spec.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { Prisma } from "@prisma/client";
+import { EXCLUDED_ACTIVITY_CODES } from "../constants/service.constants";
+import { buildFilterOptionCountsQuery } from "./buildSearchFilterOptionCountsQuery";
+
+describe("buildFilterOptionCountsQuery", () => {
+  it("should build a SQL query with a where clause and no filter flags", () => {
+    const whereClause = Prisma.sql`WHERE district_code = ${"D1"}`;
+    const query = buildFilterOptionCountsQuery(whereClause);
+
+    // Verify SQL structure
+    const queryStr = query.sql;
+    expect(queryStr).toContain("WITH filtered_resources AS");
+    expect(queryStr).toContain("FROM recreation_resource_search_view");
+    expect(queryStr).toContain("UNION ALL");
+
+    // Verify placeholders and parameter values
+    expect(query.values).toContain("D1");
+
+    // Ensure excluded activity codes are included
+    EXCLUDED_ACTIVITY_CODES.forEach((code) => {
+      expect(query.values).toContain(code);
+    });
+  });
+
+  it("should conditionally apply filter flags in CASE statements", () => {
+    const whereClause = Prisma.sql`WHERE access_code = ${"AC1"}`;
+    const filterTypes = {
+      isOnlyDistrictFilter: true,
+      isOnlyAccessFilter: true,
+      isOnlyTypeFilter: true,
+    };
+
+    const query = buildFilterOptionCountsQuery(whereClause, filterTypes);
+    const queryStr = query.sql;
+
+    expect(queryStr).toContain(
+      "WHEN ? THEN (SELECT COUNT(*) FROM recreation_resource_search_view WHERE district_code = dcv.district_code)::INT",
+    );
+    expect(queryStr).toContain(
+      "WHEN ? THEN (SELECT COUNT(*) FROM recreation_resource_search_view WHERE access_code = acv.access_code)::INT",
+    );
+    expect(queryStr).toContain(
+      "WHEN ? THEN (SELECT COUNT(*) FROM recreation_resource_search_view WHERE recreation_resource_type_code = acv.rec_resource_type_code)::INT",
+    );
+
+    expect(query.values).toContain("AC1");
+  });
+
+  it("should handle empty where clause", () => {
+    const query = buildFilterOptionCountsQuery(Prisma.empty);
+
+    expect(query.sql).toContain("FROM recreation_resource_search_view");
+
+    const filteredBlock =
+      query.sql.match(/WITH filtered_resources AS /)?.[0] || "";
+    expect(filteredBlock).not.toContain("WHERE district_code =");
+  });
+});

--- a/backend/src/recreation-resource/utils/buildSearchFilterOptionCountsQuery.ts
+++ b/backend/src/recreation-resource/utils/buildSearchFilterOptionCountsQuery.ts
@@ -1,0 +1,124 @@
+import { Prisma } from "@prisma/client";
+import { FilterTypes } from "../service/types";
+import { EXCLUDED_ACTIVITY_CODES } from "../constants/service.constants";
+
+export function buildFilterOptionCountsQuery(
+  whereClause: Prisma.Sql,
+  filterTypes?: FilterTypes,
+): Prisma.Sql {
+  return Prisma.sql`
+  WITH filtered_resources AS (
+    SELECT
+      rec_resource_id,
+      district_code,
+      access_code,
+      recreation_resource_type_code,
+      has_toilets,
+      has_tables
+    FROM recreation_resource_search_view
+    ${whereClause}
+  ),
+  activity_counts AS (
+    SELECT
+      rac.recreation_activity_code,
+      rac.description,
+      COUNT(DISTINCT fr.rec_resource_id)::INT AS recreation_activity_count
+    FROM rst.recreation_activity_code rac
+    LEFT JOIN rst.recreation_activity ra ON rac.recreation_activity_code = ra.recreation_activity_code
+    LEFT JOIN filtered_resources fr ON fr.rec_resource_id = ra.rec_resource_id
+    WHERE rac.recreation_activity_code NOT IN (${Prisma.join(EXCLUDED_ACTIVITY_CODES)})
+    GROUP BY rac.recreation_activity_code, rac.description
+    ORDER BY rac.description ASC
+  ),
+  district_counts AS (
+    SELECT
+      dcv.district_code AS code,
+      MAX(dcv.description) AS description,
+      CASE
+        WHEN ${
+          filterTypes?.isOnlyDistrictFilter ?? false
+        } THEN (SELECT COUNT(*) FROM recreation_resource_search_view WHERE district_code = dcv.district_code)::INT
+        ELSE COUNT(fr.district_code)::INT
+      END AS count
+    FROM recreation_resource_district_count_view dcv
+    LEFT JOIN filtered_resources fr ON fr.district_code = dcv.district_code
+    WHERE dcv.district_code != 'NULL'
+    GROUP BY dcv.district_code, dcv.description
+    ORDER BY dcv.description ASC
+  ),
+  access_counts AS (
+    SELECT
+      acv.access_code AS code,
+      acv.access_description AS description,
+      CASE
+        WHEN ${
+          filterTypes?.isOnlyAccessFilter ?? false
+        } THEN (SELECT COUNT(*) FROM recreation_resource_search_view WHERE access_code = acv.access_code)::INT
+        ELSE COUNT(fr.access_code)::INT
+      END AS count
+    FROM recreation_resource_access_count_view acv
+    LEFT JOIN filtered_resources fr ON fr.access_code = acv.access_code
+    WHERE acv.access_code != 'NULL'
+    GROUP BY acv.access_code, acv.access_description
+    ORDER BY acv.access_description ASC
+  ),
+  type_counts AS (
+    SELECT
+      acv.rec_resource_type_code AS code,
+      MAX(acv.description) AS description,
+      CASE
+        WHEN ${
+          filterTypes?.isOnlyTypeFilter ?? false
+        } THEN (SELECT COUNT(*) FROM recreation_resource_search_view WHERE recreation_resource_type_code = acv.rec_resource_type_code)::INT
+        ELSE COUNT(fr.recreation_resource_type_code)::INT
+      END AS count
+    FROM recreation_resource_type_count_view acv
+    LEFT JOIN filtered_resources fr ON fr.recreation_resource_type_code = acv.rec_resource_type_code
+    GROUP BY acv.rec_resource_type_code, acv.description
+    ORDER BY acv.rec_resource_type_code DESC
+  ),
+  facility_counts AS (
+    SELECT
+      COUNT(CASE WHEN has_toilets THEN 1 END)::INT AS total_toilet_count,
+      COUNT(CASE WHEN has_tables THEN 1 END)::INT AS total_table_count,
+      COUNT(*)::INT AS total_count
+    FROM filtered_resources
+  )
+  SELECT
+    'activity' AS type,
+    ac.recreation_activity_code::TEXT AS code,
+    ac.description,
+    ac.recreation_activity_count AS count
+  FROM activity_counts ac
+
+  UNION ALL
+
+  SELECT
+    'district', dc.code, dc.description, dc.count
+  FROM district_counts dc
+
+  UNION ALL
+
+  SELECT
+    'access', ac.code, ac.description, ac.count
+  FROM access_counts ac
+
+  UNION ALL
+
+  SELECT
+    'type', tc.code, tc.description, tc.count
+  FROM type_counts tc
+
+  UNION ALL
+
+  SELECT
+    'facilities', 'toilet', 'Toilets', fc.total_toilet_count
+  FROM facility_counts fc
+
+  UNION ALL
+
+  SELECT
+    'facilities', 'table', 'Tables', fc.total_table_count
+  FROM facility_counts fc
+`;
+}

--- a/backend/src/recreation-resource/utils/buildSearchFilterQuery.spec.ts
+++ b/backend/src/recreation-resource/utils/buildSearchFilterQuery.spec.ts
@@ -1,18 +1,8 @@
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 import { buildSearchFilterQuery } from "src/recreation-resource/utils/buildSearchFilterQuery";
+import { Prisma } from "@prisma/client";
 
-const filterString = "where (name ilike ? or closest_community ilike ?)";
-const accessString = "and access_code in (?,?)";
-const districtString = "and district_code in (?,?)";
-const typeString = "and recreation_resource_type_code in (?,?)";
-const activityString =
-  "where (activity->>'recreation_activity_code')::bigint in (?,?)";
-const facilityString =
-  "select count(*) from jsonb_array_elements(recreation_structure) AS facility where ( (facility->>'description') ilike ? or (facility->>'description') ilike ? ) ";
-const locationString =
-  "where (name ilike ? or closest_community ilike ?) AND public.ST_DWithin( public.ST_Transform(public.ST_SetSRID(recreation_site_point, 3005), 3005), public.ST_Transform(public.ST_SetSRID(public.ST_MakePoint(?, ?), 4326), 3005), ? )";
-
-export const getQueryString = (query) => {
+const getQueryString = (query: Prisma.Sql) => {
   return query.sql.replace(/\s+/g, " ").trim();
 };
 
@@ -20,31 +10,40 @@ describe("buildSearchFilterQuery", () => {
   it("should generate query with no filters", () => {
     const result = buildSearchFilterQuery({ filter: "" });
     const queryString = getQueryString(result);
-    expect(queryString).toBe(filterString);
+    expect(queryString).toBe(
+      "where (name ilike ? or closest_community ilike ?)",
+    );
+    expect(result.values).toEqual(["%%", "%%"]);
   });
 
   it("should generate query with basic text filter", () => {
     const result = buildSearchFilterQuery({ filter: "park" });
     const queryString = getQueryString(result);
-    expect(queryString).toBe(filterString);
+    expect(queryString).toBe(
+      "where (name ilike ? or closest_community ilike ?)",
+    );
+    expect(result.values).toEqual(["%park%", "%park%"]);
   });
 
   it("should add access filter correctly", () => {
     const result = buildSearchFilterQuery({ filter: "", access: "A1_A2" });
     const queryString = getQueryString(result);
-    expect(queryString).toContain(accessString);
+    expect(queryString).toContain("and access_code in (?,?)");
+    expect(result.values.slice(2)).toEqual(["A1", "A2"]);
   });
 
   it("should add district filter correctly", () => {
     const result = buildSearchFilterQuery({ filter: "", district: "D1_D2" });
     const queryString = getQueryString(result);
-    expect(queryString).toContain(districtString);
+    expect(queryString).toContain("and district_code in (?,?)");
+    expect(result.values.slice(2)).toEqual(["D1", "D2"]);
   });
 
   it("should add type filter correctly", () => {
     const result = buildSearchFilterQuery({ filter: "", type: "T1_T2" });
     const queryString = getQueryString(result);
-    expect(queryString).toContain(typeString);
+    expect(queryString).toContain("and recreation_resource_type_code in (?,?)");
+    expect(result.values.slice(2)).toEqual(["T1", "T2"]);
   });
 
   it("should add activity filter correctly", () => {
@@ -53,32 +52,22 @@ describe("buildSearchFilterQuery", () => {
       activities: "101_102",
     });
     const queryString = getQueryString(result);
-
-    expect(queryString).toContain(activityString);
+    expect(queryString).toContain(
+      "and ( select count(*) from jsonb_array_elements(recreation_activity) AS activity where (activity->>'recreation_activity_code')::bigint in (?,?) ) = ?",
+    );
+    expect(result.values.slice(2)).toEqual([101, 102, 2]);
   });
 
   it("should add facility filter correctly", () => {
-    const result = buildSearchFilterQuery({
-      filter: "",
-      facilities: "F1_F2",
-    });
+    const result = buildSearchFilterQuery({ filter: "", facilities: "F1_F2" });
     const queryString = getQueryString(result);
-
-    expect(queryString).toContain(facilityString);
+    expect(queryString).toContain(
+      "AND ( SELECT COUNT(*) FROM ( SELECT rec_resource_id FROM jsonb_array_elements(recreation_structure) AS facility GROUP BY rec_resource_id HAVING COUNT(*) FILTER ( WHERE facility->>'description' ILIKE ? ) > 0 AND COUNT(*) FILTER ( WHERE facility->>'description' ILIKE ? ) > 0 ) AS filtered_resources ) > 0",
+    );
+    expect(result.values.slice(2)).toEqual(["%F1%", "%F2%"]);
   });
 
-  it("should add location filter correctly", () => {
-    const result = buildSearchFilterQuery({
-      filter: "",
-      lat: 1,
-      lon: 2,
-    });
-    const queryString = getQueryString(result);
-
-    expect(queryString).toContain(locationString);
-  });
-
-  it("should handle all filters", () => {
+  it("should handle all filters combined", () => {
     const result = buildSearchFilterQuery({
       filter: "park",
       activities: "101_102",
@@ -87,13 +76,43 @@ describe("buildSearchFilterQuery", () => {
       access: "A1_A2",
       facilities: "F1_F2",
     });
-    const queryString = getQueryString(result);
 
-    expect(queryString).toContain(filterString);
-    expect(queryString).toContain(accessString);
-    expect(queryString).toContain(districtString);
-    expect(queryString).toContain(typeString);
-    expect(queryString).toContain(activityString);
-    expect(queryString).toContain(facilityString);
+    const queryString = getQueryString(result);
+    expect(queryString).toContain(
+      "where (name ilike ? or closest_community ilike ?)",
+    );
+    expect(queryString).toContain("and access_code in");
+    expect(queryString).toContain("and district_code in");
+    expect(queryString).toContain("and recreation_resource_type_code in");
+    expect(queryString).toContain(
+      "from jsonb_array_elements(recreation_activity)",
+    );
+    expect(queryString).toContain("jsonb_array_elements(recreation_structure)");
+
+    const expectedValues = [
+      "%park%",
+      "%park%",
+      "A1",
+      "A2",
+      "D1",
+      "D2",
+      "T1",
+      "T2",
+      101,
+      102,
+      2,
+      "%F1%",
+      "%F2%",
+    ];
+    expect(result.values).toEqual(expectedValues);
+  });
+
+  it("should add location filter correctly", () => {
+    const lat = 49.2;
+    const lon = -123.1;
+    const result = buildSearchFilterQuery({ filter: "", lat, lon });
+    const queryString = getQueryString(result);
+    expect(queryString).toContain("ST_DWithin");
+    expect(result.values).toEqual(["%%", "%%", lon, lat, 50000]);
   });
 });

--- a/frontend/e2e/workflows/search/filterChips.spec.ts
+++ b/frontend/e2e/workflows/search/filterChips.spec.ts
@@ -1,6 +1,6 @@
 import { test } from '@playwright/test';
 import { initHappo } from 'e2e/utils';
-import { FilterPOM, FilterChipsPOM, SearchPOM, UtilsPOM } from 'e2e/poms';
+import { FilterChipsPOM, FilterPOM, SearchPOM, UtilsPOM } from 'e2e/poms';
 
 initHappo();
 
@@ -92,6 +92,8 @@ test.describe('Filter chip workflows', () => {
     const filterChips = new FilterChipsPOM(page);
     const searchPage = new SearchPOM(page);
 
+    const ACCESS_TYPE = 'Boat-in access';
+
     await searchPage.route();
 
     await filter.verifyInitialFilterMenu();
@@ -104,9 +106,9 @@ test.describe('Filter chip workflows', () => {
 
     await filterChips.verifyFilterChips(['Recreation Trail']);
 
-    await filter.toggleFilterOn(filter.accessTypeFilters, 'Road Access');
+    await filter.toggleFilterOn(filter.accessTypeFilters, ACCESS_TYPE);
 
-    await filterChips.verifyFilterChips(['Road Access']);
+    await filterChips.verifyFilterChips([ACCESS_TYPE]);
 
     await filter.checkIsFilterToggledOn(
       filter.districtFilters,
@@ -115,16 +117,13 @@ test.describe('Filter chip workflows', () => {
 
     await filter.checkIsFilterToggledOn(filter.typeFilters, 'Recreation Trail');
 
-    await filter.checkIsFilterToggledOn(
-      filter.accessTypeFilters,
-      'Road Access',
-    );
+    await filter.checkIsFilterToggledOn(filter.accessTypeFilters, ACCESS_TYPE);
 
     await filter.toggleFilterOff(filter.districtFilters, '100 Mile-Chilcotin');
 
     await filter.toggleFilterOff(filter.typeFilters, 'Recreation Trail');
 
-    await filter.toggleFilterOff(filter.accessTypeFilters, 'Road Access');
+    await filter.toggleFilterOff(filter.accessTypeFilters, ACCESS_TYPE);
 
     await filter.checkIsFilterToggledOff(
       filter.districtFilters,
@@ -136,10 +135,7 @@ test.describe('Filter chip workflows', () => {
       'Recreation Trail',
     );
 
-    await filter.checkIsFilterToggledOff(
-      filter.accessTypeFilters,
-      'Road Access',
-    );
+    await filter.checkIsFilterToggledOff(filter.accessTypeFilters, ACCESS_TYPE);
 
     await filterChips.verifyFilterChips([]);
   });

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,7 @@
     "deploy": "npm ci --ignore-scripts --no-update-notifier --omit=dev && npm run build",
     "dev": "vite --host",
     "e2e": "npx happo-e2e -- npx playwright test",
+    "e2e:chrome": "npx happo-e2e -- npx playwright test --project=chromium",
     "e2e:ui": "npx happo-e2e -- npx playwright test --ui",
     "preview": "vite preview",
     "test": "vitest --mode test",

--- a/frontend/src/components/search/filters/FilterGroup.test.tsx
+++ b/frontend/src/components/search/filters/FilterGroup.test.tsx
@@ -1,6 +1,8 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import FilterGroup from '@/components/search/filters/FilterGroup';
 import { activitiesOptions } from '@/components/search/test/mock-data';
+import { describe, expect, it, Mock, vi } from 'vitest';
+import { useSearchParams } from 'react-router-dom';
 
 vi.mock('react-router-dom', async () => {
   return {
@@ -155,6 +157,37 @@ describe('the FilterGroup component', () => {
     checkbox.click();
     checkbox.click();
     expect(checkbox).not.toBeChecked();
+  });
+
+  it('should have checkbox checked and enabled when defaultChecked is true and count is 0', () => {
+    const testOptions = [
+      { id: 22, count: 0, description: 'Snowmobiling', hasFocus: false },
+      { id: 2, count: 14, description: 'Angling', hasFocus: false },
+    ];
+
+    (useSearchParams as Mock).mockReturnValue([
+      new URLSearchParams({ activities: '22' }), // Snowmobiling
+      vi.fn(),
+    ]);
+
+    render(
+      <FilterGroup
+        label="Activities"
+        options={testOptions}
+        param="activities"
+      />,
+    );
+
+    const snowmobilingCheckbox = screen.getByLabelText('Snowmobiling (0)');
+    const anglingCheckbox = screen.getByLabelText('Angling (14)');
+
+    // Checkbox with ID 22 (Snowmobiling) should be checked and enabled because it's in the URL params
+    expect(snowmobilingCheckbox).toBeChecked();
+    expect(snowmobilingCheckbox).toBeEnabled();
+
+    // Checkbox with ID 2 (Angling) should not be checked, but enabled because count > 0
+    expect(anglingCheckbox).not.toBeChecked();
+    expect(anglingCheckbox).toBeEnabled();
   });
 
   it('should update aria-label when toggling show all / show less', () => {

--- a/frontend/src/components/search/filters/FilterGroup.tsx
+++ b/frontend/src/components/search/filters/FilterGroup.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { Form } from 'react-bootstrap';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faChevronUp, faChevronDown } from '@fortawesome/free-solid-svg-icons';
+import { faChevronDown, faChevronUp } from '@fortawesome/free-solid-svg-icons';
 import { useFilterHandler } from '@/components/search/hooks/useFilterHandler';
 import { Filter } from '@/components/search/types';
 import '@/components/search/filters/Filters.scss';
@@ -65,7 +65,12 @@ const FilterGroup = ({
         {optionList?.map((option) => {
           const { count, description, id, hasFocus } = option;
           const isDefaultChecked = filterParamsArray?.includes(String(id));
-          const isDisabled = count === 0;
+
+          /*
+           * Disable checkbox only when it's unchecked and count is 0.
+           * This ensures the checkbox can be unchecked when count is 0
+           */
+          const isDisabled = !isDefaultChecked && count === 0;
 
           return (
             <Form.Check

--- a/frontend/src/components/search/filters/FilterMenu.test.tsx
+++ b/frontend/src/components/search/filters/FilterMenu.test.tsx
@@ -2,6 +2,15 @@ import { render, screen } from '@testing-library/react';
 import FilterMenu from '@/components/search/filters/FilterMenu';
 import searchResultsStore from '@/store/searchResults';
 import { mockFilterMenuContent } from '@/components/search/test/mock-data';
+import { describe, it, vi } from 'vitest';
+
+vi.mock('react-router-dom', async () => {
+  const actual = (await vi.importActual('react-router-dom')) as any;
+  return {
+    ...actual,
+    useSearchParams: vi.fn().mockReturnValue([new URLSearchParams()]),
+  };
+});
 
 Object.defineProperty(searchResultsStore, 'state', {
   get: vi.fn(() => ({
@@ -12,13 +21,6 @@ Object.defineProperty(searchResultsStore, 'state', {
 
 describe('FilterMenu', () => {
   it('renders FilterMenu component', () => {
-    vi.mock('react-router-dom', async () => {
-      const actual = (await vi.importActual('react-router-dom')) as any;
-      return {
-        ...actual,
-        useSearchParams: vi.fn().mockReturnValue([new URLSearchParams()]),
-      };
-    });
     render(<FilterMenu />);
 
     // Renders titles


### PR DESCRIPTION
**Implemented Dynamic Filter Counts**

Here's how filters work:

**Starting View**
When you first view the list, each filter displays the total number of items in its **category**. Categories include **district**, **type**, **access**, **activities**, and **facilities**.

**Using Multiple Filters**

- When you select filters from **different categories** (like "North District" and "Hiking"), you'll see only items that match **all** your selections. The filter counts across all categories will reflect the **narrowed-down count** of possible results.
- When you select **multiple options in the same category** (like "Hiking" and "Camping") and if that category is either district, access, or type, you'll see items that match **any** of those options. The filter counts for each option *within this single, active category* remain unchanged, showing the total count from the *initial* state since the **"OR" logic** broadens the possible results within that category.