### PR TITLE
fix: migrations delete obsolete rows

### DIFF
--- a/migrations/fta/sql/V1.0.4__fta_to_rst_activity.sql
+++ b/migrations/fta/sql/V1.0.4__fta_to_rst_activity.sql
@@ -13,7 +13,7 @@ set recreation_activity_code = excluded.recreation_activity_code,
     updated_at = excluded.updated_at,
     updated_by = excluded.updated_by;
 
--- If an activity is removed in FTA, remove it in RST
+-- If an activity row is removed in FTA, remove it in RST
 delete from rst.recreation_activity ra
 where not exists (
     select 1

--- a/migrations/fta/sql/V1.0.4__fta_to_rst_activity.sql
+++ b/migrations/fta/sql/V1.0.4__fta_to_rst_activity.sql
@@ -12,3 +12,12 @@ do update
 set recreation_activity_code = excluded.recreation_activity_code,
     updated_at = excluded.updated_at,
     updated_by = excluded.updated_by;
+
+-- If an activity is removed in FTA, remove it in RST
+delete from rst.recreation_activity ra
+where not exists (
+    select 1
+    from fta.recreation_activity fta
+    where fta.forest_file_id = ra.rec_resource_id
+      and cast(fta.recreation_activity_code as int) = ra.recreation_activity_code
+);

--- a/migrations/fta/sql/V1.0.6__fta_to_rst_access.sql
+++ b/migrations/fta/sql/V1.0.6__fta_to_rst_access.sql
@@ -36,3 +36,13 @@ set
     sub_access_code = excluded.sub_access_code,
     updated_at = excluded.updated_at,
     updated_by = excluded.updated_by;
+
+-- If an access row is removed in FTA, remove it in RST
+delete from rst.recreation_access ra
+where not exists (
+    select 1
+    from fta.recreation_access fta
+    where fta.forest_file_id = ra.rec_resource_id
+      and fta.recreation_access_code = ra.access_code
+      and fta.recreation_sub_access_code = ra.sub_access_code
+);

--- a/migrations/fta/sql/V1.0.7__fta_to_rst_structure.sql
+++ b/migrations/fta/sql/V1.0.7__fta_to_rst_structure.sql
@@ -28,3 +28,17 @@ do update
 set
     updated_at = excluded.updated_at,
     updated_by = excluded.updated_by;
+
+-- If a structure row is removed in FTA, remove it in RST
+delete from rst.recreation_structure rst_rs
+where not exists (
+    select 1
+    from fta.recreation_structure rs
+    join fta.recreation_structure_code rsc_fta
+        on rs.recreation_structure_code = rsc_fta.recreation_structure_code
+    join rst.recreation_structure_code rsc_rst
+        on rsc_fta.description = rsc_rst.description
+    where
+        rs.forest_file_id = rst_rs.rec_resource_id
+        and rsc_rst.structure_code = rst_rs.structure_code
+);

--- a/migrations/fta/sql/V1.0.8__fta_to_rst_fee.sql
+++ b/migrations/fta/sql/V1.0.8__fta_to_rst_fee.sql
@@ -50,3 +50,14 @@ set
     sunday_ind = excluded.sunday_ind,
     updated_at = excluded.updated_at,
     updated_by = excluded.updated_by;
+
+
+-- If a fee row is removed in FTA, remove it in RST
+delete from rst.recreation_fee rst_rf
+where not exists (
+    select 1
+    from fta.recreation_fee rf
+    where
+        rf.forest_file_id = rst_rf.rec_resource_id
+        and rf.recreation_fee_code = rst_rf.recreation_fee_code
+);

--- a/migrations/fta/sql/V1.0.9__fta_to_rst_campsite.sql
+++ b/migrations/fta/sql/V1.0.9__fta_to_rst_campsite.sql
@@ -31,3 +31,24 @@ set
     repair_complete_date = excluded.repair_complete_date,
     updated_at = excluded.updated_at,
     updated_by = excluded.updated_by;
+
+-- If a campsite row is removed in FTA, remove it in RST
+delete from rst.recreation_defined_campsite rst_rdc
+where not exists (
+    select 1
+    from fta.recreation_defined_campsite fdc
+    inner join (
+        select
+            forest_file_id,
+            campsite_number,
+            max(revision_count) as max_revision_count
+        from fta.recreation_defined_campsite
+        group by forest_file_id, campsite_number
+    ) latest
+        on fdc.forest_file_id = latest.forest_file_id
+       and fdc.campsite_number = latest.campsite_number
+       and fdc.revision_count = latest.max_revision_count
+    where
+        fdc.forest_file_id = rst_rdc.rec_resource_id
+      and fdc.campsite_number = rst_rdc.campsite_number
+);

--- a/migrations/fta/sql/V1.1.17__fta_to_rstrecreation_agreement_holder.sql
+++ b/migrations/fta/sql/V1.1.17__fta_to_rstrecreation_agreement_holder.sql
@@ -37,3 +37,11 @@ set
   updated_at      = excluded.updated_at,
   created_at      = excluded.created_at,
   created_by      = excluded.created_by;
+
+-- If an agreement holder row is removed in FTA, remove it in RST
+delete from rst.recreation_agreement_holder r
+where r.rec_resource_id not in (
+    select forest_file_id
+    from fta.recreation_agreement_holder a
+    where now() between a.agreement_start_date and a.agreement_end_date
+);


### PR DESCRIPTION
Delete obsolete rows in activities and some other tables. Tested each of these in dev and there were changes in each of the tables, from 1 row to about 20 depending. 

<img width="379" height="59" alt="Screenshot 2025-09-02 at 1 54 16 PM" src="https://github.com/user-attachments/assets/b8430625-9b94-4cb4-896e-caabd98f21cc" />

Camping activity is gone from https://dz37sfd9duckr.cloudfront.net/resource/REC106349 (this will get overridden if someone pushes to dev again)
<img width="778" height="437" alt="Screenshot 2025-09-02 at 1 55 15 PM" src="https://github.com/user-attachments/assets/8b27afe1-3411-4a38-be68-6d43767ebd2e" />
