### PR TITLE
fix: community search param excluded from breadcrumb history

### DIFF
--- a/frontend/src/components/recreation-search-form/LocationSearch.tsx
+++ b/frontend/src/components/recreation-search-form/LocationSearch.tsx
@@ -82,6 +82,7 @@ const LocationSearch: React.FC = () => {
               referenceElementRef(node);
             }}
             value={cityInputValue}
+            data-testid="location-search-input"
             className="form-control"
             enterKeyHint="search"
           />

--- a/frontend/src/components/recreation-search-form/RecreationSearchForm.test.tsx
+++ b/frontend/src/components/recreation-search-form/RecreationSearchForm.test.tsx
@@ -107,4 +107,22 @@ describe('RecreationSearchForm', () => {
 
     expect(setNameInputValue).not.toHaveBeenCalled();
   });
+
+  it('should retain the search input value if filter search params exist', async () => {
+    vi.restoreAllMocks();
+
+    renderWithRouter(<RecreationSearchForm />, ['/search?filter=test']);
+
+    const nameInput = await screen.findByTestId('name-search-input');
+    expect(nameInput).toHaveValue('test');
+  });
+
+  it('should retain the location input value if community search params exist', async () => {
+    vi.restoreAllMocks();
+
+    renderWithRouter(<RecreationSearchForm />, ['/search?community=test']);
+
+    const locationInput = await screen.findByTestId('location-search-input');
+    expect(locationInput).toHaveValue('test');
+  });
 });

--- a/frontend/src/components/recreation-search-form/RecreationSearchForm.tsx
+++ b/frontend/src/components/recreation-search-form/RecreationSearchForm.tsx
@@ -62,7 +62,7 @@ export const RecreationSearchForm: FC<RecreationSearchFormProps> = ({
       <Row className="gy-3 gx-0 gx-lg-3">
         <Col md={10} className="pe-md-3 pe-lg-2">
           <InputGroup className="search-input-group">
-            <Col>
+            <Col className="position-relative">
               <FormGroup
                 controlId="name-search-input"
                 className={`${nameInputValue ? 'has-text--true' : ''}`}

--- a/frontend/src/components/search/SearchPage.tsx
+++ b/frontend/src/components/search/SearchPage.tsx
@@ -48,6 +48,7 @@ const SearchPage = () => {
     facilities: searchParams.get('facilities') ?? undefined,
     lat: lat ? Number(lat) : undefined,
     lon: lon ? Number(lon) : undefined,
+    community: community ?? undefined,
     type: searchParams.get('type') ?? undefined,
     page: initialPage,
   });

--- a/frontend/src/service/queries/recreation-resource/recreationResourceQueries.ts
+++ b/frontend/src/service/queries/recreation-resource/recreationResourceQueries.ts
@@ -17,6 +17,11 @@ import {
 import { InfiniteData } from '@tanstack/react-query';
 import { RecreationResourceDetailModel } from '@/service/custom-models';
 
+interface SearchParams extends SearchRecreationResourcesRequest {
+  // Extend generated request with additional params not used in the api
+  community?: string;
+}
+
 /**
  * Custom hook to fetch a recreation resource by ID.
  *
@@ -102,9 +107,7 @@ export const useGetSiteOperatorById = ({
  * @param {Object} params - Hook parameters
  * @param {Object} params.searchRecreationResourcesParams - Search parameters excluding page number
  */
-export const useSearchRecreationResourcesPaginated = (
-  params: SearchRecreationResourcesRequest,
-) => {
+export const useSearchRecreationResourcesPaginated = (params: SearchParams) => {
   const api = useRecreationResourceApi();
   // Default page number for initial load and fallback
   const DEFAULT_PAGE = 1;
@@ -153,18 +156,17 @@ export const useSearchRecreationResourcesPaginated = (
    * Fetches recreation resources for the specified page
    * Transforms the response data using transformRecreationResource
    */
-  const queryFn = async ({
-    pageParam,
-  }: {
-    pageParam: SearchRecreationResourcesRequest;
-  }) => {
+  const queryFn = async ({ pageParam }: { pageParam: SearchParams }) => {
     try {
       const response = await api.searchRecreationResources({
         ...pageParam,
         page: pageParam.page || DEFAULT_PAGE,
       });
 
-      sessionStorage.setItem('lastSearch', buildQueryString(pageParam));
+      sessionStorage.setItem(
+        'lastSearch',
+        buildQueryString(pageParam as { [key: string]: string | number }),
+      );
 
       trackSiteSearch({
         keyword: JSON.stringify(pageParam),


### PR DESCRIPTION
Breadcrumb history now includes `community` param so the new location search input is populated on return. This had to be handled as that param isn't used by used by the api so the type wasn't autogenerated.

<img width="1021" alt="Screenshot 2025-05-15 at 10 44 29 AM" src="https://github.com/user-attachments/assets/2a7d2739-6cab-4b42-95ab-32d979e737a8" />


Also added `position: relative` to the name input container so the clear input button is inside the input as it previously was:
<img width="324" alt="Screenshot 2025-05-15 at 10 43 16 AM" src="https://github.com/user-attachments/assets/83a07718-133d-46e4-b6d8-17dce2112f66" />

