### PR TITLE
fix: search page scrolls to results on search page initial load

### DIFF
--- a/public/frontend/src/components/search-map/SearchViewControls.tsx
+++ b/public/frontend/src/components/search-map/SearchViewControls.tsx
@@ -23,7 +23,7 @@ const SearchViewControls = ({ variant }: SearchViewControlsProps) => {
 
   return (
     <Button
-      className="search-chip btn h-2"
+      className="search-chip btn h-2 text-nowrap"
       variant="secondary"
       onClick={() => handleViewChange(variant)}
     >

--- a/public/frontend/src/components/search/SearchPage.test.tsx
+++ b/public/frontend/src/components/search/SearchPage.test.tsx
@@ -200,23 +200,10 @@ describe('SearchPage', () => {
     expect(screen.getByTestId('mock-no-results')).toBeInTheDocument();
   });
 
-  it('handles null/undefined data gracefully', () => {
-    mockStoreState({ totalCount: undefined, pages: undefined });
-    renderWithQueryClient(<SearchPage />);
-    expect(screen.getByTestId('mock-no-results')).toBeInTheDocument();
-  });
-
   it('handles zero count with data', () => {
     mockStoreState({ totalCount: 0, pages: [{ data: [] }] });
     renderWithQueryClient(<SearchPage />);
     expect(screen.getByText('0')).toBeInTheDocument();
-    expect(screen.getByTestId('mock-no-results')).toBeInTheDocument();
-  });
-
-  it('handles undefined totalCount', () => {
-    mockStoreState({ totalCount: undefined, pages: [{ data: [] }] });
-    renderWithQueryClient(<SearchPage />);
-    expect(screen.getByText('Results')).toBeInTheDocument();
     expect(screen.getByTestId('mock-no-results')).toBeInTheDocument();
   });
 

--- a/public/frontend/src/components/search/SearchPage.tsx
+++ b/public/frontend/src/components/search/SearchPage.tsx
@@ -187,11 +187,7 @@ const SearchPage = () => {
                     <SearchViewControls variant="map" />
                   </div>
                   <FilterChips />
-                  {(totalCount === 0 || totalCount === undefined) && (
-                    <>
-                      <NoResults />
-                    </>
-                  )}
+                  {totalCount === 0 && <NoResults />}
                 </div>
               )}
             </div>


### PR DESCRIPTION
https://bcparksdigital.atlassian.net/jira/software/projects/ORCA/boards/22?selectedIssue=ORCA-39

The `NoResults` component was temporarily mounting and calling the useEffect which was causing focus and scrolling down on mobile even though the component wasn't visible at all. Even though `totalCount === undefined` doesn't actually seem to exist even if we log it, I believe it was happening extremely briefly on `SearchPage` mount before the default search store `totalCount` of 0 was populated.

Removed `totalCount === undefined` check as it wasn't doing anything - even if I completely turn off the backend totalCount will resolve as 0.