### PR TITLE
Fix icon display in image gallery for failed image uploads

### DIFF
--- a/admin/frontend/src/pages/rec-resource-page/components/RecResourceFileSection/GalleryFileCard/GalleryFileCard.tsx
+++ b/admin/frontend/src/pages/rec-resource-page/components/RecResourceFileSection/GalleryFileCard/GalleryFileCard.tsx
@@ -6,6 +6,7 @@ import {
 import {
   faCancel,
   faEllipsisV,
+  faFileImage,
   faFilePdf,
   faRedo,
   faTimes,
@@ -58,7 +59,7 @@ export const GalleryFileCard = <T extends GalleryFile>({
           className="align-items-center justify-content-center"
         >
           <FontAwesomeIcon
-            icon={faFilePdf}
+            icon={file.type === "document" ? faFilePdf : faFileImage}
             size="2x"
             className="fa-file-pdf"
             aria-hidden="true"

--- a/admin/frontend/test/pages/rec-resource-page/components/RecResourceFileSection/GalleryFileCard/GalleryFileCard.test.tsx
+++ b/admin/frontend/test/pages/rec-resource-page/components/RecResourceFileSection/GalleryFileCard/GalleryFileCard.test.tsx
@@ -1,5 +1,6 @@
 import { GalleryFileCard } from "@/pages/rec-resource-page/components/RecResourceFileSection/GalleryFileCard";
 import type { GalleryFile } from "@/pages/rec-resource-page/types";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { vi } from "vitest";
@@ -12,9 +13,9 @@ vi.mock("@/components/clamp-lines", () => ({
 }));
 
 vi.mock("@fortawesome/react-fontawesome", () => ({
-  FontAwesomeIcon: ({ icon, ...props }: any) => (
+  FontAwesomeIcon: vi.fn(({ icon, ...props }: any) => (
     <svg {...props} data-icon={icon.iconName} />
-  ),
+  )),
 }));
 
 // Mock internal components
@@ -75,6 +76,7 @@ describe("GalleryFileCard", () => {
     date: "2025-01-01",
     url: "http://example.com/test.pdf",
     extension: "pdf",
+    type: "document",
   };
 
   const renderCard = (
@@ -193,6 +195,15 @@ describe("GalleryFileCard", () => {
       );
 
       expect(mockHandler).toHaveBeenCalledTimes(2);
+    });
+
+    it("displays faFileImage icon for image file upload error", () => {
+      renderCard({ uploadFailed: true, type: "image" });
+      const FontAwesomeIconCalls = (FontAwesomeIcon as any).mock.calls;
+      const found = FontAwesomeIconCalls.some(
+        ([props]: any[]) => props.icon && props.icon.iconName === "file-image", // icon name for faFileImage
+      );
+      expect(found).toBe(true);
     });
 
     it("shows retry and dismiss in dropdown for failed uploads", () => {


### PR DESCRIPTION
Correctly display the image icon for failed image uploads in the GalleryFileCard component. 


### Screenshots

<img width="1285" height="703" alt="image" src="https://github.com/user-attachments/assets/661a715e-5f5a-4e0b-9be9-d1d76a8ec6c9" />
