### PR TITLE
ci: separate admin and public deployment review environments

### DIFF
--- a/.github/workflows/.review-and-deploy.yml
+++ b/.github/workflows/.review-and-deploy.yml
@@ -42,10 +42,10 @@ jobs:
 
   # Separate review job since we can't use GitHub environments in reusable workflows
   review-test-deployment:
-    name: Review Test Deployment
+    name: Review ${{ inputs.app }} test deployment
     needs: tests-e2e-dev-environment
     runs-on: ubuntu-24.04
-    environment: review-test-deployment
+    environment: review-${{ inputs.app}}-test-deployment
     steps:
       - name: Review Test Deployment
         run: echo "Reviewing Test Deployment"
@@ -95,10 +95,10 @@ jobs:
 
   # Separate review job since we can't use GitHub environments in reusable workflows
   review-prod-deployment:
-    name: Review Prod Deployment
+    name: Review ${{ inputs.app }} prod deployment
     needs: tests-e2e-test-environment
     runs-on: ubuntu-24.04
-    environment: review-prod-deployment
+    environment: review-${{inputs.app}}-prod-deployment
     steps:
       - name: Review Prod Deployment
         run: echo "Reviewing Prod Deployment"


### PR DESCRIPTION
[#1055](https://github.com/bcgov/nr-rec-resources/issues/1055)

<img width="679" height="492" alt="Screenshot 2025-07-29 at 9 13 21 AM" src="https://github.com/user-attachments/assets/71e3dca2-f450-4c39-bb69-c2ebd8716417" />


Create 4 new GitHub environments for reviewing deployments:
- `review-admin-test-deployment`
- `review-admin-prod-deployment`
- `review-public-test-deployment`
- `review-public-prod-deployment`

TODO after merge:
- delete `review-test-deployment` and `review-prod-deployment` environments
