### PR TITLE
fix: rec resource page menu and mobile padding

### DIFF
--- a/frontend/src/components/layout/PageMenu.scss
+++ b/frontend/src/components/layout/PageMenu.scss
@@ -1,10 +1,9 @@
 @import '@/styles/variables.scss';
 
 .page-menu {
+  margin-bottom: 1rem;
   padding-right: 20px;
   font-size: 0.875rem;
-  margin-top: 64px;
-  margin-bottom: 80px;
   max-width: 260px;
   align-self: flex-start;
   top: 0px;

--- a/frontend/src/components/layout/PageMenu.test.tsx
+++ b/frontend/src/components/layout/PageMenu.test.tsx
@@ -15,7 +15,7 @@ const s = [
 ];
 
 describe('the PageMenu component', () => {
-  it('renders the component correctly anc changes value', async () => {
+  it('renders the component correctly and changes value', async () => {
     const c = <PageMenu activeSection={0} pageSections={s} />;
     const { queryByTitle } = render(c);
     const select = queryByTitle('mobile-navigation');

--- a/frontend/src/components/rec-resource/RecResource.scss
+++ b/frontend/src/components/rec-resource/RecResource.scss
@@ -37,6 +37,12 @@
   margin-bottom: -112px;
 }
 
+.rec-resource-main {
+  @include media-breakpoint-up(md) {
+    margin-top: 4rem;
+  }
+}
+
 .rec-resource-content {
   padding: $pagePaddingLg;
   max-width: $pageMaxWidth;
@@ -46,7 +52,6 @@
 .rec-content-container {
   width: 100%;
   max-width: 740px;
-  margin-top: 64px;
 }
 
 .not-found-message {

--- a/frontend/src/components/rec-resource/RecResourcePage.tsx
+++ b/frontend/src/components/rec-resource/RecResourcePage.tsx
@@ -263,7 +263,7 @@ const RecResourcePage = () => {
               <PhotoGallery photos={photos} />
             </div>
           )}
-          <div className="row no-gutters">
+          <div className="row no-gutters rec-resource-main">
             <PageMenu
               pageSections={pageSections}
               activeSection={activeSection ?? 0}

--- a/frontend/src/components/recreation-search-form/RecreationSearchForm.scss
+++ b/frontend/src/components/recreation-search-form/RecreationSearchForm.scss
@@ -14,10 +14,6 @@
     box-shadow: none;
     padding: 18px 48px 0 16px;
 
-    &:hover {
-      border-width: 2px;
-    }
-
     &:focus,
     &:focus-visible {
       border-width: 3px;
@@ -43,9 +39,11 @@
     padding: 18px 16px 0;
   }
 
-  .search-button,
-  .search-input {
-    height: 48px;
+  .search-button {
+    margin-top: 1rem;
+    @media (min-width: $mdBreakpoint) {
+      margin-top: 0;
+    }
   }
 
   .clear-button {
@@ -85,6 +83,7 @@
 
     @media (min-width: $mdBreakpoint) {
       flex-direction: row;
+      flex-grow: 1;
     }
   }
 

--- a/frontend/src/components/recreation-search-form/RecreationSearchForm.tsx
+++ b/frontend/src/components/recreation-search-form/RecreationSearchForm.tsx
@@ -59,14 +59,13 @@ export const RecreationSearchForm: FC<RecreationSearchFormProps> = ({
       className="search-form"
       data-testid="search-form"
     >
-      <Row className="gy-3 gx-0 gx-md-3">
-        <Col md="auto" className="flex-grow-0 flex-lg-grow-1">
+      <Row className="gy-3 gx-0 gx-lg-3">
+        <Col md={10}>
           <InputGroup className="search-input-group">
-            <Col className="p-0">
+            <Col>
               <FormGroup
                 controlId="name-search-input"
                 className={`${nameInputValue ? 'has-text--true' : ''}`}
-                style={{ position: 'relative' }}
               >
                 <FormControl
                   aria-label={placeholder}
@@ -95,7 +94,7 @@ export const RecreationSearchForm: FC<RecreationSearchFormProps> = ({
             </Col>
           </InputGroup>
         </Col>
-        <Col md="auto">
+        <Col md={2}>
           <Button
             type="submit"
             {...searchButtonProps}

--- a/frontend/src/styles/variables.scss
+++ b/frontend/src/styles/variables.scss
@@ -30,7 +30,7 @@ $lgBreakpoint: 992px;
 $xlBreakpoint: 1200px;
 $xxlBreakpoint: 1400px;
 
-$pagePadding: 2rem;
+$pagePadding: 1rem;
 $pagePaddingLg: 1rem;
 $pageMaxWidth: 1080px;
 


### PR DESCRIPTION
Combined a few tiny bug fix prs here, #647, #658, #589

- Reduce mobile page padding from 2rem/32px to 1rem/16px
- Reduce rec resource page menu top and bottom margins on mobile
- Fix bug in medium viewport size/tablet mode where the page menu would take up most of the screen
- Fix some regression I made in the landing page search bar - these only happened in firefox and safari