### PR TITLE
ci(fix): use unified app name for migrations

### DIFF
--- a/terraform/migration/terragrunt.hcl
+++ b/terraform/migration/terragrunt.hcl
@@ -18,7 +18,7 @@ locals {
   statelock_table_name       = "${local.tf_remote_state_prefix}-lock-${local.aws_license_plate}"
   flyway_image               = get_env("flyway_image")
   api_image                  = get_env("api_image")
-  app_name = local.app == "public" ? "node-api-${local.app_env}" : "node-api-${local.app}-${local.app_env}"
+  app_name                   = "node-api-${local.app_env}"
 
 }
 


### PR DESCRIPTION
Since migrations is used by both apps, we need to keep a unified app name for things like our OpenShift imports to reference. Every time we push migrations to admin, it is deleting the fta migration task definition and breaking OpenShift migrations.