### PR TITLE
ci: add cache-control headers during cloudfront s3 sync

### DIFF
--- a/.github/workflows/.deploy-app.yml
+++ b/.github/workflows/.deploy-app.yml
@@ -111,10 +111,17 @@ jobs:
           VITE_KEYCLOAK_CLIENT_ID: ${{ secrets.KEYCLOAK_CLIENT_ID }}
         run: |
           echo "VITE_RECREATION_RESOURCE_ASSETS_BASE_URL: $VITE_RECREATION_RESOURCE_ASSETS_BASE_URL"
+          BUCKET=$(echo "$S3_BUCKET_ARN" | cut -d: -f6)
           cd shared && npm ci
           cd ../${app}/frontend
           npm run deploy
-          aws s3 sync --delete ./dist s3://$(echo "$S3_BUCKET_ARN" | cut -d: -f6)
+          aws s3 cp ./dist/index.html s3://$BUCKET/index.html \
+            --cache-control "no-cache, must-revalidate" \
+            --content-type "text/html"
+          aws s3 sync ./dist s3://$BUCKET \
+            --exclude "index.html" \
+            --cache-control "public, max-age=31536000, immutable" \
+            --delete
           aws cloudfront create-invalidation --distribution-id $CF_DISTRIBUTION_ID --paths "/*"
   fta-migration:
     name: FTA migration


### PR DESCRIPTION
Separate upload of `index.html` and add `no-cache, must-revalidate` cache control headers to that file to hopefully mitigate the issue Airlia ran into after prod deployment.

using `no-cache` instead of `no-store` as it is less strict - it still allows the browser to temporarily cache but we force the browser to revalidate before using it.

Vite hashes all the asset names so we should be good to cache everything else.

<img width="577" height="329" alt="Screenshot 2025-07-30 at 9 04 52 AM" src="https://github.com/user-attachments/assets/260dc99e-7ae1-4b7c-8ac6-26219f9d3f66" />


<img width="532" height="90" alt="Screenshot 2025-07-30 at 8 57 39 AM" src="https://github.com/user-attachments/assets/4c76a0e8-f7f9-49cb-adbb-cffe2153cca8" />
