### PR TITLE
fix: search input state issues

### DIFF
--- a/public/frontend/eslint.config.mjs
+++ b/public/frontend/eslint.config.mjs
@@ -6,7 +6,7 @@ import { fileURLToPath } from 'node:url';
 import js from '@eslint/js';
 import { FlatCompat } from '@eslint/eslintrc';
 // eslint-disable-next-line import/no-relative-parent-imports
-import baseConfig from '../eslint.config.mjs';
+import baseConfig from '../../eslint.config.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);

--- a/public/frontend/src/components/landing-page/LandingPage.tsx
+++ b/public/frontend/src/components/landing-page/LandingPage.tsx
@@ -129,7 +129,7 @@ export const LandingPage: FC = () => {
                 <a
                   rel="noreferrer noopener"
                   className="research-signup-link"
-                  href={EXTERNAL_LINKS.RESEARCH_PARTICIPANT_SIGN_UP}
+                  href={EXTERNAL_LINKS.ORIGINAL_SITE}
                 >
                   original interactive map
                 </a>{' '}

--- a/public/frontend/src/components/recreation-search-form/LocationSearch.test.tsx
+++ b/public/frontend/src/components/recreation-search-form/LocationSearch.test.tsx
@@ -1,16 +1,11 @@
 import { vi } from 'vitest';
 import type { Mock } from 'vitest';
-import {
-  render,
-  screen,
-  fireEvent,
-  waitFor,
-  within,
-} from '@testing-library/react';
+import { screen, fireEvent, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import LocationSearch from '@/components/recreation-search-form/LocationSearch';
 import { useSearchInput } from '@/components/recreation-search-form/hooks/useSearchInput';
 import { useSearchCitiesApi } from '@/components/recreation-search-form/hooks/useSearchCitiesApi';
+import { renderWithRouter } from '@/test-utils';
 
 vi.mock('@/components/recreation-search-form/hooks/useSearchInput', () => ({
   useSearchInput: vi.fn(),
@@ -53,12 +48,12 @@ describe('LocationSearch', () => {
   });
 
   it('renders input with label', () => {
-    render(<LocationSearch />);
+    renderWithRouter(<LocationSearch />);
     expect(screen.getByLabelText(/Near a city/i)).toBeInTheDocument();
   });
 
   it('shows and selects a suggestion', async () => {
-    render(<LocationSearch />);
+    renderWithRouter(<LocationSearch />);
 
     const input = screen.getByLabelText(/near a city/i);
     await userEvent.type(input, 'Vic');
@@ -82,7 +77,7 @@ describe('LocationSearch', () => {
       handleClearCityInput,
     });
 
-    render(<LocationSearch />);
+    renderWithRouter(<LocationSearch />);
     const input = screen.getByLabelText(/Near a city/i);
 
     fireEvent.change(input, { target: { value: 'Victoria' } });
@@ -103,7 +98,7 @@ describe('LocationSearch', () => {
       handleClearCityInput,
     });
 
-    render(<LocationSearch />);
+    renderWithRouter(<LocationSearch />);
     const clearButton = await screen.findByRole('button', {
       name: /clear search/i,
     });
@@ -121,7 +116,7 @@ describe('LocationSearch', () => {
       refetch: vi.fn(),
     });
 
-    render(<LocationSearch />);
+    renderWithRouter(<LocationSearch />);
 
     const input = screen.getByLabelText(/Near a city/i);
 

--- a/public/frontend/src/components/recreation-search-form/LocationSearch.tsx
+++ b/public/frontend/src/components/recreation-search-form/LocationSearch.tsx
@@ -62,7 +62,7 @@ const LocationSearch: React.FC = () => {
       labelKey="cityName"
       filterBy={() => true}
       options={cityOptions}
-      selected={selectedCity}
+      selected={selectedCity ?? []}
       onChange={handleOnChange}
       onInputChange={handleInputChange}
       placeholder=" "

--- a/public/frontend/src/components/recreation-search-form/RecreationSearchForm.test.tsx
+++ b/public/frontend/src/components/recreation-search-form/RecreationSearchForm.test.tsx
@@ -35,7 +35,7 @@ describe('RecreationSearchForm', () => {
 
   const setup = (mockValues = {}) => {
     const hooks = { ...mockHooks, ...mockValues };
-    vi.spyOn(SearchHooks, 'useSearchInput').mockReturnValue(hooks);
+    vi.spyOn(SearchHooks, 'useSearchInput').mockReturnValue(hooks as any);
     return hooks;
   };
 
@@ -92,13 +92,6 @@ describe('RecreationSearchForm', () => {
     fireEvent.submit(form);
 
     expect(handleSearch).toHaveBeenCalledTimes(1);
-  });
-
-  it('clears the search input if no filter search params', async () => {
-    const { setNameInputValue } = setup();
-    renderWithRouter(<RecreationSearchForm />, ['/search']);
-
-    expect(setNameInputValue).toHaveBeenCalledWith('');
   });
 
   it('does not clear the search input if filter search params exist', async () => {

--- a/public/frontend/src/components/recreation-search-form/RecreationSearchForm.tsx
+++ b/public/frontend/src/components/recreation-search-form/RecreationSearchForm.tsx
@@ -1,4 +1,4 @@
-import { FC, FormEvent, useEffect } from 'react';
+import { FC, FormEvent } from 'react';
 import {
   Button,
   ButtonProps,
@@ -11,7 +11,6 @@ import {
 } from 'react-bootstrap';
 import { ClearButton } from 'react-bootstrap-typeahead';
 import LocationSearch from '@/components/recreation-search-form/LocationSearch';
-import { useSearchParams } from 'react-router-dom';
 import '@/components/recreation-search-form/RecreationSearchForm.scss';
 import { useSearchInput } from '@/components/recreation-search-form/hooks/useSearchInput';
 import { trackSiteSearch } from '@/utils/matomo';
@@ -29,8 +28,6 @@ export const RecreationSearchForm: FC<RecreationSearchFormProps> = ({
   searchButtonProps,
   location = 'Search page',
 }) => {
-  const [searchParams] = useSearchParams();
-  const filter = searchParams.get('filter');
   const {
     nameInputValue,
     setNameInputValue,
@@ -46,12 +43,6 @@ export const RecreationSearchForm: FC<RecreationSearchFormProps> = ({
       keyword: nameInputValue,
     });
   };
-
-  useEffect(() => {
-    if (!filter) {
-      setNameInputValue('');
-    }
-  }, [filter, setNameInputValue]);
 
   return (
     <Form

--- a/public/frontend/src/components/recreation-search-form/hooks/useSearchInput.test.ts
+++ b/public/frontend/src/components/recreation-search-form/hooks/useSearchInput.test.ts
@@ -147,4 +147,21 @@ describe('useSearchInput', () => {
 
     expect(result.current.selectedCity).toEqual([city]);
   });
+
+  it('should initialize nameInputValue and cityInputValue from filter and community search params', () => {
+    const searchParams = new URLSearchParams({
+      filter: 'test',
+      community: 'Victoria',
+    });
+
+    vi.spyOn(ReactRouterDom, 'useSearchParams').mockReturnValue([
+      searchParams,
+      mockSetSearchParams,
+    ]);
+
+    const { result } = renderHook(() => useSearchInput());
+
+    expect(result.current.nameInputValue).toBe('test');
+    expect(result.current.cityInputValue).toBe('Victoria');
+  });
 });

--- a/public/frontend/src/components/search/NoResults.test.tsx
+++ b/public/frontend/src/components/search/NoResults.test.tsx
@@ -1,87 +1,48 @@
-import { vi } from 'vitest';
+import { vi, Mock } from 'vitest';
 import { fireEvent, render, screen } from '@testing-library/react';
 import NoResults from 'src/components/search/NoResults';
-import { filterChipStore } from '@/store';
-import { MemoryRouter, useSearchParams } from 'react-router-dom';
 
-vi.mock('react-router-dom', async () => {
-  const originalModule = await vi.importActual('react-router-dom');
-  return {
-    ...originalModule,
-    useSearchParams: vi.fn(),
-  };
-});
+import { useClearFilters } from '@/components/search/hooks/useClearFilters';
+import { useSearchInput } from '@/components/recreation-search-form/hooks/useSearchInput';
 
-vi.mock('@/store', () => ({
-  filterChipStore: {
-    setState: vi.fn(),
-  },
-}));
+vi.mock('@/components/search/hooks/useClearFilters');
+vi.mock('@/components/recreation-search-form/hooks/useSearchInput');
 
 describe('NoResults component', () => {
-  it('clears the search parameters when the "Go back to the full list" button is clicked', () => {
-    const mockSetSearchParams = vi.fn();
-    const mockUseSearchParams = useSearchParams as any;
+  const clearFiltersMock = vi.fn();
+  const handleClearSearchMock = vi.fn();
 
-    mockUseSearchParams.mockReturnValue([
-      new URLSearchParams(),
-      mockSetSearchParams,
-    ]);
+  beforeEach(() => {
+    vi.clearAllMocks();
 
-    render(
-      <MemoryRouter initialEntries={['/search?filter=test']}>
-        <NoResults />
-      </MemoryRouter>,
-    );
+    (useClearFilters as Mock).mockReturnValue(clearFiltersMock);
+    (useSearchInput as Mock).mockReturnValue({
+      handleClearSearch: handleClearSearchMock,
+    });
+  });
+
+  it('calls both clearFilters and handleClearSearch when the "Go back to the full list" button is clicked', () => {
+    render(<NoResults />);
 
     const clearButton = screen.getByText('Go back to the full list');
     fireEvent.click(clearButton);
 
-    expect(mockSetSearchParams).toHaveBeenCalledWith(expect.any(Function));
-
-    const setParamsFunction = mockSetSearchParams.mock.calls[1][0];
-    const newParams = setParamsFunction(new URLSearchParams());
-
-    expect(newParams).toEqual(new URLSearchParams());
+    expect(clearFiltersMock).toHaveBeenCalled();
+    expect(handleClearSearchMock).toHaveBeenCalled();
   });
 
-  it('clear the filter chips store when the "Go back to the full list" button is clicked', () => {
-    const mockSetSearchParams = vi.fn();
-    const mockUseSearchParams = useSearchParams as any;
-
-    mockUseSearchParams.mockReturnValue([
-      new URLSearchParams(),
-      mockSetSearchParams,
-    ]);
-
-    render(
-      <MemoryRouter initialEntries={['/search?filter=test']}>
-        <NoResults />
-      </MemoryRouter>,
-    );
-
-    const clearButton = screen.getByText('Go back to the full list');
-    fireEvent.click(clearButton);
-
-    expect(filterChipStore.setState).toHaveBeenCalled();
-  });
-
-  it('focuses the "Go back to the full list" button', () => {
-    const mockSetSearchParams = vi.fn();
-    const mockUseSearchParams = useSearchParams as any;
-
-    mockUseSearchParams.mockReturnValue([
-      new URLSearchParams(),
-      mockSetSearchParams,
-    ]);
-
-    render(
-      <MemoryRouter>
-        <NoResults />
-      </MemoryRouter>,
-    );
+  it('focuses the "Go back to the full list" button on mount', () => {
+    render(<NoResults />);
 
     const clearButton = screen.getByText('Go back to the full list');
     expect(document.activeElement).toBe(clearButton);
+  });
+
+  it('renders the no results message and suggestions', () => {
+    render(<NoResults />);
+
+    expect(screen.getByText(/Sorry.../)).toBeVisible();
+    expect(screen.getByText(/No sites or trails matched/)).toBeVisible();
+    expect(screen.getByText(/Go back to the full list/)).toBeVisible();
   });
 });

--- a/public/frontend/src/components/search/NoResults.tsx
+++ b/public/frontend/src/components/search/NoResults.tsx
@@ -1,19 +1,19 @@
 import { useEffect, useRef } from 'react';
-import { useSearchParams } from 'react-router-dom';
 import { useClearFilters } from '@/components/search/hooks/useClearFilters';
+import { useSearchInput } from '@/components/recreation-search-form/hooks/useSearchInput';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faMagnifyingGlass } from '@fortawesome/free-solid-svg-icons';
 import '@/components/search/NoResults.scss';
 
 const NoResults = () => {
-  const [_, setSearchParams] = useSearchParams();
   const clearFilters = useClearFilters();
+  const { handleClearSearch } = useSearchInput();
 
   const buttonRef = useRef<HTMLButtonElement>(null);
 
   const handleClear = () => {
     clearFilters();
-    setSearchParams(() => new URLSearchParams());
+    handleClearSearch();
   };
 
   useEffect(() => {

--- a/public/frontend/src/store/searchInputStore.ts
+++ b/public/frontend/src/store/searchInputStore.ts
@@ -1,0 +1,18 @@
+import { Store } from '@tanstack/store';
+import { City } from '@/components/recreation-search-form/types';
+
+interface SearchInputState {
+  nameInputValue: string;
+  cityInputValue: string;
+  selectedCity?: City[];
+}
+
+const initialSearchInputState: SearchInputState = {
+  nameInputValue: '',
+  cityInputValue: '',
+  selectedCity: undefined,
+};
+
+const searchInputStore = new Store<SearchInputState>(initialSearchInputState);
+
+export default searchInputStore;

--- a/public/frontend/src/test-utils.tsx
+++ b/public/frontend/src/test-utils.tsx
@@ -1,7 +1,8 @@
-import { cleanup } from '@testing-library/react';
+import { cleanup, render } from '@testing-library/react';
 import { afterEach } from 'vitest';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactNode } from 'react';
+import { MemoryRouter } from 'react-router-dom';
 
 afterEach(() => {
   cleanup();
@@ -25,5 +26,11 @@ export const TestQueryClientProvider = ({
   const testClient = createTestQueryClient();
   return (
     <QueryClientProvider client={testClient}>{children}</QueryClientProvider>
+  );
+};
+
+export const renderWithRouter = (ui: ReactNode, initialEntry: string = '/') => {
+  return render(
+    <MemoryRouter initialEntries={[initialEntry]}>{ui}</MemoryRouter>,
   );
 };


### PR DESCRIPTION
#786 
- Fix `Go back to full list` button not clearing the city input search when there are no search results
- Fix if user types in name search field, then selects a city. Previously it would only search by the city and ignore the name input search, now it searches both name and city.
- Fix landing page url
- Fix screenreaders not letting people know there are no results