### PR TITLE
fix(csp): use full domain name instead of wild cards

### DIFF
--- a/terraform/frontend/admin-dev/terragrunt.hcl
+++ b/terraform/frontend/admin-dev/terragrunt.hcl
@@ -10,8 +10,8 @@ generate "dev_tfvars" {
   contents          = <<-EOF
   target_env = "dev"
   csp_urls = {
-    image_src = "https://dam.lqc63d-*.nimbus.cloud.gov.bc.ca"
-    connect_src = "https://dam.lqc63d-*.nimbus.cloud.gov.bc.ca"
+    image_src = "https://dam.lqc63d-test.nimbus.cloud.gov.bc.ca https://dam.lqc63d-prod.nimbus.cloud.gov.bc.ca"
+    connect_src = "https://dam.lqc63d-test.nimbus.cloud.gov.bc.ca https://dam.lqc63d-prod.nimbus.cloud.gov.bc.ca"
     matomo_src = "https://iuqxrr50zl.execute-api.ca-central-1.amazonaws.com"
   }
 EOF

--- a/terraform/frontend/admin-test/terragrunt.hcl
+++ b/terraform/frontend/admin-test/terragrunt.hcl
@@ -10,8 +10,8 @@ generate "test_tfvars" {
   contents          = <<-EOF
   target_env = "test"
   csp_urls = {
-      image_src = "https://dam.lqc63d-*.nimbus.cloud.gov.bc.ca"
-      connect_src = "https://dam.lqc63d-*.nimbus.cloud.gov.bc.ca"
+      image_src = "https://dam.lqc63d-test.nimbus.cloud.gov.bc.ca https://dam.lqc63d-prod.nimbus.cloud.gov.bc.ca"
+      connect_src = "https://dam.lqc63d-test.nimbus.cloud.gov.bc.ca https://dam.lqc63d-prod.nimbus.cloud.gov.bc.ca"
       matomo_src = "https://iuqxrr50zl.execute-api.ca-central-1.amazonaws.com"
   }
 EOF

--- a/terraform/frontend/public-dev/terragrunt.hcl
+++ b/terraform/frontend/public-dev/terragrunt.hcl
@@ -10,8 +10,8 @@ generate "dev_tfvars" {
   contents          = <<-EOF
   target_env = "dev"
   csp_urls = {
-    image_src = "https://dam.lqc63d-*.nimbus.cloud.gov.bc.ca"
-    connect_src = "https://dam.lqc63d-*.nimbus.cloud.gov.bc.ca https://bcparks.api.gov.bc.ca"
+    image_src = "https://dam.lqc63d-test.nimbus.cloud.gov.bc.ca https://dam.lqc63d-prod.nimbus.cloud.gov.bc.ca"
+    connect_src = "https://dam.lqc63d-test.nimbus.cloud.gov.bc.ca https://dam.lqc63d-prod.nimbus.cloud.gov.bc.ca https://bcparks.api.gov.bc.ca"
     matomo_src = "https://iuqxrr50zl.execute-api.ca-central-1.amazonaws.com"
   }
 EOF

--- a/terraform/frontend/public-test/terragrunt.hcl
+++ b/terraform/frontend/public-test/terragrunt.hcl
@@ -10,8 +10,8 @@ generate "test_tfvars" {
   contents          = <<-EOF
   target_env = "test"
   csp_urls = {
-    image_src = "https://dam.lqc63d-*.nimbus.cloud.gov.bc.ca"
-    connect_src = "https://dam.lqc63d-*.nimbus.cloud.gov.bc.ca https://bcparks.api.gov.bc.ca"
+    image_src = "https://dam.lqc63d-test.nimbus.cloud.gov.bc.ca https://dam.lqc63d-prod.nimbus.cloud.gov.bc.ca"
+    connect_src = "https://dam.lqc63d-test.nimbus.cloud.gov.bc.ca https://dam.lqc63d-prod.nimbus.cloud.gov.bc.ca https://bcparks.api.gov.bc.ca"
     matomo_src = "https://iuqxrr50zl.execute-api.ca-central-1.amazonaws.com"
   }
 EOF


### PR DESCRIPTION
# Description
full domain names are required for csp to work properly. the wildcard used in the previous PR was incorrect.