### PR TITLE
chore: mobile search image and filter style improvements

### DIFF
--- a/frontend/src/components/rec-resource/card/CardCarousel.tsx
+++ b/frontend/src/components/rec-resource/card/CardCarousel.tsx
@@ -6,6 +6,7 @@ import {
   faCircleChevronLeft,
   faCircleChevronRight,
 } from '@fortawesome/free-solid-svg-icons';
+import '@/components/rec-resource/card/RecResourceCard.scss';
 
 type ImageList = { imageUrl: string }[];
 

--- a/frontend/src/components/rec-resource/card/RecResourceCard.scss
+++ b/frontend/src/components/rec-resource/card/RecResourceCard.scss
@@ -93,8 +93,10 @@
 }
 
 .carousel-mobile-image {
-  max-height: 300px;
   display: block;
+  max-height: 300px;
+  min-width: 100%;
+  object-fit: cover;
 
   @include media-breakpoint-up(sm) {
     display: none;

--- a/frontend/src/components/rec-resource/card/helpers.test.ts
+++ b/frontend/src/components/rec-resource/card/helpers.test.ts
@@ -65,4 +65,34 @@ describe('getImageList', () => {
 
     expect(result).toEqual([]);
   });
+
+  it('should sort images with landscape orientation before portrait', () => {
+    const mockResource: RecreationResourceSearchModel = {
+      recreation_resource_images: [
+        {
+          recreation_resource_image_variants: [
+            {
+              size_code: IMAGE_SIZE_CODE_FOR_SEARCH_RESULTS_CARD,
+              url: 'portrait.jpg',
+              width: 600,
+              height: 800,
+            },
+            {
+              size_code: IMAGE_SIZE_CODE_FOR_SEARCH_RESULTS_CARD,
+              url: 'landscape.jpg',
+              width: 1200,
+              height: 800,
+            },
+          ],
+        },
+      ],
+    } as unknown as RecreationResourceSearchModel;
+
+    const result = getImageList(mockResource);
+
+    expect(result).toEqual([
+      { imageUrl: 'landscape.jpg' },
+      { imageUrl: 'portrait.jpg' },
+    ]);
+  });
 });

--- a/frontend/src/components/rec-resource/card/helpers.ts
+++ b/frontend/src/components/rec-resource/card/helpers.ts
@@ -7,18 +7,27 @@ import { IMAGE_SIZE_CODE_FOR_SEARCH_RESULTS_CARD } from '@/components/rec-resour
  * @param {RecreationResourceSearchModel} recreationResource - Resource containing image data
  * @returns {Array<{imageUrl: string}>} Array of image URL objects
  */
+
 export const getImageList = (
   recreationResource: RecreationResourceSearchModel,
 ): Array<{ imageUrl: string }> => {
-  return (
+  const variants =
     recreationResource.recreation_resource_images?.flatMap(
       ({ recreation_resource_image_variants }) =>
-        recreation_resource_image_variants
-          ?.filter(
-            ({ size_code }) =>
-              size_code === IMAGE_SIZE_CODE_FOR_SEARCH_RESULTS_CARD,
-          )
-          .map(({ url }) => ({ imageUrl: url })) || [],
-    ) || []
-  );
+        recreation_resource_image_variants?.filter(
+          ({ size_code }) =>
+            size_code === IMAGE_SIZE_CODE_FOR_SEARCH_RESULTS_CARD,
+        ) || [],
+    ) || [];
+
+  const sortedVariants = variants.sort((a, b) => {
+    const aIsLandscape = a.width > a.height;
+    const bIsLandscape = b.width > b.height;
+
+    // Return landscape images first since they are more suitable for the card
+    if (aIsLandscape === bIsLandscape) return 0;
+    return aIsLandscape ? -1 : 1;
+  });
+
+  return sortedVariants.map(({ url }) => ({ imageUrl: url }));
 };

