### PR TITLE
feat(csp): add new matomo lza urls to csp policy

### DIFF
--- a/terraform/frontend/admin-dev/terragrunt.hcl
+++ b/terraform/frontend/admin-dev/terragrunt.hcl
@@ -12,7 +12,7 @@ generate "dev_tfvars" {
   csp_urls = {
     image_src = "https://dam.lqc63d-test.nimbus.cloud.gov.bc.ca https://dam.lqc63d-prod.nimbus.cloud.gov.bc.ca"
     connect_src = "https://dam.lqc63d-test.nimbus.cloud.gov.bc.ca https://dam.lqc63d-prod.nimbus.cloud.gov.bc.ca"
-    matomo_src = "https://iuqxrr50zl.execute-api.ca-central-1.amazonaws.com"
+    matomo_src = "https://iuqxrr50zl.execute-api.ca-central-1.amazonaws.com https://y09s3hx8j6.execute-api.ca-central-1.amazonaws.com"
   }
 EOF
 }

--- a/terraform/frontend/admin-prod/terragrunt.hcl
+++ b/terraform/frontend/admin-prod/terragrunt.hcl
@@ -12,7 +12,7 @@ generate "prod_tfvars" {
   csp_urls = {
       image_src = "https://dam.lqc63d-prod.nimbus.cloud.gov.bc.ca"
       connect_src = "https://dam.lqc63d-prod.nimbus.cloud.gov.bc.ca"
-      matomo_src = "https://iuqxrr50zl.execute-api.ca-central-1.amazonaws.com"
+      matomo_src = "https://iuqxrr50zl.execute-api.ca-central-1.amazonaws.com https://y09s3hx8j6.execute-api.ca-central-1.amazonaws.com"
   }
 EOF
 }

--- a/terraform/frontend/admin-test/terragrunt.hcl
+++ b/terraform/frontend/admin-test/terragrunt.hcl
@@ -12,7 +12,7 @@ generate "test_tfvars" {
   csp_urls = {
       image_src = "https://dam.lqc63d-test.nimbus.cloud.gov.bc.ca https://dam.lqc63d-prod.nimbus.cloud.gov.bc.ca"
       connect_src = "https://dam.lqc63d-test.nimbus.cloud.gov.bc.ca https://dam.lqc63d-prod.nimbus.cloud.gov.bc.ca"
-      matomo_src = "https://iuqxrr50zl.execute-api.ca-central-1.amazonaws.com"
+      matomo_src = "https://iuqxrr50zl.execute-api.ca-central-1.amazonaws.com https://y09s3hx8j6.execute-api.ca-central-1.amazonaws.com"
   }
 EOF
 }

--- a/terraform/frontend/public-dev/terragrunt.hcl
+++ b/terraform/frontend/public-dev/terragrunt.hcl
@@ -12,7 +12,7 @@ generate "dev_tfvars" {
   csp_urls = {
     image_src = "https://dam.lqc63d-test.nimbus.cloud.gov.bc.ca https://dam.lqc63d-prod.nimbus.cloud.gov.bc.ca"
     connect_src = "https://dam.lqc63d-test.nimbus.cloud.gov.bc.ca https://dam.lqc63d-prod.nimbus.cloud.gov.bc.ca https://bcparks.api.gov.bc.ca"
-    matomo_src = "https://iuqxrr50zl.execute-api.ca-central-1.amazonaws.com"
+    matomo_src = "https://iuqxrr50zl.execute-api.ca-central-1.amazonaws.com https://y09s3hx8j6.execute-api.ca-central-1.amazonaws.com"
   }
 EOF
 }

--- a/terraform/frontend/public-prod/terragrunt.hcl
+++ b/terraform/frontend/public-prod/terragrunt.hcl
@@ -12,7 +12,7 @@ generate "prod_tfvars" {
   csp_urls = {
       image_src = "https://dam.lqc63d-prod.nimbus.cloud.gov.bc.ca https://beta.sitesandtrailsbc.ca https://sitesandtrailsbc.ca"
       connect_src = "https://dam.lqc63d-prod.nimbus.cloud.gov.bc.ca https://bcparks.api.gov.bc.ca"
-      matomo_src = "https://iuqxrr50zl.execute-api.ca-central-1.amazonaws.com"
+      matomo_src = "https://iuqxrr50zl.execute-api.ca-central-1.amazonaws.com https://y09s3hx8j6.execute-api.ca-central-1.amazonaws.com"
     }
 EOF
 }

--- a/terraform/frontend/public-test/terragrunt.hcl
+++ b/terraform/frontend/public-test/terragrunt.hcl
@@ -12,7 +12,7 @@ generate "test_tfvars" {
   csp_urls = {
     image_src = "https://dam.lqc63d-test.nimbus.cloud.gov.bc.ca https://dam.lqc63d-prod.nimbus.cloud.gov.bc.ca"
     connect_src = "https://dam.lqc63d-test.nimbus.cloud.gov.bc.ca https://dam.lqc63d-prod.nimbus.cloud.gov.bc.ca https://bcparks.api.gov.bc.ca"
-    matomo_src = "https://iuqxrr50zl.execute-api.ca-central-1.amazonaws.com"
+    matomo_src = "https://iuqxrr50zl.execute-api.ca-central-1.amazonaws.com https://y09s3hx8j6.execute-api.ca-central-1.amazonaws.com"
   }
 EOF
 }


### PR DESCRIPTION
Incorporate new Matomo LZA URLs into the Content Security Policy across development, production, and test configurations.