### PR TITLE
feat(migrations): add migration scripts for recreation control access code

### DIFF
--- a/admin/backend/prisma/schema.prisma
+++ b/admin/backend/prisma/schema.prisma
@@ -24,6 +24,7 @@ model recreation_resource {
   created_by                           String?
   sys_period                           Unsupported("tstzrange")              @default(dbgenerated("tstzrange(CURRENT_TIMESTAMP, NULL::timestamp with time zone)"))
   project_established_date             DateTime?                             @db.Date
+  control_access_code                  String?                               @db.VarChar(1)
   recreation_access                    recreation_access[]
   recreation_activity                  recreation_activity[]
   recreation_agreement_holder          recreation_agreement_holder?
@@ -31,6 +32,7 @@ model recreation_resource {
   recreation_driving_direction         recreation_driving_direction?
   recreation_fee                       recreation_fee[]
   recreation_map_feature               recreation_map_feature[]
+  recreation_control_access_code       recreation_control_access_code?       @relation(fields: [control_access_code], references: [recreation_control_access_code], onDelete: NoAction, onUpdate: NoAction)
   recreation_district_code             recreation_district_code?             @relation(fields: [district_code], references: [district_code], onDelete: NoAction, onUpdate: NoAction)
   recreation_maintenance_standard_code recreation_maintenance_standard_code? @relation(fields: [maintenance_standard_code], references: [maintenance_standard_code], onDelete: NoAction, onUpdate: NoAction)
   recreation_resource_docs             recreation_resource_docs[]
@@ -886,6 +888,39 @@ model recreation_resource_reservation_info_history {
   created_at               DateTime?                @db.Timestamp(6)
   created_by               String?
   sys_period               Unsupported("tstzrange")
+
+  @@ignore
+  @@schema("rst")
+}
+
+model recreation_control_access_code {
+  recreation_control_access_code String                   @id @db.VarChar(1)
+  description                    String?                  @db.VarChar(120)
+  effective_date                 DateTime?                @db.Date
+  expiry_date                    DateTime?                @db.Date
+  update_timestamp               DateTime?                @db.Timestamp(6)
+  updated_at                     DateTime?                @default(now()) @db.Timestamp(6)
+  updated_by                     String?
+  created_at                     DateTime?                @default(now()) @db.Timestamp(6)
+  created_by                     String?
+  sys_period                     Unsupported("tstzrange") @default(dbgenerated("tstzrange(CURRENT_TIMESTAMP, NULL::timestamp with time zone)"))
+  recreation_resource            recreation_resource[]
+
+  @@schema("rst")
+}
+
+/// The underlying table does not contain a valid unique identifier and can therefore currently not be handled by Prisma Client.
+model recreation_control_access_code_history {
+  recreation_control_access_code String                   @db.VarChar(1)
+  description                    String?                  @db.VarChar(120)
+  effective_date                 DateTime?                @db.Date
+  expiry_date                    DateTime?                @db.Date
+  update_timestamp               DateTime?                @db.Timestamp(6)
+  updated_at                     DateTime?                @db.Timestamp(6)
+  updated_by                     String?
+  created_at                     DateTime?                @db.Timestamp(6)
+  created_by                     String?
+  sys_period                     Unsupported("tstzrange")
 
   @@ignore
   @@schema("rst")

--- a/migrations/fixtures/sql/V1.0.0__recreation_resource.sql
+++ b/migrations/fixtures/sql/V1.0.0__recreation_resource.sql
@@ -7,7 +7,8 @@ insert into
     display_on_public_site,
     district_code,
     maintenance_standard_code,
-    project_established_date
+    project_established_date,
+    control_access_code
   )
 values
   (
@@ -18,7 +19,8 @@ values
     true,
     'RDKA',
     'M',
-    '2015-03-15'
+    '2015-03-15',
+    'G'
   ),
   (
     'REC1222',
@@ -28,7 +30,8 @@ values
     true,
     'RDPG',
     null,
-    '2008-01-15'
+    '2008-01-15',
+    'R'
   ),
   (
     'REC160773',
@@ -38,7 +41,8 @@ values
     true,
     'RDKA',
     'U',
-    '2012-07-22'
+    '2012-07-22',
+    'G'
   ),
   (
     'REC203239',
@@ -48,7 +52,8 @@ values
     true,
     'RDKA',
     'M',
-    '2014-11-08'
+    '2014-11-08',
+    null
   ),
   (
     'REC6866',
@@ -58,7 +63,8 @@ values
     true,
     'RDVA',
     'M',
-    '1998-05-12'
+    '1998-05-12',
+    'G'
   ),
   (
     'REC203900',
@@ -68,7 +74,8 @@ values
     true,
     'RDRM',
     'M',
-    '2016-09-30'
+    '2016-09-30',
+    'G'
   ),
   (
     'REC160432',
@@ -78,7 +85,8 @@ values
     true,
     'RDKA',
     null,
-    '2011-02-14'
+    '2011-02-14',
+    'G'
   ),
   (
     'REC6739',
@@ -88,7 +96,8 @@ values
     true,
     'RDKB',
     'M',
-    '2007-12-03'
+    '2007-12-03',
+    'G'
   ),
   (
     'REC16158',
@@ -98,7 +107,8 @@ values
     true,
     'RDSQ',
     'U',
-    '2013-06-18'
+    '2013-06-18',
+    'G'
   ),
   (
     'REC2094',
@@ -108,7 +118,8 @@ values
     true,
     'RDKB',
     'M',
-    '2009-04-25'
+    '2009-04-25',
+    'G'
   ),
   (
     'REC6897',
@@ -118,7 +129,8 @@ values
     true,
     'RDMH',
     'M',
-    '2005-08-16'
+    '2005-08-16',
+    'G'
   ),
   (
     'REC2206',
@@ -128,7 +140,8 @@ values
     true,
     'RDKB',
     null,
-    '2010-03-07'
+    '2010-03-07',
+    'G'
   ),
   (
     'REC206043',
@@ -138,7 +151,8 @@ values
     true,
     'RDSI',
     'M',
-    '2017-10-14'
+    '2017-10-14',
+    'R'
   ),
   (
     'REC166903',
@@ -148,7 +162,8 @@ values
     true,
     'RDOS',
     'M',
-    '2006-01-28'
+    '2006-01-28',
+    null
   ),
   (
     'REC32013',
@@ -158,7 +173,8 @@ values
     true,
     'RDOS',
     'M',
-    '2004-11-19'
+    '2004-11-19',
+    null
   ),
   (
     'REC261475',
@@ -168,7 +184,8 @@ values
     true,
     'RDOS',
     null,
-    '2018-07-01'
+    '2018-07-01',
+    null
   ),
   (
     'REC166942',
@@ -178,7 +195,8 @@ values
     true,
     'RDOS',
     'M',
-    '2003-09-12'
+    '2003-09-12',
+    null
   ),
   (
     'REC2792',
@@ -188,7 +206,8 @@ values
     true,
     'RDOS',
     'U',
-    '2001-12-05'
+    '2001-12-05',
+    null
   ),
   (
     'REC230522',
@@ -198,7 +217,8 @@ values
     true,
     'RDOS',
     'M',
-    '2019-02-15'
+    '2019-02-15',
+    null
   ),
   (
     'REC205035',
@@ -208,7 +228,8 @@ values
     true,
     'RDOS',
     null,
-    '2016-04-20'
+    '2016-04-20',
+    null
   ),
   (
     'REC2566',
@@ -218,7 +239,8 @@ values
     true,
     'RDPG',
     'M',
-    '2002-06-08'
+    '2002-06-08',
+    null
   ),
   (
     'REC1735',
@@ -228,7 +250,8 @@ values
     true,
     'RDKA',
     'M',
-    '2008-10-11'
+    '2008-10-11',
+    'G'
   ),
   (
     'REC2978',
@@ -238,7 +261,8 @@ values
     true,
     'RDPG',
     'U',
-    '2000-05-20'
+    '2000-05-20',
+    null
   ),
   (
     'REC136003',
@@ -248,7 +272,8 @@ values
     true,
     'RDKA',
     'U',
-    '2014-08-03'
+    '2014-08-03',
+    null
   ),
   (
     'REC265901',
@@ -258,7 +283,8 @@ values
     true,
     'RDKA',
     null,
-    '2011-09-27'
+    '2011-09-27',
+    null
   ),
   (
     'REC1585',
@@ -268,7 +294,8 @@ values
     true,
     'RDKA',
     null,
-    '2007-03-14'
+    '2007-03-14',
+    null
   ),
   (
     'REC262200',
@@ -278,7 +305,8 @@ values
     true,
     'RDKA',
     null,
-    '2015-12-01'
+    '2015-12-01',
+    null
   ),
   (
     'REC265549',
@@ -288,7 +316,8 @@ values
     true,
     'RDCC',
     'U',
-    '2012-01-18'
+    '2012-01-18',
+    'G'
   ),
   (
     'REC270155',
@@ -298,7 +327,8 @@ values
     true,
     'RDCC',
     'U',
-    '2009-07-09'
+    '2009-07-09',
+    null
   ),
   (
     'REC0587',
@@ -308,7 +338,8 @@ values
     true,
     'RDCC',
     'U',
-    '2006-04-22'
+    '2006-04-22',
+    null
   ),
   (
     'REC166367',
@@ -318,7 +349,8 @@ values
     true,
     'RDCC',
     'M',
-    '2003-11-30'
+    '2003-11-30',
+    null
   ),
   (
     'REC1621',
@@ -328,7 +360,8 @@ values
     true,
     'RDOS',
     'M',
-    '2013-02-26'
+    '2013-02-26',
+    null
   ),
   (
     'REC1164',
@@ -338,7 +371,8 @@ values
     true,
     'RDCO',
     null,
-    '2010-08-17'
+    '2010-08-17',
+    'G'
   ),
   (
     'REC5763',
@@ -348,7 +382,8 @@ values
     true,
     'RDCO',
     'M',
-    '2005-12-04'
+    '2005-12-04',
+    'G'
   ),
   (
     'REC4519',
@@ -358,7 +393,8 @@ values
     true,
     'RDCO',
     'U',
-    null
+    null,
+    'G'
   ),
   (
     'REC265446',
@@ -368,7 +404,8 @@ values
     true,
     'RDCK',
     'U',
-    null
+    null,
+    'G'
   ),
   (
     'REC262362',
@@ -378,7 +415,8 @@ values
     true,
     'RDCK',
     'U',
-    null
+    null,
+    'G'
   ),
   (
     'REC192109',
@@ -388,7 +426,8 @@ values
     true,
     'RDCR',
     'M',
-    null
+    null,
+    'G'
   ),
   (
     'REC204480',
@@ -398,7 +437,8 @@ values
     true,
     'RDPG',
     null,
-    null
+    null,
+    'G'
   ),
   (
     'REC0180',
@@ -408,7 +448,8 @@ values
     true,
     'RDPG',
     null,
-    null
+    null,
+    'G'
   ),
   (
     'REC97746',
@@ -418,7 +459,8 @@ values
     true,
     'RDKM',
     'M',
-    null
+    null,
+    'G'
   ),
   (
     'REC2047',
@@ -428,7 +470,8 @@ values
     true,
     'RDKM',
     'U',
-    null
+    null,
+    'G'
   ),
   (
     'REC2054',
@@ -438,7 +481,8 @@ values
     true,
     'RDKM',
     'U',
-    null
+    null,
+    'G'
   ),
   (
     'REC0108',
@@ -448,7 +492,8 @@ values
     true,
     'RDKM',
     null,
-    null
+    null,
+    'G'
   ),
   (
     'REC13876',
@@ -458,7 +503,8 @@ values
     true,
     'RDSI',
     null,
-    null
+    null,
+    'G'
   ),
   (
     'REC1605',
@@ -468,7 +514,8 @@ values
     true,
     'RDKA',
     'U',
-    null
+    null,
+    'G'
   ),
   (
     'REC1163',
@@ -478,7 +525,8 @@ values
     true,
     'RDKA',
     'M',
-    null
+    null,
+    'G'
   ),
   (
     'REC5973',
@@ -488,7 +536,8 @@ values
     true,
     'RDSQ',
     'U',
-    null
+    null,
+    'G'
   ),
   (
     'REC1298',
@@ -498,6 +547,7 @@ values
     true,
     'RDSQ',
     'M',
+    null,
     null
   ),
   (
@@ -508,6 +558,7 @@ values
     true,
     'RDSQ',
     'M',
+    null,
     null
   ),
   (
@@ -518,5 +569,6 @@ values
     true,
     'RDSQ',
     'M',
+    null,
     null
-  );
+  )

--- a/migrations/fta/sql/V1.0.2__fta_to_rst_rec_resource.sql
+++ b/migrations/fta/sql/V1.0.2__fta_to_rst_rec_resource.sql
@@ -10,7 +10,8 @@ insert into rst.recreation_resource (
     description,
     district_code,
     maintenance_standard_code,
-    project_established_date
+    project_established_date,
+    control_access_code
 )
 select
     rp.forest_file_id as rec_resource_id,
@@ -27,7 +28,8 @@ select
     rp.site_description as description,
     xref.recreation_district_code as district_code,
     rp.recreation_maintain_std_code as maintenance_standard_code,
-    rp.project_established_date as project_established_date
+    rp.project_established_date as project_established_date,
+    rp.recreation_control_access_code as control_access_code
 from
     fta.recreation_project rp
 left join
@@ -52,4 +54,5 @@ set
     description = excluded.description,
     district_code = excluded.district_code,
     maintenance_standard_code = excluded.maintenance_standard_code,
-    project_established_date = excluded.project_established_date;
+    project_established_date = excluded.project_established_date,
+    control_access_code = excluded.control_access_code;

--- a/migrations/fta/sql/V1.1.18__fta_to_recreation_control_access_code.sql
+++ b/migrations/fta/sql/V1.1.18__fta_to_recreation_control_access_code.sql
@@ -1,0 +1,7 @@
+insert into rst.recreation_control_access_code (recreation_control_access_code,
+                                                description,
+                                                expiry_date,
+                                                effective_date,
+                                                update_timestamp)
+select *
+from fta.recreation_control_access_code ca;

--- a/migrations/rst/sql/V1.1.34__recreation_control_access_code.sql
+++ b/migrations/rst/sql/V1.1.34__recreation_control_access_code.sql
@@ -1,0 +1,47 @@
+
+-- Create table: rst.recreation_control_access_code
+CREATE TABLE IF NOT EXISTS rst.recreation_control_access_code
+(
+    recreation_control_access_code varchar(1) NOT NULL PRIMARY KEY,
+    description                    varchar(120),
+    effective_date                 date,
+    expiry_date                    date,
+    update_timestamp               timestamp
+);
+
+
+select upsert_timestamp_columns('rst', 'recreation_control_access_code');
+
+select setup_temporal_table('rst', 'recreation_control_access_code');
+
+comment on table rst.recreation_control_access_code is
+    'Describes the Controlled Access Code for a rec resource. E.g. “Gated”, “Restricted Use”.';
+
+comment on column rst.recreation_control_access_code.recreation_control_access_code is
+    'The Controlled Access Code for a rec resource. E.g. “Gated”, “Restricted Use”.';
+
+comment on column rst.recreation_control_access_code.description is
+    'The description of the Controlled Access Code for a rec resource.';
+
+comment on column rst.recreation_control_access_code.effective_date is
+    'The effective date of the Controlled Access Code for a rec resource.';
+
+comment on column rst.recreation_control_access_code.expiry_date is
+    'The expiry date of the Controlled Access Code for a rec resource.';
+
+comment on column rst.recreation_control_access_code.update_timestamp is
+    'The update timestamp of the Controlled Access Code for a rec resource.';
+
+-- just need the code and descriptions, no need for existing effective and expiry dates as they have no use yet!.
+insert into rst.recreation_control_access_code (recreation_control_access_code, description)
+values  ('G', 'Gated'),
+        ('R', 'Restricted Use');
+
+
+-- Add control_access_code column to recreation_resource table
+alter table rst.recreation_resource
+    add column if not exists control_access_code varchar(1)
+        references rst.recreation_control_access_code (recreation_control_access_code);
+
+comment on column rst.recreation_resource.control_access_code is
+    'Describes the Controlled Access Code for a rec resource. E.g. “Gated”, “Restricted Use”.';


### PR DESCRIPTION
# Description
- Add migration scripts to import `fta.recreation_control_access_code` table into rst schema 
- add history table for this new table
- added new column in `rst.recreation_resource` which refers to `rst.recreation_control_access_code`