--- a/frontend/src/components/recreation-search-form/RecreationSearchForm.tsx
+++ b/frontend/src/components/recreation-search-form/RecreationSearchForm.tsx
@@ -60,7 +60,7 @@ export const RecreationSearchForm: FC<RecreationSearchFormProps> = ({
       data-testid="search-form"
     >
       <Row className="gy-3 gx-0 gx-lg-3">
-        <Col md={10}>
+        <Col md={10} className="pe-md-3 pe-lg-2">
           <InputGroup className="search-input-group">
             <Col>
               <FormGroup

--- a/frontend/src/components/search/filters/FilterMenuMobile.tsx
+++ b/frontend/src/components/search/filters/FilterMenuMobile.tsx
@@ -58,7 +58,7 @@ const FilterMenuMobile = ({ isOpen, setIsOpen }: FilterMenuMobileProps) => {
     >
       <Modal.Body className="mobile-filter-modal-content">
         <div className="mobile-filter-modal-content--header">
-          <h2>Filter</h2>
+          <h2 className="fs-4 mb-4">Filter</h2>
           <button
             aria-label="close"
             className="btn close-filter-btn"
@@ -67,7 +67,7 @@ const FilterMenuMobile = ({ isOpen, setIsOpen }: FilterMenuMobileProps) => {
             <FontAwesomeIcon icon={faXmark} />
           </button>
         </div>
-        <button className="btn btn-link expand-link" onClick={handleExpandAll}>
+        <button className="show-all-link p-0" onClick={handleExpandAll}>
           {expandAll ? 'Collapse' : 'Expand'} all
           {expandAll ? (
             <FontAwesomeIcon icon={faChevronUp} />
@@ -100,7 +100,7 @@ const FilterMenuMobile = ({ isOpen, setIsOpen }: FilterMenuMobileProps) => {
           Show {totalCount} {totalCount > 1 ? 'results' : 'result'}
         </button>
         <button
-          className="btn btn-link clear-filter-link w-100"
+          className="btn-link clear-filter-link w-100 fw-normal"
           onClick={clearFilters}
         >
           Clear filters

--- a/frontend/src/components/search/filters/Filters.scss
+++ b/frontend/src/components/search/filters/Filters.scss
@@ -99,6 +99,11 @@
     flex-direction: column;
     align-items: center;
     justify-content: center;
+    margin: 32px;
+
+    @include media-breakpoint-up(sm) {
+      margin: 32px auto;
+    }
   }
   .modal-content {
     background-color: $colorBackgroundGrey;
@@ -118,6 +123,7 @@
         margin: 0;
         padding: 0;
         color: $colorBlue;
+        font-weight: normal;
 
         svg {
           font-size: 1rem;
@@ -143,6 +149,7 @@
           align-items: center;
           justify-content: space-between;
           border: none;
+          line-height: 1.125rem;
           background-color: inherit;
         }
       }
@@ -153,6 +160,7 @@
     .modal-footer {
       .clear-filter-link {
         margin: 0;
+        text-decoration: underline;
       }
     }
   }


### PR DESCRIPTION
- Use `object-fit: cover` on the mobile search card images just as we do for desktop
- Sort image variants by landscape first since they look/fit better with our card design which has the images with more width than height. This way the more zoomed in portrait images aren't displayed first.
- Update mobile filter styles to closer align with bcparks.ca

Update to how we handle images in the mobile search cards. 

Some sites currently show portait images like this:
<img width="324" alt="Screenshot 2025-05-14 at 9 29 46 AM" src="https://github.com/user-attachments/assets/df98475a-2db3-4ac2-8147-ec5c2cf241ed" />

Now we sort images to show landscape first since they aren't so zoomed in:
<img width="324" alt="Screenshot 2025-05-14 at 9 27 50 AM" src="https://github.com/user-attachments/assets/ee0e0ac7-4137-4d41-b8a9-4204300044d7" />

Then we use `object-fit: cover` to display portrait images just like we do on desktop:
<img width="324" alt="Screenshot 2025-05-14 at 9 29 07 AM" src="https://github.com/user-attachments/assets/3eaf90d1-65c9-4f0f-aeb9-1bfec2a2698d" />



Minor updates filter styles to more closely align with bcparks. Minor differences in colour due to acessibility/contrast.
<img width="324" alt="Screenshot 2025-05-14 at 9 25 23 AM" src="https://github.com/user-attachments/assets/65eebe81-2f68-4cc7-9842-b05b796671e6" />
Bcparks:
<img width="324" alt="Screenshot 2025-05-14 at 9 27 06 AM" src="https://github.com/user-attachments/assets/f16294ab-9593-4bd6-afca-c4e26139dbcc" />
