### PR TITLE
fix(backend-env-vars): modify the postgres schema env var in terraform config

### DIFF
--- a/admin/backend/src/app-config/app-config.schema.ts
+++ b/admin/backend/src/app-config/app-config.schema.ts
@@ -49,7 +49,6 @@ export class EnvironmentVariables {
   POSTGRES_DATABASE: string;
 
   @IsString()
-  @IsNotEmpty()
   POSTGRES_SCHEMA: string;
 
   // Keycloak configuration

--- a/admin/backend/src/app-config/app-config.service.ts
+++ b/admin/backend/src/app-config/app-config.service.ts
@@ -67,7 +67,7 @@ export class AppConfigService {
   }
 
   get databaseSchema(): string {
-    return this.configService.get("POSTGRES_SCHEMA", { infer: true })!;
+    return this.configService.get("POSTGRES_SCHEMA", "rst", { infer: true })!;
   }
 
   // Database URL helper

--- a/infrastructure/api/ecs.tf
+++ b/infrastructure/api/ecs.tf
@@ -129,7 +129,7 @@ resource "aws_ecs_task_definition" "node_api_task" {
           value = var.db_name
         },
         {
-          name  = "DB_SCHEMA"
+          name  = "POSTGRES_SCHEMA"
           value = "${var.db_schema}"
         },
         {


### PR DESCRIPTION
Modify the PostgreSQL schema environment variable in the backend configuration to ensure it is correctly referenced and used throughout the application.