### PR TITLE
fix: dev e2e

### DIFF
--- a/public/frontend/e2e/workflows/search/search.spec.ts
+++ b/public/frontend/e2e/workflows/search/search.spec.ts
@@ -25,11 +25,11 @@ test.describe('Search for a recreation site or trail workflows', () => {
 
     await searchPage.verifyInitialResults();
 
-    await searchPage.searchFor('summerland');
+    await searchPage.searchFor('summer');
 
-    await utils.checkExpectedUrlParams('filter=summerland&page=1');
+    await utils.checkExpectedUrlParams('filter=summer&page=1');
 
-    await searchPage.verifySearchResults('summerland');
+    await searchPage.verifySearchResults('summer');
 
     await utils.clickLinkByText('Agur Lake');
 


### PR DESCRIPTION
The changes to the search where it searches by location if there is an exact text match passed e2e with local fixtures but was broken in dev environment which has the full site data. 