### PR TITLE
fix(csp-images): adjust csp policy to allow blob links in img tags

### DIFF
--- a/infrastructure/frontend/cloudfront.tf
+++ b/infrastructure/frontend/cloudfront.tf
@@ -161,7 +161,7 @@ resource "aws_cloudfront_response_headers_policy" "csp_policy" {
         "style-src-elem 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdn.jsdelivr.net",
         "style-src-attr 'self' 'unsafe-inline'",
         "font-src 'self' https://fonts.gstatic.com",
-        "img-src 'self' data: https://fonts.googleapis.com https://*.arcgis.com https://www.w3.org ${var.csp_urls.image_src} ${var.csp_urls.matomo_src}",
+        "img-src 'self' blob: data: https://fonts.googleapis.com https://*.arcgis.com https://www.w3.org ${var.csp_urls.image_src} ${var.csp_urls.matomo_src}",
         "connect-src 'self' ${local.api_url} https://${var.app_env}.loginproxy.gov.bc.ca https://loginproxy.gov.bc.ca https://services6.arcgis.com https://www.arcgis.com https://services.arcgis.com https://tiles.arcgis.com https://maps.arcgis.com ${var.csp_urls.connect_src} ${var.csp_urls.matomo_src}",
         "media-src 'self'",
         "frame-src 'none'",


### PR DESCRIPTION
Update the Content Security Policy to permit blob URLs in image tags, enhancing the flexibility of image sources.