### PR TITLE
fix: axe e2e link-in-text-block accessibility error

### DIFF
--- a/public/frontend/src/components/rec-resource/RecResourceReservation.scss
+++ b/public/frontend/src/components/rec-resource/RecResourceReservation.scss
@@ -1,3 +1,13 @@
+@import '@/styles/variables.scss';
+
+.camping-info {
+  // Fix for Axe accessibility "link-in-text-block" error
+  // Ensure links are distinguished from surrounding text in a way that does not rely on color
+  a {
+    text-decoration: underline;
+  }
+}
+
 .note {
   font-size: small;
 }

--- a/public/frontend/src/components/rec-resource/RecResourceReservation.tsx
+++ b/public/frontend/src/components/rec-resource/RecResourceReservation.tsx
@@ -72,7 +72,7 @@ const RecResourceReservation: React.FC<RecResourceReservationProps> = ({
           </div>
         </>
       ) : (
-        <div className="icon-container mt-4">
+        <div className="camping-info icon-container mt-4">
           <img src={campground} alt="Campground icon" height={24} width={24} />{' '}
           <div>
             <span>This site is first come first served.</span> <br />


### PR DESCRIPTION
Difference in dev data vs the actual data revealed a minor accessibility issue when e2e runs on dev. The `additional fees` url doesn't show up on our dev data so the test passed fine on our local and PR e2e in CI.

<img width="970" height="606" alt="Screenshot 2025-09-15 at 3 25 38 PM" src="https://github.com/user-attachments/assets/c36b183b-f82f-41d0-ad3a-b215a19e9928" />


Tested deploying and running this on dev here:
https://github.com/bcgov/nr-rec-resources/actions/runs/17744568995/job/50427121275