### PR TITLE
chore: last fixes for reservations

### DIFF
--- a/public/frontend/src/components/rec-resource/RecResourcePage.tsx
+++ b/public/frontend/src/components/rec-resource/RecResourcePage.tsx
@@ -156,7 +156,7 @@ const RecResourcePage = () => {
       id: SectionIds.KNOW_BEFORE_YOU_GO,
       href: `#${SectionIds.KNOW_BEFORE_YOU_GO}`,
       title: SectionTitles.KNOW_BEFORE_YOU_GO,
-      isVisible: true,
+      isVisible: isRecreationSite,
     },
     {
       id: SectionIds.MAPS_AND_LOCATION,
@@ -287,6 +287,7 @@ const RecResourcePage = () => {
                     <KnowBeforeYouGo
                       isReservable={isReservable}
                       isAdditionalFeesAvailable={isAdditionalFeesAvailable}
+                      isCampingAvailable={isCampingAvailable}
                     />
                   )}
 

--- a/public/frontend/src/components/rec-resource/RecResourceReservation.test.tsx
+++ b/public/frontend/src/components/rec-resource/RecResourceReservation.test.tsx
@@ -129,7 +129,7 @@ describe('RecResourceReservation', () => {
     expect(
       screen.getByText(/This site is first come first served/i),
     ).toBeInTheDocument();
-    const campingLink = screen.getByRole('link', { name: 'camping' });
+    const campingLink = screen.getByRole('link', { name: 'camping fees' });
     expect(campingLink).toHaveAttribute('href', '/resource/REC123#camping');
   });
 

