### PR TITLE
chore: remove bcgov-nr references

### DIFF
--- a/.github/workflows/.build.yml
+++ b/.github/workflows/.build.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
 
 jobs:
-  # https://github.com/bcgov-nr/action-builder-ghcr
+  # https://github.com/bcgov/action-builder-ghcr
   build-containers:
     name: Builds
     runs-on: ubuntu-24.04
@@ -14,7 +14,7 @@ jobs:
         package: ['admin/backend', 'admin/frontend', 'migrations/rst', 'migrations/fta', 'public/backend', 'public/frontend']
     timeout-minutes: 10
     steps:
-      - uses: bcgov-nr/action-builder-ghcr@d63c76a4bb7914d3a986a035904b49d99c2c4613 # v3.0.0
+      - uses: bcgov/action-builder-ghcr@v3.0.1
         with:
           package: ${{ matrix.package }}
           tags: ${{ github.sha }}

--- a/.github/workflows/.tests.yml
+++ b/.github/workflows/.tests.yml
@@ -38,7 +38,7 @@ jobs:
 
 
     steps:
-      - uses: bcgov-nr/action-test-and-analyse@v1.3.0
+      - uses: bcgov/action-test-and-analyse@v1.3.0
         with:
           commands: |
             npm ci

--- a/.github/workflows/build-deploy-el-openshift.yml
+++ b/.github/workflows/build-deploy-el-openshift.yml
@@ -53,7 +53,7 @@ jobs:
             build_context: ./backend-el
     timeout-minutes: 10
     steps:
-      - uses: bcgov/action-builder-ghcr@d63c76a4bb7914d3a986a035904b49d99c2c4613 # v3.0.0
+      - uses: bcgov/action-builder-ghcr@v3.0.1
         with:
           package: ${{ matrix.package }}
           tags: ${{ github.sha }}
@@ -68,7 +68,7 @@ jobs:
     steps:
       - name: Helm Deploy
         id: deploy
-        uses: bcgov/action-oc-runner@v1.2.0
+        uses: bcgov/action-oc-runner@v1.2.2
         env:
           DB_PASSWORD: ${{ secrets.DBPASSWORD }} # handle special characters.
         with:


### PR DESCRIPTION
This PR removes `bcgov-nr` references for reusable GHA as the org is deprecated and all actions are now moved under `bcgov`
