### PR TITLE
ci(security-csp): added dam urls to csp policy

### DIFF
--- a/.github/workflows/.deploy-app.yml
+++ b/.github/workflows/.deploy-app.yml
@@ -100,7 +100,7 @@ jobs:
         working-directory: ${{ inputs.app }}/frontend
         env:
           app: ${{ inputs.app }}
-          VITE_RECREATION_RESOURCE_ASSETS_BASE_URL: "https://dam.lqc63d-prod.nimbus.cloud.gov.bc.ca"
+          VITE_RECREATION_RESOURCE_ASSETS_BASE_URL: ${{ secrets.VITE_RECREATION_RESOURCE_ASSETS_BASE_URL }}
           VITE_API_BASE_URL: ${{ needs.deploy-api.outputs.API_GW_URL }}/api
           VITE_MATOMO_URL: ${{ secrets.VITE_MATOMO_URL }}
           VITE_MATOMO_SITE_ID: ${{ secrets.VITE_MATOMO_SITE_ID }}

--- a/terraform/frontend/admin-dev/terragrunt.hcl
+++ b/terraform/frontend/admin-dev/terragrunt.hcl
@@ -10,8 +10,9 @@ generate "dev_tfvars" {
   contents          = <<-EOF
   target_env = "dev"
   csp_urls = {
-      image_src = "https://dam.lqc63d-prod.nimbus.cloud.gov.bc.ca"
-      matomo_src = "https://iuqxrr50zl.execute-api.ca-central-1.amazonaws.com"
+    image_src = "https://dam.lqc63d-test.nimbus.cloud.gov.bc.ca"
+    connect_src = "https://dam.lqc63d-test.nimbus.cloud.gov.bc.ca"
+    matomo_src = "https://iuqxrr50zl.execute-api.ca-central-1.amazonaws.com"
   }
 EOF
 }

--- a/terraform/frontend/admin-prod/terragrunt.hcl
+++ b/terraform/frontend/admin-prod/terragrunt.hcl
@@ -11,6 +11,7 @@ generate "prod_tfvars" {
   target_env = "prod"
   csp_urls = {
       image_src = "https://dam.lqc63d-prod.nimbus.cloud.gov.bc.ca"
+      connect_src = "https://dam.lqc63d-prod.nimbus.cloud.gov.bc.ca"
       matomo_src = "https://iuqxrr50zl.execute-api.ca-central-1.amazonaws.com"
   }
 EOF

--- a/terraform/frontend/admin-test/terragrunt.hcl
+++ b/terraform/frontend/admin-test/terragrunt.hcl
@@ -10,7 +10,8 @@ generate "test_tfvars" {
   contents          = <<-EOF
   target_env = "test"
   csp_urls = {
-      image_src = "https://dam.lqc63d-prod.nimbus.cloud.gov.bc.ca"
+      image_src = "https://dam.lqc63d-test.nimbus.cloud.gov.bc.ca"
+      connect_src = "https://dam.lqc63d-test.nimbus.cloud.gov.bc.ca"
       matomo_src = "https://iuqxrr50zl.execute-api.ca-central-1.amazonaws.com"
   }
 EOF

--- a/terraform/frontend/public-dev/terragrunt.hcl
+++ b/terraform/frontend/public-dev/terragrunt.hcl
@@ -10,8 +10,8 @@ generate "dev_tfvars" {
   contents          = <<-EOF
   target_env = "dev"
   csp_urls = {
-    image_src = "https://dam.lqc63d-prod.nimbus.cloud.gov.bc.ca"
-    connect_src = "https://bcparks.api.gov.bc.ca"
+    image_src = "https://dam.lqc63d-test.nimbus.cloud.gov.bc.ca"
+    connect_src = "https://dam.lqc63d-test.nimbus.cloud.gov.bc.ca https://bcparks.api.gov.bc.ca"
     matomo_src = "https://iuqxrr50zl.execute-api.ca-central-1.amazonaws.com"
   }
 EOF

--- a/terraform/frontend/public-prod/terragrunt.hcl
+++ b/terraform/frontend/public-prod/terragrunt.hcl
@@ -11,7 +11,7 @@ generate "prod_tfvars" {
   target_env = "prod"
   csp_urls = {
       image_src = "https://dam.lqc63d-prod.nimbus.cloud.gov.bc.ca https://beta.sitesandtrailsbc.ca https://sitesandtrailsbc.ca"
-      connect_src = "https://bcparks.api.gov.bc.ca"
+      connect_src = "https://dam.lqc63d-prod.nimbus.cloud.gov.bc.ca https://bcparks.api.gov.bc.ca"
       matomo_src = "https://iuqxrr50zl.execute-api.ca-central-1.amazonaws.com"
     }
 EOF

--- a/terraform/frontend/public-test/terragrunt.hcl
+++ b/terraform/frontend/public-test/terragrunt.hcl
@@ -10,8 +10,8 @@ generate "test_tfvars" {
   contents          = <<-EOF
   target_env = "test"
   csp_urls = {
-    image_src = "https://dam.lqc63d-prod.nimbus.cloud.gov.bc.ca"
-    connect_src = "https://bcparks.api.gov.bc.ca"
+    image_src = "https://dam.lqc63d-test.nimbus.cloud.gov.bc.ca"
+    connect_src = "https://dam.lqc63d-test.nimbus.cloud.gov.bc.ca https://bcparks.api.gov.bc.ca"
     matomo_src = "https://iuqxrr50zl.execute-api.ca-central-1.amazonaws.com"
   }
 EOF


### PR DESCRIPTION
# Description

- Added DAM test and prod urls to the Content Security Policies for the respective environment
- Added the DAM url as repository secret in Github
    
    ```
    gh secret set VITE_RECREATION_RESOURCE_ASSETS_BASE_URL --body="https://dam.lqc63d-test.nimbus.cloud.gov.bc.ca" --env test
    
    gh secret set VITE_RECREATION_RESOURCE_ASSETS_BASE_URL --body="https://dam.lqc63d-test.nimbus.cloud.gov.bc.ca" --env dev
    
    gh secret set VITE_RECREATION_RESOURCE_ASSETS_BASE_URL --body="https://dam.lqc63d-prod.nimbus.cloud.gov.bc.ca" --env prod
    ```