### PR TITLE
fix: search typeahead form mobile styles

### DIFF
--- a/admin/frontend/src/components/rec-resource-suggestion-form/SuggestionListItem.tsx
+++ b/admin/frontend/src/components/rec-resource-suggestion-form/SuggestionListItem.tsx
@@ -49,26 +49,21 @@ export const SuggestionListItem: FC<SearchItemData> = ({
           </div>
         </Col>
 
-        {/* Middle Section (Desktop/Tablet) */}
-        <Col className="desktop-col">
-          <span className="rec-name">
-            <Highlighter search={searchTerm}>{title}</Highlighter>
+        {/* Combined Middle Section */}
+        <Col className="content-col d-flex flex-column">
+          <span className="rec-name mb-1 capitalize">
+            <Highlighter search={searchTerm}>{title.toLowerCase()}</Highlighter>
           </span>
-          <div className="description-text">
+
+          {/* Desktop / Tablet description */}
+          <div className="description-text d-none d-sm-block">
             {resourceType} &bull; {district}
           </div>
-        </Col>
 
-        {/* Middle Section (Mobile) */}
-        <Col className="mobile-col">
-          <div className="mobile-inner">
-            <span className="rec-name mb-1">
-              <Highlighter search={searchTerm}>{title}</Highlighter>
-            </span>
-            <Badge className="rec-id-badge px-3 py-2 rounded-pill align-self-start">
-              {rec_resource_id}
-            </Badge>
-          </div>
+          {/* Mobile badge */}
+          <Badge className="rec-id-badge px-3 py-2 rounded-pill align-self-start d-sm-none">
+            {rec_resource_id}
+          </Badge>
         </Col>
 
         {/* Right Section (Desktop/Tablet) */}

--- a/admin/frontend/test/components/rec-resource-suggestion-form/SuggestionListItem.test.tsx
+++ b/admin/frontend/test/components/rec-resource-suggestion-form/SuggestionListItem.test.tsx
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { SuggestionListItem } from "@/components/rec-resource-suggestion-form/SuggestionListItem";
-// Mock react-bootstrap-typeahead Highlighter
+
 vi.mock("react-bootstrap-typeahead", () => ({
   Highlighter: ({ children }: any) => (
     <mark data-testid="highlighter">{children}</mark>
@@ -25,10 +25,13 @@ describe("SuggestionListItem", () => {
   it("renders icon, title, resourceType, district, and rec_resource_id badges", () => {
     render(<SuggestionListItem {...defaultProps} />);
     expect(screen.getByTestId("icon")).toBeInTheDocument();
+
     const highlighters = screen.getAllByTestId("highlighter");
-    expect(highlighters.length).toBe(2);
-    highlighters.forEach((h) => expect(h).toHaveTextContent("Riverfront Park"));
+    expect(highlighters.length).toBe(1);
+    expect(highlighters[0]).toHaveTextContent("riverfront park");
+
     expect(screen.getByText("Urban Park • Downtown")).toBeInTheDocument();
+
     const badges = screen.getAllByText("R-1234");
     expect(badges.length).toBe(2);
     badges.forEach((badge) =>
@@ -47,6 +50,7 @@ describe("SuggestionListItem", () => {
   it("renders mobile and desktop badge locations", () => {
     render(<SuggestionListItem {...defaultProps} />);
     const badges = screen.getAllByText("R-1234");
+    expect(badges.length).toBe(2);
     // First badge is mobile, second is desktop
     expect(badges[0].className).toContain("rec-id-badge");
     expect(badges[1].className).toContain("rec-id-badge");
@@ -55,8 +59,8 @@ describe("SuggestionListItem", () => {
   it("renders Highlighter with correct children and search term", () => {
     render(<SuggestionListItem {...defaultProps} />);
     const marks = screen.getAllByTestId("highlighter");
-    expect(marks.length).toBe(2);
-    marks.forEach((mark) => expect(mark).toHaveTextContent("Riverfront Park"));
+    expect(marks.length).toBe(1);
+    expect(marks[0]).toHaveTextContent("riverfront park");
   });
 
   it("renders correct resourceType and district", () => {
@@ -75,10 +79,13 @@ describe("SuggestionListItem", () => {
     };
     render(<SuggestionListItem {...props} />);
     expect(screen.getByTestId("icon2")).toBeInTheDocument();
+
     const highlighters = screen.getAllByTestId("highlighter");
-    expect(highlighters.length).toBe(2);
-    highlighters.forEach((h) => expect(h).toHaveTextContent("Crystal Lake"));
+    expect(highlighters.length).toBe(1);
+    expect(highlighters[0]).toHaveTextContent("crystal lake");
+
     expect(screen.getByText("Lake • Northside")).toBeInTheDocument();
+
     expect(screen.getAllByText("R-9999").length).toBe(2);
   });
 });

--- a/public/frontend/src/components/recreation-suggestion-form/SuggestionListCity.test.tsx
+++ b/public/frontend/src/components/recreation-suggestion-form/SuggestionListCity.test.tsx
@@ -14,10 +14,10 @@ describe('SuggestionListCity', () => {
       expect(el.tagName.toLowerCase()).toBe('mark');
     }
 
-    const fullCityInstances = screen.getAllByText(
-      (_content, element) => element?.textContent === 'Vancouver',
-    );
-    expect(fullCityInstances.length).toBeGreaterThanOrEqual(2); // mobile + desktop
+    const city = screen.getByText((_content, element) => {
+      return element?.textContent === 'Vancouver';
+    });
+    expect(city).toBeInTheDocument();
   });
 
   it('shows LOCATION_ICON and "Region" description for regular city', () => {
@@ -42,14 +42,12 @@ describe('SuggestionListCity', () => {
     expect(description).toBeInTheDocument();
   });
 
-  it('renders both desktop and mobile versions of the city name', () => {
+  it('renders the city name', () => {
     render(<SuggestionListCity city="Vancouver" searchTerm="couv" />);
 
-    const fullTextSpans = screen.getAllByText(
-      (_text, el) => el?.textContent === 'Vancouver',
-    );
-
-    // Expect desktop and mobile each render 'Vancouver'
-    expect(fullTextSpans.length).toBeGreaterThanOrEqual(2);
+    const city = screen.getByText((_content, element) => {
+      return element?.textContent === 'Vancouver';
+    });
+    expect(city).toBeInTheDocument();
   });
 });

--- a/public/frontend/src/components/recreation-suggestion-form/SuggestionListCity.tsx
+++ b/public/frontend/src/components/recreation-suggestion-form/SuggestionListCity.tsx
@@ -40,20 +40,12 @@ export const SuggestionListCity: React.FC<SearchItemData> = ({
           </div>
         </Col>
 
-        <Col className="desktop-col">
+        <Col className="content-col">
           <span className="rec-name">
             <Highlighter search={searchTerm}>{city}</Highlighter>
           </span>
           <div className="description-text">
             {isCurrentLocation ? 'Find whats around you' : 'Region'}
-          </div>
-        </Col>
-
-        <Col className="mobile-col">
-          <div className="mobile-inner">
-            <span className="rec-name mb-1">
-              <Highlighter search={searchTerm}>{city}</Highlighter>
-            </span>
           </div>
         </Col>
       </Row>

--- a/public/frontend/src/components/recreation-suggestion-form/SuggestionListItem.test.tsx
+++ b/public/frontend/src/components/recreation-suggestion-form/SuggestionListItem.test.tsx
@@ -18,11 +18,11 @@ describe('SuggestionListItem', () => {
 
     expect(screen.getByTestId('test-icon')).toBeInTheDocument();
 
-    // Check lowercase rendering
-    const title = screen.getAllByText(
-      (_, el) => el?.textContent === 'golden lake trail',
+    // Match full text ignoring markup like <mark>
+    const title = screen.getByText(
+      (_, el) => el?.textContent?.toLowerCase() === 'golden lake trail',
     );
-    expect(title.length).toBeGreaterThanOrEqual(2); // mobile + desktop
+    expect(title).toBeInTheDocument();
 
     const resourceText = screen.getByText(/recreation trail/i);
     const communityText = screen.getByText('whistler');
@@ -31,23 +31,14 @@ describe('SuggestionListItem', () => {
     expect(communityText).toBeInTheDocument();
   });
 
-  it('highlights search term in both mobile and desktop versions', () => {
+  it('highlights the search term', () => {
     render(<SuggestionListItem {...defaultProps} />);
 
     const highlights = screen.getAllByText(/lake/i);
-    expect(highlights.length).toBeGreaterThanOrEqual(2); // mobile + desktop
+    expect(highlights.length).toBeGreaterThanOrEqual(1);
     highlights.forEach((el) => {
       expect(el.tagName.toLowerCase()).toBe('mark');
     });
-  });
-
-  it('renders different text regions for desktop and mobile', () => {
-    render(<SuggestionListItem {...defaultProps} />);
-
-    const allCityText = screen.getAllByText(
-      (_text, el) => el?.textContent === 'golden lake trail',
-    );
-    expect(allCityText.length).toBeGreaterThanOrEqual(2);
   });
 
   it('converts title and community to lowercase', () => {
@@ -60,10 +51,10 @@ describe('SuggestionListItem', () => {
       />,
     );
 
-    const titleElements = screen.getAllByText((_content, element) => {
-      return element?.textContent?.toLowerCase() === 'upper river';
-    });
-    expect(titleElements.length).toBeGreaterThanOrEqual(2);
+    const titleElement = screen.getByText(
+      (_, el) => el?.textContent?.toLowerCase() === 'upper river',
+    );
+    expect(titleElement).toBeInTheDocument();
 
     expect(screen.getByText('squamish')).toBeInTheDocument();
   });

--- a/public/frontend/src/components/recreation-suggestion-form/SuggestionListItem.tsx
+++ b/public/frontend/src/components/recreation-suggestion-form/SuggestionListItem.tsx
@@ -43,21 +43,13 @@ export const SuggestionListItem: FC<SearchItemData> = ({
           <div className="icon-wrapper">{icon}</div>
         </Col>
 
-        <Col className="desktop-col">
+        <Col className="content-col">
           <span className="rec-name">
             <Highlighter search={searchTerm}>{lowerCaseTitle}</Highlighter>
           </span>
           <div className="description-text">
             {resourceType} &bull;{' '}
             <span className="capitalize">{lowerCaseCommunity}</span>
-          </div>
-        </Col>
-
-        <Col className="mobile-col">
-          <div className="mobile-inner">
-            <span className="rec-name mb-1">
-              <Highlighter search={searchTerm}>{lowerCaseTitle}</Highlighter>
-            </span>
           </div>
         </Col>
       </Row>

--- a/shared/src/components/suggestion-typeahead/SuggestionListItem.scss
+++ b/shared/src/components/suggestion-typeahead/SuggestionListItem.scss
@@ -4,22 +4,22 @@
 @import "bootstrap/scss/mixins/_breakpoints";
 
 .suggestion-list-item {
+  width: 100%;
   display: flex;
   align-items: center;
 
   .suggestion-list-row {
+    width: 100%;
     display: flex;
-    flex-grow: 1;
     flex-wrap: nowrap;
     align-items: center;
-    width: 100%;
   }
 
   .icon-col {
+    flex: 0 0 40px;
     display: flex;
     align-items: center;
     justify-content: center;
-    flex: 0 0 auto;
 
     .icon-wrapper {
       border-radius: 50%;
@@ -29,38 +29,33 @@
     }
   }
 
-  .desktop-col {
-    display: none;
+  .content-col {
+    flex: 1 1 auto;
+    min-width: 0;
     margin-right: auto;
     padding: 0;
-
-    @include media-breakpoint-up(sm) {
-      display: block;
-    }
 
     .rec-name {
       text-transform: capitalize;
-      margin-bottom: 0.25rem;
     }
 
     .description-text {
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      display: block;
+      min-width: 0;
       color: $text-muted;
       font-size: 0.9em;
     }
-  }
-
-  .mobile-col {
-    display: block;
-    margin-right: auto;
-    padding: 0;
 
     @include media-breakpoint-up(sm) {
-      display: none;
-    }
-
-    .mobile-inner {
       display: flex;
       flex-direction: column;
+
+      .description-text {
+        white-space: normal;
+      }
     }
   }
 }


### PR DESCRIPTION
Airlia noticed that mobile styling was broken in PO review.

Before:
<img width="337" height="469" alt="Screenshot 2025-08-08 at 1 05 16 PM" src="https://github.com/user-attachments/assets/147a5028-a7a5-4e29-a688-6e1ca78d5dae" />



After:
<img width="322" height="469" alt="Screenshot 2025-08-08 at 1 04 50 PM" src="https://github.com/user-attachments/assets/71424d9b-50fa-4b71-b70c-58a77ea868fd" />

