### PR TITLE
fix: always show card carousel navigation buttons on mobile

### DIFF
--- a/public/frontend/src/components/rec-resource/card/RecResourceCard.scss
+++ b/public/frontend/src/components/rec-resource/card/RecResourceCard.scss
@@ -81,12 +81,26 @@
     height: 200px;
     width: 250px;
   }
-}
 
-.card-carousel {
-  min-height: 190px;
-  max-height: 280px;
-  overflow: hidden;
+  .card-carousel {
+    min-height: 190px;
+    max-height: 280px;
+    overflow: hidden;
+
+    .nav-icon {
+      display: block;
+      font-size: 1.5rem;
+      color: $white;
+
+      @include media-breakpoint-up(sm) {
+        display: none;
+      }
+    }
+
+    &:hover .nav-icon {
+      display: block;
+    }
+  }
 }
 
 .carousel-desktop-image {
@@ -98,6 +112,13 @@
   }
 }
 
+.carousel .carousel-indicators button {
+  border: none;
+  border-radius: 6px;
+  height: 6px;
+  width: 6px;
+}
+
 .carousel-mobile-image {
   display: block;
   min-width: 100%;
@@ -107,21 +128,4 @@
   @include media-breakpoint-up(sm) {
     display: none;
   }
-}
-
-.carousel .carousel-indicators button {
-  border: none;
-  border-radius: 6px;
-  height: 6px;
-  width: 6px;
-}
-
-.nav-icon {
-  font-size: 1.5rem;
-  display: none;
-  color: $white;
-}
-
-.card-carousel:hover .nav-icon {
-  display: block;
 }


### PR DESCRIPTION
#821
Always show navigation buttons on mobile:
<img width="241" alt="Screenshot 2025-06-24 at 9 36 59 AM" src="https://github.com/user-attachments/assets/0a9df6ef-e1f5-47fb-b4b3-20eaa4fe6a4f" />

Desktop remains the same, need to hover to show them:
<img width="798" alt="Screenshot 2025-06-24 at 9 37 13 AM" src="https://github.com/user-attachments/assets/a4469404-541a-40ab-bc5a-bb7324019d48" />
