### PR TITLE
chore: bread crumb search page link has search history

### DIFF
--- a/frontend/src/components/layout/BreadCrumbs.test.tsx
+++ b/frontend/src/components/layout/BreadCrumbs.test.tsx
@@ -17,7 +17,7 @@ describe('BreadCrumbs', () => {
       </MemoryRouter>,
     );
 
-    expect(screen.getByAltText('Home')).toBeInTheDocument();
+    expect(screen.getByAltText('Home icon')).toBeInTheDocument();
     expect(screen.getAllByAltText('chevron icon')).toHaveLength(2);
     expect(screen.getByText('Find a site or trail')).toHaveAttribute(
       'href',

--- a/frontend/src/components/layout/BreadCrumbs.test.tsx
+++ b/frontend/src/components/layout/BreadCrumbs.test.tsx
@@ -1,0 +1,46 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import BreadCrumbs from './BreadCrumbs';
+
+describe('BreadCrumbs', () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  it('renders breadcrumb with default links and current path', () => {
+    render(
+      <MemoryRouter initialEntries={['/resource/REC123']}>
+        <Routes>
+          <Route path="/resource/:id" element={<BreadCrumbs />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByAltText('Home')).toBeInTheDocument();
+    expect(screen.getAllByAltText('chevron icon')).toHaveLength(2);
+    expect(screen.getByText('Find a site or trail')).toHaveAttribute(
+      'href',
+      '/search',
+    );
+    expect(screen.getByText('REC123')).toBeInTheDocument();
+  });
+
+  it('appends lastSearch from sessionStorage to search link if available', () => {
+    sessionStorage.setItem('lastSearch', '?filter=abc');
+
+    render(
+      <MemoryRouter initialEntries={['/resource/REC456']}>
+        <Routes>
+          <Route path="/resource/:id" element={<BreadCrumbs />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText('Find a site or trail')).toHaveAttribute(
+      'href',
+      '/search?filter=abc',
+    );
+    expect(screen.getByText('REC456')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/layout/BreadCrumbs.tsx
+++ b/frontend/src/components/layout/BreadCrumbs.tsx
@@ -13,11 +13,11 @@ const BreadCrumbs = () => {
       <a href="/" aria-label="Home">
         <img src={HomeIcon} alt="Home icon" />
       </a>
-      <img src={ChevronRightIcon} alt="chevron" />
+      <img src={ChevronRightIcon} alt="chevron icon" />
       <a href={`/search${lastSearch ? lastSearch : ''}`}>
         Find a site or trail
       </a>
-      <img src={ChevronRightIcon} alt="chevron" />
+      <img src={ChevronRightIcon} alt="chevron icon" />
       <span className="current-path">{id}</span>
     </div>
   );

--- a/frontend/src/components/layout/BreadCrumbs.tsx
+++ b/frontend/src/components/layout/BreadCrumbs.tsx
@@ -1,21 +1,12 @@
-import { Fragment } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 import HomeIcon from '@/images/icons/home.svg';
 import ChevronRightIcon from '@/images/icons/chevron-right.svg';
 import '@/components/layout/BreadCrumbs.scss';
 
-interface BreadCrumbsProps {
-  customPaths?: { name: string; route: string }[];
-}
+const BreadCrumbs = () => {
+  const { id } = useParams();
 
-const BreadCrumbs = ({ customPaths }: BreadCrumbsProps) => {
-  const { pathname } = useLocation();
-  const paths = pathname
-    .split('/')
-    .filter((x) => x)
-    .map((path, index) => {
-      return customPaths?.[index]?.route ?? path;
-    });
+  const lastSearch = sessionStorage.getItem('lastSearch');
 
   return (
     <div className="breadcrumbs">
@@ -23,24 +14,11 @@ const BreadCrumbs = ({ customPaths }: BreadCrumbsProps) => {
         <img src={HomeIcon} alt="Home icon" />
       </a>
       <img src={ChevronRightIcon} alt="chevron" />
-      {paths.length > 0 &&
-        paths.map((name, index) => {
-          const pathName = customPaths?.[index]?.name ?? name;
-          const routeTo = `/${paths.slice(0, index + 1).join('/')}`;
-
-          return index === paths.length - 1 ? (
-            <span key={pathName} className="current-path">
-              {pathName}
-            </span>
-          ) : (
-            <Fragment key={pathName}>
-              <a href={routeTo} key={pathName}>
-                {pathName}
-              </a>
-              <img src={ChevronRightIcon} alt="chevron" />
-            </Fragment>
-          );
-        })}
+      <a href={`/search${lastSearch ? lastSearch : ''}`}>
+        Find a site or trail
+      </a>
+      <img src={ChevronRightIcon} alt="chevron" />
+      <span className="current-path">{id}</span>
     </div>
   );
 };

--- a/frontend/src/components/rec-resource/RecResourcePage.tsx
+++ b/frontend/src/components/rec-resource/RecResourcePage.tsx
@@ -227,9 +227,7 @@ const RecResourcePage = () => {
       <div className="rec-resource-container">
         <div className={`bg-container ${isPhotoGallery ? 'with-gallery' : ''}`}>
           <div className="page">
-            <BreadCrumbs
-              customPaths={[{ name: 'Find a site or trail', route: 'search' }]}
-            />
+            <BreadCrumbs />
             <section>
               <div>
                 <h1>{formattedName}</h1>

--- a/frontend/src/service/queries/recreation-resource/recreationResourceQueries.ts
+++ b/frontend/src/service/queries/recreation-resource/recreationResourceQueries.ts
@@ -9,6 +9,7 @@ import {
 import { useRecreationResourceApi } from '@/service/hooks/useRecreationResourceApi';
 import { useInfiniteQuery, useQuery } from '~/@tanstack/react-query';
 import { trackSiteSearch } from '@/utils/matomo';
+import buildQueryString from '@/utils/buildQueryString';
 import {
   transformRecreationResourceBase,
   transformRecreationResourceDetail,
@@ -162,6 +163,8 @@ export const useSearchRecreationResourcesPaginated = (
         ...pageParam,
         page: pageParam.page || DEFAULT_PAGE,
       });
+
+      sessionStorage.setItem('lastSearch', buildQueryString(pageParam));
 
       trackSiteSearch({
         keyword: JSON.stringify(pageParam),


### PR DESCRIPTION
[#661](https://github.com/bcgov/nr-rec-resources/issues/661)

Also refactored the breadcrumbs to be static - we are only using them on the rec resource page so there was no need for them to be dynamic. I was having to add all these checks and conditionals to add the history to the search url and it seemed bug prone and overcomplicated. Let me know if you think I should revert it.