### PR TITLE
fix: ecs-flyway-task module task definition name

### DIFF
--- a/infrastructure/modules/ecs-flyway-task/main.tf
+++ b/infrastructure/modules/ecs-flyway-task/main.tf
@@ -51,7 +51,7 @@ resource "aws_ecs_task_definition" "flyway_task" {
         echo "Starting Flyway task (attempt $attempt)..."
 
         task_arn=$(aws ecs run-task \
-          --task-definition ${var.app_name}-flyway-task \
+          --task-definition ${var.app_name}-${var.db_schema}-flyway-task \
           --cluster ${var.cluster_id} \
           --count 1 \
           --network-configuration "{\"awsvpcConfiguration\":{\"subnets\":[\"${var.subnet}\"],\"securityGroups\":[\"${var.security_group}\"],\"assignPublicIp\":\"DISABLED\"}}" \


### PR DESCRIPTION
Update to match naming update in this PR: https://github.com/bcgov/nr-rec-resources/commit/5e569a5695659488edd523c40e8c9375ee35584d