### PR TITLE
fix(fta-migrations): remove unwanted fta to rst migration script for control access code

### DIFF
--- a/migrations/fta/sql/V1.1.18__fta_to_recreation_control_access_code.sql
+++ b/migrations/fta/sql/V1.1.18__fta_to_recreation_control_access_code.sql
@@ -1,7 +1,0 @@
-insert into rst.recreation_control_access_code (recreation_control_access_code,
-                                                description,
-                                                expiry_date,
-                                                effective_date,
-                                                update_timestamp)
-select *
-from fta.recreation_control_access_code ca;


### PR DESCRIPTION
# Description

- `rst.recreation_control_access_code` table was being seeded twice which lead to db contratint errors during flyway migrations. so this pr removes the unwanted script