### PR TITLE
fix: persist search input value between list and map view

### DIFF
--- a/public/frontend/src/components/recreation-suggestion-form/SuggestionListCity.test.tsx
+++ b/public/frontend/src/components/recreation-suggestion-form/SuggestionListCity.test.tsx
@@ -20,11 +20,11 @@ describe('SuggestionListCity', () => {
     expect(city).toBeInTheDocument();
   });
 
-  it('shows LOCATION_ICON and "Region" description for regular city', () => {
+  it('shows LOCATION_ICON and "Community" description for regular city', () => {
     render(<SuggestionListCity city="Victoria" searchTerm="vic" />);
 
     const icon = screen.getByAltText(/location icon/i);
-    const description = screen.getByText(/region/i);
+    const description = screen.getByText(/community/i);
 
     expect(icon).toBeInTheDocument();
     expect(description).toBeInTheDocument();
@@ -36,7 +36,7 @@ describe('SuggestionListCity', () => {
     );
 
     const icon = screen.getByAltText(/current location icon/i);
-    const description = screen.getByText(/find whats around you/i);
+    const description = screen.getByText(/find what's around you/i);
 
     expect(icon).toBeInTheDocument();
     expect(description).toBeInTheDocument();

--- a/public/frontend/src/components/recreation-suggestion-form/SuggestionListCity.tsx
+++ b/public/frontend/src/components/recreation-suggestion-form/SuggestionListCity.tsx
@@ -45,7 +45,7 @@ export const SuggestionListCity: React.FC<SearchItemData> = ({
             <Highlighter search={searchTerm}>{city}</Highlighter>
           </span>
           <div className="description-text">
-            {isCurrentLocation ? 'Find whats around you' : 'Region'}
+            {isCurrentLocation ? `Find what's around you` : 'Community'}
           </div>
         </Col>
       </Row>

--- a/shared/src/components/suggestion-typeahead/SuggestionTypeahead.tsx
+++ b/shared/src/components/suggestion-typeahead/SuggestionTypeahead.tsx
@@ -77,6 +77,10 @@ export interface SuggestionTypeaheadProps<T> {
    * Allows for custom handling of input changes.
    */
   onInputChange?: (input: string) => void;
+  /**
+   * The currently selected suggestion(s).
+   */
+  selected?: T[];
 }
 
 /**
@@ -100,6 +104,7 @@ export const SuggestionTypeahead = <T extends object>({
   labelKey = "name",
   minLength = 1,
   onInputChange,
+  selected,
 }: SuggestionTypeaheadProps<T>) => {
   const typeaheadRef = useRef(null);
 
@@ -143,6 +148,7 @@ export const SuggestionTypeahead = <T extends object>({
           onChange(selected[0] as T);
         }
       }}
+      selected={selected}
       onInputChange={onInputChange}
       onKeyDown={onKeyDown}
       options={suggestions}


### PR DESCRIPTION
Fix for: https://bcparksdigital.atlassian.net/browse/ORCA-101

The search input should now persist between list and map view. The landing page should always be clear when returning to it. 

Also has a few very minor text updates.