### PR TITLE
ci: temporary fix to use asea aws role arn for prod openshift sync

### DIFF
--- a/.github/workflows/openshift-oracle-s3-sync.yml
+++ b/.github/workflows/openshift-oracle-s3-sync.yml
@@ -28,7 +28,8 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-            role-to-assume: ${{ secrets.AWS_LZA_DEPLOY_ROLE_ARN }}
+            # Temporary change to keep FTA migration running on the original AWS environment until we switch the public site to LZA
+            role-to-assume: ${{ matrix.short == 'prod' && secrets.AWS_DEPLOY_ROLE_ARN || secrets.AWS_LZA_DEPLOY_ROLE_ARN }}
             role-session-name: openshift-oracle-s3-sync
             aws-region: ${{ env.AWS_REGION }}
 


### PR DESCRIPTION
Something I didn't consider when moving the pipeline to deploy to LZA is we still want the OpenShift FTA sync to use the "old" AWS account that `prod` is still running on. Though for dev/test we will sync to LZA and make sure it's running great. 
  
This sync runs nightly to fetch credentials for our OpenShift FTA export app to save to s3. 

Once this PR is merged I will make another PR with the current file so it's ready for when we switch over the public site.