--- a/public/frontend/src/components/rec-resource/RecResourceReservation.tsx
+++ b/public/frontend/src/components/rec-resource/RecResourceReservation.tsx
@@ -80,7 +80,8 @@ const RecResourceReservation: React.FC<RecResourceReservationProps> = ({
           <img src={campground} alt="Campground icon" height={24} width={24} />{' '}
           <div>
             <span>This site is first come first served.</span> <br />
-            {isAdditionalFeesAvailable && (
+            {(isAdditionalFeesAvailable ||
+              Boolean(recResource.recreation_fee?.length)) && (
               <>
                 <span>Fees apply when arriving on site.</span> <br />
               </>
@@ -89,9 +90,19 @@ const RecResourceReservation: React.FC<RecResourceReservationProps> = ({
               <span>
                 Check{' '}
                 {isCampingAvailable && (
-                  <a href={`/resource/${recResource.rec_resource_id}#camping`}>
-                    camping
-                  </a>
+                  <>
+                    <a
+                      href={`/resource/${recResource.rec_resource_id}#camping`}
+                    >
+                      camping fees
+                    </a>
+                    {isAdditionalFeesAvailable &&
+                      !isFacilitiesAvailable &&
+                      ' and '}
+                    {isAdditionalFeesAvailable && isFacilitiesAvailable
+                      ? ', '
+                      : ' '}
+                  </>
                 )}
                 {isAdditionalFeesAvailable && (
                   <a

--- a/public/frontend/src/components/rec-resource/section/KnowBeforeYouGo.scss
+++ b/public/frontend/src/components/rec-resource/section/KnowBeforeYouGo.scss
@@ -1,52 +1,53 @@
 @import '@/styles/variables.scss';
-
-.guides {
-  list-style-type: none;
-  margin: 10px 0;
-  padding: 0;
-}
-
-.packing-info {
-  // Fix for Axe accessibility "link-in-text-block" error
-  // Ensure links are distinguished from surrounding text in a way that does not rely on color
-  a {
-    text-decoration: underline;
+.know-before-you-go {
+  .guides {
+    list-style-type: none;
+    margin: 10px 0;
+    padding: 0;
   }
-}
 
-li {
-  margin: 10px 0;
-  padding: 0;
-  color: $colorBlueMed;
-}
+  .packing-info {
+    // Fix for Axe accessibility "link-in-text-block" error
+    // Ensure links are distinguished from surrounding text in a way that does not rely on color
+    a {
+      text-decoration: underline;
+    }
+  }
 
-.small-tittle {
-  font-weight: 700;
-  font-style: Bold;
-  font-size: 16px;
-  line-height: 25.6px;
-}
+  li {
+    margin: 10px 0;
+    padding: 0;
+    color: $colorBlueMed;
+  }
 
-p.small-tittle {
-  margin-bottom: 6px;
-}
+  .small-tittle {
+    font-weight: 700;
+    font-style: Bold;
+    font-size: 16px;
+    line-height: 25.6px;
+  }
 
-h3 {
-  // Unfortunate use of !important due to bootstrap theme headings using !important
-  font-size: 1.5rem !important;
-  margin-bottom: 1rem;
-}
+  p.small-tittle {
+    margin-bottom: 6px;
+  }
 
-.info-box {
-  background-color: $colorBlueLight;
-  color: $colorBlue;
-  font-weight: 700;
-  font-style: Bold;
-  font-size: 16px;
-  line-height: 25.6px;
-  letter-spacing: 0px;
-  border-radius: 4px;
-  padding: 16px;
-  margin-bottom: 32px;
-  margin-top: 10px;
+  h3 {
+    // Unfortunate use of !important due to bootstrap theme headings using !important
+    font-size: 1.5rem !important;
+    margin-bottom: 1rem;
+  }
+
+  .info-box {
+    background-color: $colorBlueLight;
+    color: $colorBlue;
+    font-weight: 700;
+    font-style: Bold;
+    font-size: 16px;
+    line-height: 25.6px;
+    letter-spacing: 0px;
+    border-radius: 4px;
+    padding: 16px;
+    margin-bottom: 32px;
+    margin-top: 10px;
+  }
 }

--- a/public/frontend/src/components/rec-resource/section/KnowBeforeYouGo.test.tsx
+++ b/public/frontend/src/components/rec-resource/section/KnowBeforeYouGo.test.tsx
@@ -6,7 +6,11 @@ import { describe, it, expect } from 'vitest';
 describe('KnowBeforeYouGo', () => {
   it('renders reservable content when isReservable = true', () => {
     render(
-      <KnowBeforeYouGo isAdditionalFeesAvailable={false} isReservable={true} />,
+      <KnowBeforeYouGo
+        isAdditionalFeesAvailable={false}
+        isCampingAvailable={false}
+        isReservable={true}
+      />,
     );
 
     // Section heading
@@ -40,6 +44,7 @@ describe('KnowBeforeYouGo', () => {
     render(
       <KnowBeforeYouGo
         isAdditionalFeesAvailable={false}
+        isCampingAvailable={false}
         isReservable={false}
       />,
     );
@@ -63,7 +68,11 @@ describe('KnowBeforeYouGo', () => {
 
   it('renders additional fees section when isAdditionalFeesAvailable = true and not reservable', () => {
     render(
-      <KnowBeforeYouGo isAdditionalFeesAvailable={true} isReservable={false} />,
+      <KnowBeforeYouGo
+        isAdditionalFeesAvailable={true}
+        isReservable={false}
+        isCampingAvailable={false}
+      />,
     );
 
     // Cash only section appears
@@ -76,6 +85,7 @@ describe('KnowBeforeYouGo', () => {
       <KnowBeforeYouGo
         isAdditionalFeesAvailable={false}
         isReservable={false}
+        isCampingAvailable={false}
       />,
     );
 

--- a/public/frontend/src/components/rec-resource/section/KnowBeforeYouGo.tsx
+++ b/public/frontend/src/components/rec-resource/section/KnowBeforeYouGo.tsx
@@ -19,7 +19,7 @@ const KnowBeforeYouGo: React.FC<KnowBeforeYouGoProps> = ({
   return (
     <section
       id={SectionIds.KNOW_BEFORE_YOU_GO}
-      className="rec-resource-section"
+      className="rec-resource-section know-before-you-go"
     >
       <h2 className="section-heading">{SectionTitles.KNOW_BEFORE_YOU_GO}</h2>
       <section className="mb-4">

--- a/public/frontend/src/components/rec-resource/section/KnowBeforeYouGo.tsx
+++ b/public/frontend/src/components/rec-resource/section/KnowBeforeYouGo.tsx
@@ -7,11 +7,13 @@ import reservations from '@/images/icons/reservations.svg';
 
 interface KnowBeforeYouGoProps {
   isAdditionalFeesAvailable: boolean;
+  isCampingAvailable: boolean;
   isReservable: boolean;
 }
 
 const KnowBeforeYouGo: React.FC<KnowBeforeYouGoProps> = ({
   isAdditionalFeesAvailable,
+  isCampingAvailable,
   isReservable,
 }) => {
   return (
@@ -51,7 +53,7 @@ const KnowBeforeYouGo: React.FC<KnowBeforeYouGoProps> = ({
               </div>
             </div>
           </>
-        ) : isAdditionalFeesAvailable ? (
+        ) : isAdditionalFeesAvailable || isCampingAvailable ? (
           <p>
             This site operates on a First Come, First Served (FCFS) basis.
             Reservations are not available - you must arrive to claim an
@@ -63,10 +65,10 @@ const KnowBeforeYouGo: React.FC<KnowBeforeYouGoProps> = ({
             This site operates on a First Come, First Served (FCFS) basis.
             Reservations are not available - you must arrive to claim an
             available spot in person. No fees apply and spots are limited. Plan
-            to arrive early, especially during busy periods
+            to arrive early, especially during busy periods.
           </p>
         )}
-        {isAdditionalFeesAvailable && !isReservable && (
+        {(isAdditionalFeesAvailable || isCampingAvailable) && !isReservable && (
           <div className="row">
             <div className="col-sm-1">
               <img src={cash} alt="Cash Only icon" height={40} width={40} />
@@ -150,7 +152,7 @@ const KnowBeforeYouGo: React.FC<KnowBeforeYouGoProps> = ({
               rel="noreferer noreferrer"
               aria-label="Alerts, closures, and Warnings (opens in new window)"
             >
-              Alerts, closures, and Warnings
+              Alerts, closures, and warnings
             </a>{' '}
             {'>'}
           </li>


### PR DESCRIPTION
Final adjustments after call with @BAAlexK 

- Consider recreation fee (camping fee) as a condition to fees on reservation and Know Before you know sessions
- Change Know Before you know session visibility to only Recreation sites
- Few text adjustments and conditionals for more elegant display (colons, and, spaces).