### PR TITLE
fix: shorten suggestion menu on mobile

### DIFF
--- a/public/frontend/src/components/recreation-suggestion-form/SuggestionMenu.scss
+++ b/public/frontend/src/components/recreation-suggestion-form/SuggestionMenu.scss
@@ -16,7 +16,6 @@
   touch-action: pan-y;
 
   .suggestion-menu-scroll {
-    // min-height: 120px;
     max-height: 18vh;
 
     @include media-breakpoint-up(sm) {

--- a/public/frontend/src/components/recreation-suggestion-form/SuggestionMenu.scss
+++ b/public/frontend/src/components/recreation-suggestion-form/SuggestionMenu.scss
@@ -1,3 +1,8 @@
+@import '@/styles/variables.scss';
+@import 'bootstrap/scss/functions';
+@import 'bootstrap/scss/variables';
+@import 'bootstrap/scss/mixins/_breakpoints';
+
 .suggestion-menu-label {
   font-size: 0.9rem;
   margin-top: 0.5rem;
@@ -5,9 +10,17 @@
 }
 
 .suggestion-menu {
-  max-height: 300px;
   overflow-y: auto;
   -webkit-overflow-scrolling: touch;
   overscroll-behavior: contain;
   touch-action: pan-y;
+
+  .suggestion-menu-scroll {
+    // min-height: 120px;
+    max-height: 18vh;
+
+    @include media-breakpoint-up(sm) {
+      max-height: 300px;
+    }
+  }
 }

--- a/public/frontend/src/components/recreation-suggestion-form/SuggestionMenu.tsx
+++ b/public/frontend/src/components/recreation-suggestion-form/SuggestionMenu.tsx
@@ -34,50 +34,52 @@ export const SuggestionMenu = ({
 
   return (
     <Menu className="suggestion-menu">
-      <div className="suggestion-menu-label">Location</div>
-      {cityOptions.map((option, index) => (
-        <MenuItem
-          key={`city-${option.name}`}
-          option={option}
-          position={index}
-          className="dropdown-menu-item"
-        >
-          <SuggestionListCity searchTerm={searchTerm} city={option.name} />
-        </MenuItem>
-      ))}
-
-      {showResultsLabel && (
-        <div className="suggestion-menu-label">Sites and trails</div>
-      )}
-      {results.map((option: RecreationSuggestion, index: number) => {
-        const {
-          rec_resource_id,
-          recreation_resource_type_code,
-          recreation_resource_type,
-          closest_community,
-          name,
-        } = option;
-        return (
+      <div className="suggestion-menu-scroll">
+        <div className="suggestion-menu-label">Location</div>
+        {cityOptions.map((option, index) => (
           <MenuItem
-            key={rec_resource_id}
+            key={`city-${option.name}`}
             option={option}
-            position={index + cityOptions.length}
+            position={index}
             className="dropdown-menu-item"
           >
-            <SuggestionListItem
-              searchTerm={searchTerm}
-              community={closest_community}
-              icon={
-                <Image
-                  src={RESOURCE_TYPE_ICONS[recreation_resource_type_code]}
-                />
-              }
-              resourceType={recreation_resource_type}
-              title={name}
-            />
+            <SuggestionListCity searchTerm={searchTerm} city={option.name} />
           </MenuItem>
-        );
-      })}
+        ))}
+
+        {showResultsLabel && (
+          <div className="suggestion-menu-label">Sites and trails</div>
+        )}
+        {results.map((option: RecreationSuggestion, index: number) => {
+          const {
+            rec_resource_id,
+            recreation_resource_type_code,
+            recreation_resource_type,
+            closest_community,
+            name,
+          } = option;
+          return (
+            <MenuItem
+              key={rec_resource_id}
+              option={option}
+              position={index + cityOptions.length}
+              className="dropdown-menu-item"
+            >
+              <SuggestionListItem
+                searchTerm={searchTerm}
+                community={closest_community}
+                icon={
+                  <Image
+                    src={RESOURCE_TYPE_ICONS[recreation_resource_type_code]}
+                  />
+                }
+                resourceType={recreation_resource_type}
+                title={name}
+              />
+            </MenuItem>
+          );
+        })}
+      </div>
     </Menu>
   );
 };


### PR DESCRIPTION
After discussion with Harry and Airlia we decided to shorten the suggestion menu on mobile since items at the bottom were obscured by the on screen keyboard.

<img width="416" height="892" alt="Screenshot 2025-08-26 at 11 38 53 AM" src="https://github.com/user-attachments/assets/e4afa8c4-4248-4088-b3df-7e33206768ae" />


