### PR TITLE
fix: map preview card see all showing

### DIFF
--- a/public/frontend/src/components/rec-resource/card/RecResourceCard.scss
+++ b/public/frontend/src/components/rec-resource/card/RecResourceCard.scss
@@ -49,6 +49,9 @@
     align-items: flex-start;
 
     .card-activities {
+      display: flex;
+      flex-direction: row;
+      align-items: flex-end;
       margin-bottom: 16px;
 
       @include media-breakpoint-up(sm) {

--- a/public/frontend/src/components/rec-resource/card/RecResourceCard.tsx
+++ b/public/frontend/src/components/rec-resource/card/RecResourceCard.tsx
@@ -66,7 +66,7 @@ const RecResourceCard: React.FC<RecResourceCardProps> = ({
           </div>
         </div>
         <div className="card-content-lower">
-          <span className="card-activities d-flex d-row align-items-end">
+          <span className="card-activities">
             {hasActivities && <Activities activities={activities} />}{' '}
             {isSeeAllActivities && (
               <a href={`/resource/${rec_resource_id}#things-to-do`}>see all</a>

--- a/public/frontend/src/components/search-map/preview/MapFeaturePreview.scss
+++ b/public/frontend/src/components/search-map/preview/MapFeaturePreview.scss
@@ -23,8 +23,7 @@
       max-width: none;
     }
 
-    .activities-list,
-    .card-activities.a {
+    .card-activities {
       display: none;
     }
 


### PR DESCRIPTION
Fix for the `see all` showing in the map preview card. We aren't showing any activities at all but this slipped through. I added the flex styles to the `.card-activities` class so the bootstrap `display: flex` wouldn't override `display: none` when I set it in the preview card.

Issue:
<img width="610" height="212" alt="Screenshot 2025-08-25 at 11 29 05 AM" src="https://github.com/user-attachments/assets/bc74a92e-86fa-48fe-b557-67e49162ccbd" />
