### PR TITLE
feat(rec-resource-map): add kml and gpx download functionality

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL := /usr/bin/env bash
 
-include ./backend/.env
+include ./public/backend/.env
 
 PSQL=psql -h localhost -U ${POSTGRES_USER}
 DB_NAME=${POSTGRES_DATABASE}

--- a/public/frontend/src/components/StyledVectorFeatureMap/StyledVectorFeatureMap.tsx
+++ b/public/frontend/src/components/StyledVectorFeatureMap/StyledVectorFeatureMap.tsx
@@ -1,6 +1,5 @@
 import { ReactNode, useCallback, useEffect, useState } from 'react';
 import { Feature } from 'ol';
-import { StyleLike } from 'ol/style/Style';
 import {
   useAddVectorLayerToMap,
   useMapBaseLayers,
@@ -16,8 +15,6 @@ interface StyledVectorFeatureMapProps {
   mapComponentCssStyles?: React.CSSProperties;
   /** Array of OpenLayers features to display on the map as vector layers */
   features: Feature[];
-  /** Style configuration for the vector features */
-  layerStyle: StyleLike;
   /** Child components to render within the map context */
   children?: ReactNode;
 }
@@ -29,7 +26,6 @@ interface StyledVectorFeatureMapProps {
 export const StyledVectorFeatureMap: React.FC<StyledVectorFeatureMapProps> = ({
   mapComponentCssStyles,
   features,
-  layerStyle,
   children,
 }) => {
   const [featureExtent, setFeatureExtent] = useState<Coordinate>();
@@ -51,7 +47,6 @@ export const StyledVectorFeatureMap: React.FC<StyledVectorFeatureMapProps> = ({
   useAddVectorLayerToMap({
     map,
     features,
-    layerStyle,
     onLayerAdded: handleCallback,
   });
 

--- a/public/frontend/src/components/StyledVectorFeatureMap/components/MapControls.test.tsx
+++ b/public/frontend/src/components/StyledVectorFeatureMap/components/MapControls.test.tsx
@@ -46,10 +46,7 @@ describe('MapControls', () => {
 
     fireEvent.click(screen.getByLabelText('Zoom in'));
 
-    expect(mockView.animate).toHaveBeenCalledWith({
-      zoom: 3,
-      duration: 250,
-    });
+    expect(mockView.setZoom).toHaveBeenCalledWith(3);
   });
 
   it('handles zoom out click', () => {
@@ -58,10 +55,7 @@ describe('MapControls', () => {
 
     fireEvent.click(screen.getByLabelText('Zoom out'));
 
-    expect(mockView.animate).toHaveBeenCalledWith({
-      zoom: 1,
-      duration: 250,
-    });
+    expect(mockView.setZoom).toHaveBeenCalledWith(1);
   });
 
   it('handles center click with provided extent', () => {
@@ -88,9 +82,6 @@ describe('MapControls', () => {
 
     fireEvent.click(screen.getByLabelText('Zoom in'));
 
-    expect(mockView.animate).toHaveBeenCalledWith({
-      zoom: 1,
-      duration: 250,
-    });
+    expect(mockView.setZoom).toHaveBeenCalledWith(1);
   });
 });

--- a/public/frontend/src/components/StyledVectorFeatureMap/components/MapControls.tsx
+++ b/public/frontend/src/components/StyledVectorFeatureMap/components/MapControls.tsx
@@ -32,7 +32,7 @@ export const MapControls: FC<MapControlsProps> = memo(({ map, extent }) => {
     (e: React.MouseEvent) => {
       e.stopPropagation();
       const zoom = view.getZoom() ?? 0;
-      view.animate({ zoom: zoom + 1, duration: 250 });
+      view.setZoom(zoom + 1);
       trackEvent({
         category: 'Map Controls',
         action: 'Click',
@@ -46,7 +46,7 @@ export const MapControls: FC<MapControlsProps> = memo(({ map, extent }) => {
     (e: React.MouseEvent) => {
       e.stopPropagation();
       const zoom = view.getZoom() ?? 0;
-      view.animate({ zoom: zoom - 1, duration: 250 });
+      view.setZoom(zoom - 1);
       trackEvent({
         category: 'Map Controls',
         action: 'Click',

--- a/public/frontend/src/components/StyledVectorFeatureMap/constants.ts
+++ b/public/frontend/src/components/StyledVectorFeatureMap/constants.ts
@@ -1,6 +1,7 @@
 // Coordinate Reference System (CRS) projections
 export const MAP_PROJECTION_BC_ALBERS = 'EPSG:3005';
 export const MAP_PROJECTION_WEB_MERCATOR = 'EPSG:3857';
+export const MAP_PROJECTION_WGS84 = 'EPSG:4326';
 
 /**
  * Default map center coordinates in Web Mercator (EPSG:3857) projection

--- a/public/frontend/src/components/StyledVectorFeatureMap/hooks/useAddVectorLayerToMap.ts
+++ b/public/frontend/src/components/StyledVectorFeatureMap/hooks/useAddVectorLayerToMap.ts
@@ -4,15 +4,12 @@ import VectorLayer from 'ol/layer/Vector';
 import OlMap from 'ol/Map';
 import { Feature } from 'ol';
 import { Coordinate } from 'ol/coordinate';
-import { StyleLike } from 'ol/style/Style';
 
 interface UseVectorLayerProps {
   /** OpenLayers map instance */
   map: OlMap;
   /** Array of features to display */
   features: Feature[];
-  /** Style configuration for the layer */
-  layerStyle?: StyleLike;
   /** Callback fired when layer is added to map */
   onLayerAdded?: (extent: Coordinate) => void;
 }
@@ -25,7 +22,6 @@ interface UseVectorLayerProps {
 export const useAddVectorLayerToMap = ({
   map,
   features,
-  layerStyle,
   onLayerAdded,
 }: UseVectorLayerProps) => {
   const [vectorSource, setVectorSource] = useState<VectorSource>();
@@ -37,7 +33,6 @@ export const useAddVectorLayerToMap = ({
     const source = new VectorSource({ features });
     const layer = new VectorLayer({
       source,
-      style: layerStyle,
     });
 
     setVectorSource(source);
@@ -54,7 +49,7 @@ export const useAddVectorLayerToMap = ({
     return () => {
       map.removeLayer(layer);
     };
-  }, [map, features, layerStyle, onLayerAdded]);
+  }, [map, features, onLayerAdded]);
 
   return { vectorSource, vectorLayer };
 };

--- a/public/frontend/src/components/rec-resource/RecreationResourceMap/RecreationResourceMap.test.tsx
+++ b/public/frontend/src/components/rec-resource/RecreationResourceMap/RecreationResourceMap.test.tsx
@@ -1,110 +1,167 @@
-import { render } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { RecreationResourceMap } from './RecreationResourceMap';
 import { StyledVectorFeatureMap } from '@/components/StyledVectorFeatureMap';
 import {
+  downloadGPX,
+  downloadKML,
   getLayerStyleForRecResource,
   getMapFeaturesFromRecResource,
 } from '@/components/rec-resource/RecreationResourceMap/helpers';
-import { Mock, vi } from 'vitest';
+import { trackEvent } from '@/utils/matomo';
 
-// Mock the dependencies
 vi.mock('@/components/StyledVectorFeatureMap', () => ({
-  StyledVectorFeatureMap: vi.fn(() => null),
+  StyledVectorFeatureMap: vi.fn(() => <div data-testid="vector-map" />),
 }));
 
 vi.mock('@/components/rec-resource/RecreationResourceMap/helpers', () => ({
   getLayerStyleForRecResource: vi.fn(),
-  getMapFeaturesFromRecResource: vi.fn(),
+  getMapFeaturesFromRecResource: vi.fn().mockReturnValue([]),
+  downloadGPX: vi.fn(),
+  downloadKML: vi.fn(),
+}));
+
+vi.mock('@/utils/matomo', () => ({
+  trackEvent: vi.fn(),
 }));
 
 describe('RecreationResourceMap', () => {
   const mockRecResource = {
-    additional_fees: undefined,
-    closest_community: '',
-    description: undefined,
-    name: '',
-    rec_resource_type: '',
-    recreation_access: undefined,
-    recreation_activity: undefined,
-    recreation_campsite: undefined,
-    recreation_fee: undefined,
-    recreation_resource_images: undefined,
-    recreation_status: undefined,
-    recreation_structure: undefined,
     rec_resource_id: '123',
-    // Add other required properties
+    name: 'Test Resource',
+    site_point_geometry: {},
   } as any;
 
-  const mockFeatures = [{ id: 'feature1' }];
+  const mockFeatures = [
+    {
+      id: 'feature1',
+      clone: () => ({
+        id: 'feature1-clone',
+        setStyle: vi.fn(),
+        getGeometry: vi.fn(() => ({ getType: () => 'Point' })),
+      }),
+      setStyle: vi.fn(),
+    },
+  ];
   const mockLayerStyle = { color: 'red' };
   const mockMapStyles = { height: '100px' };
 
   beforeEach(() => {
     vi.clearAllMocks();
-    (getMapFeaturesFromRecResource as Mock).mockReturnValue(mockFeatures);
-    (getLayerStyleForRecResource as Mock).mockReturnValue(mockLayerStyle);
+    (getMapFeaturesFromRecResource as any).mockReturnValue(mockFeatures);
+    (getLayerStyleForRecResource as any).mockReturnValue(mockLayerStyle);
   });
 
-  it('renders StyledVectorFeatureMap with correct props when features exist', () => {
+  it('renders map and download buttons when features exist', () => {
     render(
       <RecreationResourceMap
         recResource={mockRecResource}
         mapComponentCssStyles={mockMapStyles}
       />,
     );
-
     expect(getMapFeaturesFromRecResource).toHaveBeenCalledWith(mockRecResource);
     expect(getLayerStyleForRecResource).toHaveBeenCalledWith(mockRecResource);
     expect(StyledVectorFeatureMap).toHaveBeenCalledWith(
-      {
-        mapComponentCssStyles: mockMapStyles,
+      expect.objectContaining({
         features: mockFeatures,
-        layerStyle: mockLayerStyle,
-      },
+        mapComponentCssStyles: mockMapStyles,
+      }),
       undefined,
     );
+    expect(
+      screen.getByRole('button', { name: /Download GPX/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /Download KML/i }),
+    ).toBeInTheDocument();
   });
 
-  it('returns null when no features exist', () => {
-    (getMapFeaturesFromRecResource as Mock).mockReturnValue([]);
-
+  it('returns null when features array is empty', () => {
+    (getMapFeaturesFromRecResource as any).mockReturnValue([]);
     const { container } = render(
       <RecreationResourceMap recResource={mockRecResource} />,
     );
-
     expect(container.firstChild).toBeNull();
   });
 
   it('returns null when features is undefined', () => {
-    (getMapFeaturesFromRecResource as Mock).mockReturnValue(undefined);
-
+    (getMapFeaturesFromRecResource as any).mockReturnValue(undefined);
     const { container } = render(
       <RecreationResourceMap recResource={mockRecResource} />,
     );
-
     expect(container.firstChild).toBeNull();
   });
 
-  it('memoizes features and layer style', () => {
+  it('memoizes helper calls on re-render with same recResource', () => {
     const { rerender } = render(
       <RecreationResourceMap recResource={mockRecResource} />,
     );
-
     expect(getMapFeaturesFromRecResource).toHaveBeenCalledTimes(1);
     expect(getLayerStyleForRecResource).toHaveBeenCalledTimes(1);
-
-    // Rerender with same props
     rerender(<RecreationResourceMap recResource={mockRecResource} />);
-
-    // Should not call the functions again due to memoization
     expect(getMapFeaturesFromRecResource).toHaveBeenCalledTimes(1);
     expect(getLayerStyleForRecResource).toHaveBeenCalledTimes(1);
   });
 
-  it('handles undefined recResource prop', () => {
+  it('handles undefined recResource prop correctly', () => {
     render(<RecreationResourceMap />);
-
     expect(getMapFeaturesFromRecResource).toHaveBeenCalledWith(undefined);
     expect(getLayerStyleForRecResource).toHaveBeenCalledWith(undefined);
+  });
+
+  it('calls downloadGPX with recResource.name if defined', () => {
+    render(
+      <RecreationResourceMap
+        recResource={{ ...mockRecResource, name: 'Special Name' }}
+        mapComponentCssStyles={mockMapStyles}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /Download GPX/i }));
+    expect(downloadGPX).toHaveBeenCalledWith(mockFeatures, 'Special Name');
+    expect(trackEvent).toHaveBeenCalledWith({
+      category: 'Map',
+      action: 'Download GPX',
+      name: 'Special Name-123-Download GPX',
+    });
+  });
+
+  it('calls downloadKML with recResource.name if defined', () => {
+    render(
+      <RecreationResourceMap
+        recResource={{ ...mockRecResource, name: 'Special Name' }}
+        mapComponentCssStyles={mockMapStyles}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /Download KML/i }));
+    expect(downloadKML).toHaveBeenCalledWith(mockFeatures, 'Special Name');
+    expect(trackEvent).toHaveBeenCalledWith({
+      category: 'Map',
+      action: 'Download KML',
+      name: 'Special Name-123-Download KML',
+    });
+  });
+
+  it('uses "map" as name if recResource.name is undefined', () => {
+    const resourceWithoutName = { ...mockRecResource, name: undefined };
+    render(
+      <RecreationResourceMap
+        recResource={resourceWithoutName}
+        mapComponentCssStyles={mockMapStyles}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /Download GPX/i }));
+    expect(downloadGPX).toHaveBeenCalledWith(mockFeatures, 'map');
+    expect(trackEvent).toHaveBeenCalledWith({
+      category: 'Map',
+      action: 'Download GPX',
+      name: 'map-123-Download GPX',
+    });
+    fireEvent.click(screen.getByRole('button', { name: /Download KML/i }));
+    expect(downloadKML).toHaveBeenCalledWith(mockFeatures, 'map');
+    expect(trackEvent).toHaveBeenCalledWith({
+      category: 'Map',
+      action: 'Download KML',
+      name: 'map-123-Download KML',
+    });
   });
 });

--- a/public/frontend/src/components/rec-resource/RecreationResourceMap/RecreationResourceMap.tsx
+++ b/public/frontend/src/components/rec-resource/RecreationResourceMap/RecreationResourceMap.tsx
@@ -1,39 +1,82 @@
 import { CSSProperties, useMemo } from 'react';
 import { StyledVectorFeatureMap } from '@/components/StyledVectorFeatureMap';
 import {
+  downloadGPX,
+  downloadKML,
   getLayerStyleForRecResource,
   getMapFeaturesFromRecResource,
 } from '@/components/rec-resource/RecreationResourceMap/helpers';
 import { RecreationResourceDetailModel } from '@/service/custom-models';
+import { Button, Col, Row, Stack } from 'react-bootstrap';
+import { trackEvent } from '@/utils/matomo';
+import { MATOMO_TRACKING_CATEGORY_MAP } from '@/components/rec-resource/RecreationResourceMap/constants';
 
 interface TrailMapProps {
   recResource?: RecreationResourceDetailModel;
   mapComponentCssStyles?: CSSProperties;
 }
 
+/**
+ * Displays a styled map for a given recreation resource, with options to download GPX/KML.
+ * Returns null if no features are available.
+ */
 export const RecreationResourceMap = ({
   recResource,
   mapComponentCssStyles,
 }: TrailMapProps) => {
-  const features = useMemo(
-    () => getMapFeaturesFromRecResource(recResource),
-    [recResource],
-  );
+  const styledFeatures = useMemo(() => {
+    const features = getMapFeaturesFromRecResource(recResource);
+    if (!features?.length) return [];
+    const layerStyle = getLayerStyleForRecResource(recResource);
+    return features.map((feature) => {
+      feature.setStyle(layerStyle);
+      return feature;
+    });
+  }, [recResource]);
 
-  const layerStyle = useMemo(
-    () => getLayerStyleForRecResource(recResource),
-    [recResource],
-  );
-
-  if (!features || !features.length) {
+  // Early return if there are no features to display or download
+  if (styledFeatures.length === 0) {
     return null;
   }
 
+  const recResourceName = recResource?.name || 'map';
+
+  const renderDownloadButton = (label: string, clickHandler: () => void) => {
+    const onClick = () => {
+      trackEvent({
+        category: MATOMO_TRACKING_CATEGORY_MAP,
+        action: label,
+        name: `${recResourceName}-${recResource?.rec_resource_id}-${label}`,
+      });
+      clickHandler();
+    };
+    return (
+      <Col xs={12} md="auto">
+        <Button
+          variant={'outline'}
+          onClick={onClick}
+          className="w-100 p-0 bc-color-blue-dk"
+        >
+          {label}
+        </Button>
+      </Col>
+    );
+  };
+
   return (
-    <StyledVectorFeatureMap
-      mapComponentCssStyles={mapComponentCssStyles}
-      features={features}
-      layerStyle={layerStyle}
-    />
+    <Stack direction="vertical" gap={3}>
+      <StyledVectorFeatureMap
+        mapComponentCssStyles={mapComponentCssStyles}
+        features={styledFeatures}
+      />
+      <Row className="g-md-5 g-2">
+        {renderDownloadButton('Download GPX', () =>
+          downloadGPX(styledFeatures, recResourceName),
+        )}
+        {renderDownloadButton('Download KML', () =>
+          downloadKML(styledFeatures, recResourceName),
+        )}
+      </Row>
+    </Stack>
   );
 };

--- a/public/frontend/src/components/rec-resource/RecreationResourceMap/constants.ts
+++ b/public/frontend/src/components/rec-resource/RecreationResourceMap/constants.ts
@@ -23,3 +23,5 @@ export const MAP_STYLES = {
     COLOR: FILL_COLOR,
   },
 };
+
+export const MATOMO_TRACKING_CATEGORY_MAP = 'Map';

--- a/public/frontend/src/components/rec-resource/RecreationResourceMap/helpers/index.ts
+++ b/public/frontend/src/components/rec-resource/RecreationResourceMap/helpers/index.ts
@@ -1,2 +1,3 @@
 export { getLayerStyleForRecResource } from './getLayerStyleForRecResource';
 export { getMapFeaturesFromRecResource } from './getMapFeaturesFromRecResource';
+export * from './mapDownloadHandlers';

--- a/public/frontend/src/components/rec-resource/RecreationResourceMap/helpers/mapDownloadHandlers.test.ts
+++ b/public/frontend/src/components/rec-resource/RecreationResourceMap/helpers/mapDownloadHandlers.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { downloadGPX, downloadKML } from './mapDownloadHandlers';
+import { GPX, KML } from 'ol/format';
+import { triggerFileDownload } from '@/utils/fileUtils';
+
+// Mock ol/format and ol/style modules
+vi.mock('ol/format', () => {
+  return {
+    GPX: vi.fn().mockImplementation(() => ({
+      writeFeatures: vi.fn().mockReturnValue('mockedGPX'),
+    })),
+    KML: vi.fn().mockImplementation(() => ({
+      writeFeatures: vi.fn().mockReturnValue('mockedKML'),
+    })),
+  };
+});
+vi.mock('ol/style', () => {
+  return {
+    Icon: vi.fn(),
+    Style: vi.fn(),
+  };
+});
+
+// Mock triggerFileDownload utility
+vi.mock('@/utils/fileUtils', () => ({
+  triggerFileDownload: vi.fn(),
+}));
+
+// Fallback for URL.createObjectURL in test envs
+if (!URL.createObjectURL) {
+  URL.createObjectURL = () => 'blob-url';
+}
+
+// Helper to create a fake Feature with proper typing
+function createFakeFeature(geometryType: string) {
+  return {
+    clone: vi.fn(function () {
+      // @ts-ignore
+      return this;
+    }),
+    getGeometry: vi.fn(() => ({
+      getType: () => geometryType,
+    })),
+    setStyle: vi.fn(),
+  } as any;
+}
+
+describe('downloadGPX', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should generate GPX data and trigger download', () => {
+    const feature = createFakeFeature('Point');
+    downloadGPX([feature], 'testName');
+    expect(GPX).toHaveBeenCalled();
+    expect((GPX as any).mock.results[0].value.writeFeatures).toHaveBeenCalled();
+    expect(triggerFileDownload).toHaveBeenCalledWith(
+      'mockedGPX',
+      'testName.gpx',
+      'application/gpx+xml',
+    );
+  });
+});
+
+describe('downloadKML', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should generate KML data for non-point geometries without setting style', () => {
+    const feature = createFakeFeature('LineString');
+    downloadKML([feature], 'nonPointTest');
+    expect(feature.setStyle).not.toHaveBeenCalled();
+    expect(KML).toHaveBeenCalled();
+    expect((KML as any).mock.results[0].value.writeFeatures).toHaveBeenCalled();
+    expect(triggerFileDownload).toHaveBeenCalledWith(
+      'mockedKML',
+      'nonPointTest.kml',
+      'application/vnd.google-earth.kml+xml',
+    );
+  });
+
+  it('should generate KML data for point geometries and set style', () => {
+    const feature = createFakeFeature('Point');
+    downloadKML([feature], 'pointTest');
+    expect(feature.setStyle).toHaveBeenCalled();
+    expect(KML).toHaveBeenCalled();
+    expect((KML as any).mock.results[0].value.writeFeatures).toHaveBeenCalled();
+    expect(triggerFileDownload).toHaveBeenCalledWith(
+      'mockedKML',
+      'pointTest.kml',
+      'application/vnd.google-earth.kml+xml',
+    );
+  });
+});

--- a/public/frontend/src/components/rec-resource/RecreationResourceMap/helpers/mapDownloadHandlers.ts
+++ b/public/frontend/src/components/rec-resource/RecreationResourceMap/helpers/mapDownloadHandlers.ts
@@ -1,0 +1,55 @@
+import { GPX, KML } from 'ol/format';
+import { Feature } from 'ol';
+import { Icon, Style } from 'ol/style';
+import {
+  MAP_PROJECTION_WEB_MERCATOR,
+  MAP_PROJECTION_WGS84,
+} from '@/components/StyledVectorFeatureMap/constants';
+import { triggerFileDownload } from '@/utils/fileUtils';
+
+// Import raw SVG content for KML export
+import locationDotSVGRaw from '@/images/icons/location-dot-bc-color-blue-med.svg?raw';
+
+export function downloadGPX(features: Feature[], fileName: string) {
+  const gpxFormat = new GPX();
+  const gpxXml = gpxFormat.writeFeatures(features, {
+    featureProjection: MAP_PROJECTION_WEB_MERCATOR,
+    dataProjection: MAP_PROJECTION_WGS84,
+  });
+  triggerFileDownload(gpxXml, `${fileName}.gpx`, 'application/gpx+xml');
+}
+
+export function downloadKML(features: Feature[], fileName: string) {
+  // Clone features so original styles are not mutated
+  const clonedFeatures = features.map((feature) => feature.clone());
+
+  clonedFeatures.forEach((feature) => {
+    const geometry = feature.getGeometry();
+
+    // For point geometries, use base64-encoded SVG icon
+    if (geometry?.getType() === 'Point') {
+      feature.setStyle(
+        new Style({
+          image: new Icon({
+            src: `data:image/svg+xml;base64,${btoa(locationDotSVGRaw)}`,
+            scale: 0.5,
+          }),
+        }),
+      );
+    }
+  });
+
+  const kmlFormat = new KML({
+    extractStyles: true,
+    writeStyles: true,
+  });
+  const kmlXml = kmlFormat.writeFeatures(clonedFeatures, {
+    featureProjection: MAP_PROJECTION_WEB_MERCATOR,
+    dataProjection: MAP_PROJECTION_WGS84,
+  });
+  triggerFileDownload(
+    kmlXml,
+    `${fileName}.kml`,
+    'application/vnd.google-earth.kml+xml',
+  );
+}

--- a/public/frontend/src/components/rec-resource/section/MapsAndLocation.test.tsx
+++ b/public/frontend/src/components/rec-resource/section/MapsAndLocation.test.tsx
@@ -3,13 +3,13 @@ import { render, screen } from '@testing-library/react';
 import MapsAndLocation from './MapsAndLocation';
 import { RecreationResourceMap } from '@/components/rec-resource/RecreationResourceMap';
 import { RecreationResourceDocsList } from '@/components/rec-resource/RecreationResourceDocsList';
+import parse from 'html-react-parser';
 
-// Mock the RecreationResourceMap component
+// Mocks
 vi.mock('@/components/rec-resource/RecreationResourceMap', () => ({
-  RecreationResourceMap: vi.fn(() => null),
+  RecreationResourceMap: vi.fn(() => <div data-testid="vector-map" />),
 }));
 
-// Mock the RecreationResourceDocsList component
 vi.mock('@/components/rec-resource/RecreationResourceDocsList', () => ({
   RecreationResourceDocsList: vi.fn(() => <div data-testid="docs-list" />),
 }));
@@ -24,100 +24,114 @@ describe('MapsAndLocation', () => {
     name: 'Test Resource',
     latitude: 47.6062,
     longitude: -122.3321,
-    driving_directions: 'driving directions',
+    driving_directions: 'Drive straight and turn left',
   } as any;
+
+  const mockRecResourceWithDocs = {
+    ...mockRecResource,
+    recreation_resource_docs: [{ id: 'doc1' }],
+  };
 
   const mockAccessTypes = ['Drive-up', 'Walk-in'];
 
-  it('renders the component with all props', () => {
+  it('renders section with proper id and heading', () => {
     render(
       <MapsAndLocation
         recResource={mockRecResource}
         accessTypes={mockAccessTypes}
       />,
     );
-
-    // Check if main section elements are present
     expect(
       screen.getByRole('heading', { name: /maps and location/i }),
     ).toBeInTheDocument();
-    expect(
-      screen.getByRole('heading', { name: /access types/i }),
-    ).toBeInTheDocument();
+    expect(document.getElementById('maps-and-location')).toBeInTheDocument();
+  });
 
-    // Check if access types are rendered
-    mockAccessTypes.forEach((type) => {
-      expect(screen.getByText(type)).toBeInTheDocument();
-    });
-
-    // Verify map component is rendered with correct props
+  it('renders RecreationResourceMap with correct props', () => {
+    render(<MapsAndLocation recResource={mockRecResource} />);
     expect(RecreationResourceMap).toHaveBeenCalledWith(
       expect.objectContaining({
         recResource: mockRecResource,
-        mapComponentCssStyles: {
-          position: 'relative',
-          height: '40vh',
-          marginBottom: '4rem',
-        },
+        mapComponentCssStyles: { position: 'relative', height: '40vh' },
       }),
       undefined,
     );
+    expect(screen.getByTestId('vector-map')).toBeInTheDocument();
   });
 
-  it('renders without access types', () => {
-    render(<MapsAndLocation recResource={mockRecResource} />);
-
+  it('renders access types list when provided', () => {
+    render(
+      <MapsAndLocation
+        recResource={mockRecResource}
+        accessTypes={mockAccessTypes}
+      />,
+    );
     expect(
-      screen.getByRole('heading', { name: /maps and location/i }),
+      screen.getByRole('heading', { name: /access types/i }),
     ).toBeInTheDocument();
-    expect(
-      screen.queryByRole('heading', { name: /access types?/i }),
-    ).not.toBeInTheDocument();
+    mockAccessTypes.forEach((type) => {
+      expect(screen.getByText(type)).toBeInTheDocument();
+    });
   });
 
-  it('renders singular "Access Type" when only one type provided', () => {
+  it('renders singular "Access Type" heading when only one access type provided', () => {
     render(
       <MapsAndLocation
         recResource={mockRecResource}
         accessTypes={['Drive-up']}
       />,
     );
-
     expect(
-      screen.getByRole('heading', { name: /access type$/i }),
+      screen.getByRole('heading', { name: /^access type$/i }),
     ).toBeInTheDocument();
   });
 
-  it('forwards ref correctly', () => {
-    const ref = { current: null };
-    render(
-      <MapsAndLocation
-        ref={ref}
-        recResource={mockRecResource}
-        accessTypes={mockAccessTypes}
-      />,
-    );
+  it('does not render access types section when accessTypes prop is missing or empty', () => {
+    render(<MapsAndLocation recResource={mockRecResource} />);
+    expect(screen.queryByRole('heading', { name: /access types/i })).toBeNull();
 
-    expect(ref.current).toBeInstanceOf(HTMLElement);
+    render(<MapsAndLocation recResource={mockRecResource} accessTypes={[]} />);
+    expect(screen.queryByRole('heading', { name: /access types/i })).toBeNull();
   });
 
-  describe('RecreationResourceDocsList visibility', () => {
-    it('renders and configures docs list when recResource exists', () => {
-      render(<MapsAndLocation recResource={mockRecResource} />);
+  it('renders "Getting there" section when driving_directions is provided', () => {
+    render(<MapsAndLocation recResource={mockRecResource} />);
+    expect(
+      screen.getByRole('heading', { name: /getting there/i }),
+    ).toBeInTheDocument();
+    // Verify that the driving directions text is parsed and rendered
+    expect(
+      screen.getByText(parse(mockRecResource.driving_directions).toString()),
+    ).toBeInTheDocument();
+  });
 
-      const docsList = screen.getByTestId('docs-list');
-      expect(docsList).toBeInTheDocument();
+  it('does not render "Getting there" section when driving_directions is not provided', () => {
+    const recResourceNoDirections = {
+      ...mockRecResource,
+      driving_directions: undefined,
+    };
+    render(<MapsAndLocation recResource={recResourceNoDirections} />);
+    expect(
+      screen.queryByRole('heading', { name: /getting there/i }),
+    ).toBeNull();
+  });
+
+  describe('RecreationResourceDocsList', () => {
+    it('renders docs list when recResource has recreation_resource_docs', () => {
+      render(<MapsAndLocation recResource={mockRecResourceWithDocs} />);
+      expect(screen.getByTestId('docs-list')).toBeInTheDocument();
       expect(RecreationResourceDocsList).toHaveBeenCalledWith(
-        { recResource: mockRecResource },
+        { recResource: mockRecResourceWithDocs },
         undefined,
       );
     });
 
-    it('does not render docs list without recResource', () => {
-      render(<MapsAndLocation />);
-
+    it('does not render docs list when recResource is undefined or missing docs', () => {
+      render(<MapsAndLocation recResource={mockRecResource} />);
       expect(screen.queryByTestId('docs-list')).toBeNull();
-      expect(RecreationResourceDocsList).not.toHaveBeenCalled();
+
+      render(<MapsAndLocation />);
+      expect(screen.queryByTestId('docs-list')).toBeNull();
     });
   });
 });

--- a/public/frontend/src/components/rec-resource/section/MapsAndLocation.tsx
+++ b/public/frontend/src/components/rec-resource/section/MapsAndLocation.tsx
@@ -4,6 +4,7 @@ import { RecreationResourceMap } from '@/components/rec-resource/RecreationResou
 import { RecreationResourceDetailModel } from '@/service/custom-models';
 import { RecreationResourceDocsList } from '@/components/rec-resource/RecreationResourceDocsList';
 import { SectionIds, SectionTitles } from '@/components/rec-resource/enum';
+import { Stack } from 'react-bootstrap';
 
 interface MapsAndLocationProps {
   accessTypes?: string[];
@@ -13,6 +14,8 @@ interface MapsAndLocationProps {
 const MapsAndLocation = forwardRef<HTMLElement, MapsAndLocationProps>(
   ({ accessTypes, recResource }, ref) => {
     const { driving_directions } = recResource || {};
+    const showDocsList =
+      recResource && Boolean(recResource.recreation_resource_docs?.length);
     return (
       <section
         id={SectionIds.MAPS_AND_LOCATION}
@@ -21,38 +24,39 @@ const MapsAndLocation = forwardRef<HTMLElement, MapsAndLocationProps>(
       >
         <h2 className="section-heading">{SectionTitles.MAPS_AND_LOCATION}</h2>
 
-        {recResource && (
-          <section className="mb-4">
-            <RecreationResourceDocsList recResource={recResource} />
-          </section>
-        )}
+        <Stack gap={5} direction="vertical">
+          {showDocsList && (
+            <div>
+              <RecreationResourceDocsList recResource={recResource} />
+            </div>
+          )}
 
-        <RecreationResourceMap
-          recResource={recResource}
-          mapComponentCssStyles={{
-            position: 'relative',
-            height: '40vh',
-            marginBottom: '4rem',
-          }}
-        />
+          <RecreationResourceMap
+            recResource={recResource}
+            mapComponentCssStyles={{
+              position: 'relative',
+              height: '40vh',
+            }}
+          />
 
-        {driving_directions && (
-          <article className="mb-4">
-            <h3>Getting there</h3>
-            <p>{parse(driving_directions)}</p>
-          </article>
-        )}
+          {driving_directions && (
+            <article>
+              <h3>Getting there</h3>
+              <p className="mb-0">{parse(driving_directions)}</p>
+            </article>
+          )}
 
-        {accessTypes && accessTypes?.length > 0 && (
-          <section className="mb-4">
-            <h3>Access type{accessTypes.length > 1 && 's'}</h3>
-            <ul className="list-unstyled">
-              {accessTypes.map((type) => (
-                <li key={type}>{type}</li>
-              ))}
-            </ul>
-          </section>
-        )}
+          {accessTypes && accessTypes?.length > 0 && (
+            <article>
+              <h3>Access type{accessTypes.length > 1 && 's'}</h3>
+              <ul className="list-unstyled">
+                {accessTypes.map((type) => (
+                  <li key={type}>{type}</li>
+                ))}
+              </ul>
+            </article>
+          )}
+        </Stack>
       </section>
     );
   },

--- a/public/frontend/src/utils/fileUtils.test.ts
+++ b/public/frontend/src/utils/fileUtils.test.ts
@@ -1,0 +1,84 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  MockInstance,
+  vi,
+} from 'vitest';
+import { triggerFileDownload } from './fileUtils';
+
+describe('triggerFileDownload', () => {
+  const originalCreateObjectURL = URL.createObjectURL;
+  const originalRevokeObjectURL = URL.revokeObjectURL;
+  let createElementSpy: MockInstance;
+  let appendChildSpy: MockInstance;
+  let removeChildSpy: MockInstance;
+  let clickSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    // Mock URL.createObjectURL and revokeObjectURL
+    URL.createObjectURL = vi.fn(() => 'blob:url');
+    URL.revokeObjectURL = vi.fn();
+
+    // Mock document.createElement and DOM manipulation
+    clickSpy = vi.fn();
+    createElementSpy = vi
+      .spyOn(document, 'createElement')
+      .mockImplementation(() => {
+        return {
+          set href(val: string) {},
+          set download(val: string) {},
+          click: clickSpy,
+        } as unknown as HTMLAnchorElement;
+      });
+    appendChildSpy = vi
+      .spyOn(document.body, 'appendChild')
+      .mockImplementation((): any => {});
+    removeChildSpy = vi
+      .spyOn(document.body, 'removeChild')
+      .mockImplementation((): any => {});
+  });
+
+  afterEach(() => {
+    // Restore all mocks
+    URL.createObjectURL = originalCreateObjectURL;
+    URL.revokeObjectURL = originalRevokeObjectURL;
+    createElementSpy.mockRestore();
+    appendChildSpy.mockRestore();
+    removeChildSpy.mockRestore();
+  });
+
+  it('should trigger a file download with correct parameters', () => {
+    triggerFileDownload('test-content', 'test.txt', 'text/plain');
+
+    expect(createElementSpy).toHaveBeenCalledWith('a');
+    expect(appendChildSpy).toHaveBeenCalled();
+    expect(clickSpy).toHaveBeenCalled();
+    expect(removeChildSpy).toHaveBeenCalled();
+    expect(URL.createObjectURL).toHaveBeenCalled();
+    expect(URL.revokeObjectURL).toHaveBeenCalled();
+  });
+
+  it('should handle errors gracefully', () => {
+    // Force Blob constructor to throw
+    const originalBlob = globalThis.Blob;
+    globalThis.Blob = vi.fn(() => {
+      throw new Error('Blob error');
+    }) as any;
+
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    triggerFileDownload('bad-content', 'bad.txt', 'text/plain');
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      'Download failed:',
+      expect.any(Error),
+    );
+
+    // Restore Blob and error spy
+    globalThis.Blob = originalBlob;
+    errorSpy.mockRestore();
+  });
+});

--- a/public/frontend/src/utils/fileUtils.ts
+++ b/public/frontend/src/utils/fileUtils.ts
@@ -1,0 +1,26 @@
+/**
+ * Triggers a file download in the browser for the given content.
+ *
+ * @param content - The file content as a string.
+ * @param fileName - The name for the downloaded file.
+ * @param mimeType - The MIME type of the file.
+ */
+export function triggerFileDownload(
+  content: string,
+  fileName: string,
+  mimeType: string,
+) {
+  try {
+    const blob = new Blob([content], { type: mimeType });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = fileName;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+  } catch (error) {
+    console.error('Download failed:', error);
+  }
+}


### PR DESCRIPTION
# Description
- add kml and gpx download functionality for the rec resource map
- removed zoom animation on the map

# Screenshots

<img width="1784" alt="image" src="https://github.com/user-attachments/assets/24aaaee2-a3cc-4837-9008-f9d8fde0f339" />

---
<img width="2438" alt="image" src="https://github.com/user-attachments/assets/b518d3f9-856c-4489-8c3c-295b9507d5c2" />
