### PR TITLE
chore: update recreation resource map text styles

### DIFF
--- a/public/frontend/src/components/rec-resource/RecreationResourceMap/constants.ts
+++ b/public/frontend/src/components/rec-resource/RecreationResourceMap/constants.ts
@@ -14,24 +14,24 @@ export enum StyleContext {
 }
 
 export const ICON_SCALE = {
-  [StyleContext.MAP_DISPLAY]: 0.6,
-  [StyleContext.DOWNLOAD]: 0.3,
+  [StyleContext.MAP_DISPLAY]: 0.5,
+  [StyleContext.DOWNLOAD]: 0.4,
 };
 
 export const TEXT_STYLE = {
   [StyleContext.MAP_DISPLAY]: {
-    backgroundFill: new Fill({ color: 'rgba(255, 255, 255, 0)' }), // transparent
+    font: '14px BC Sans,sans-serif',
     fill: new Fill({ color: '#000' }),
-    stroke: new Stroke({
-      color: TEXT_STROKE_COLOR,
-    }),
+    stroke: new Stroke({ color: '#fff', width: 2 }),
+    scale: 1.3,
   },
   [StyleContext.DOWNLOAD]: {
-    backgroundFill: new Fill({ color: '#000' }),
+    font: '14px BC Sans,sans-serif',
     fill: new Fill({ color: '#FFF' }),
     stroke: new Stroke({
       color: TEXT_STROKE_COLOR,
     }),
+    scale: 0.9,
   },
 };
 

--- a/public/frontend/src/components/rec-resource/RecreationResourceMap/helpers/layerStyleHelpers.test.ts
+++ b/public/frontend/src/components/rec-resource/RecreationResourceMap/helpers/layerStyleHelpers.test.ts
@@ -43,7 +43,7 @@ describe('Map Style Functions', () => {
       expect(Icon).toHaveBeenCalled();
       expect(Icon).toHaveBeenCalledWith(
         expect.objectContaining({
-          scale: 0.3,
+          scale: 0.4,
         }),
       );
     });
@@ -62,7 +62,7 @@ describe('Map Style Functions', () => {
       expect(Icon).toHaveBeenCalled();
       expect(Icon).toHaveBeenCalledWith(
         expect.objectContaining({
-          scale: 0.3,
+          scale: 0.4,
         }),
       );
     });
@@ -81,7 +81,7 @@ describe('Map Style Functions', () => {
       expect(Icon).toHaveBeenCalled();
       expect(Icon).toHaveBeenCalledWith(
         expect.objectContaining({
-          scale: 0.3,
+          scale: 0.4,
         }),
       );
     });
@@ -134,14 +134,15 @@ describe('Map Style Functions', () => {
   });
 
   describe('createTextStyle', () => {
-    it('creates Text style for line type with default download styles (isForMapDisplay = false)', () => {
+    it('creates Text style for line type with download styles', () => {
       createTextStyle('Test Label', true, false, StyleContext.DOWNLOAD);
       expect(Text).toHaveBeenCalledWith({
         text: 'Test Label',
+        font: TEXT_STYLE[StyleContext.DOWNLOAD].font,
+        fill: TEXT_STYLE[StyleContext.DOWNLOAD].fill,
+        stroke: TEXT_STYLE[StyleContext.DOWNLOAD].stroke,
+        scale: TEXT_STYLE[StyleContext.DOWNLOAD].scale,
         placement: 'line',
-        fill: TEXT_STYLE.DOWNLOAD.fill,
-        backgroundFill: TEXT_STYLE.DOWNLOAD.backgroundFill,
-        stroke: TEXT_STYLE.DOWNLOAD.stroke,
         textBaseline: 'middle',
         offsetY: 0,
         textAlign: 'center',
@@ -149,37 +150,18 @@ describe('Map Style Functions', () => {
         padding: [2, 5, 2, 5],
         rotateWithView: true,
         declutterMode: 'declutter',
-        scale: 1.3,
       });
     });
 
-    it('creates Text style for line type with map display styles (isForMapDisplay = true)', () => {
-      createTextStyle('Test Label', true, false, StyleContext.DOWNLOAD);
+    it('creates Text style for point type with download styles', () => {
+      createTextStyle('Test Label', false, true, StyleContext.DOWNLOAD);
       expect(Text).toHaveBeenCalledWith({
         text: 'Test Label',
-        placement: 'line',
-        fill: TEXT_STYLE.DOWNLOAD.fill,
-        backgroundFill: TEXT_STYLE.DOWNLOAD.backgroundFill,
-        stroke: TEXT_STYLE.DOWNLOAD.stroke,
-        textBaseline: 'middle',
-        offsetY: 0,
-        textAlign: 'center',
-        repeat: 300,
-        padding: [2, 5, 2, 5],
-        rotateWithView: true,
-        declutterMode: 'declutter',
-        scale: 1.3,
-      });
-    });
-
-    it('creates Text style for point type with default download styles', () => {
-      createTextStyle('Test Label', false, true);
-      expect(Text).toHaveBeenCalledWith({
-        text: 'Test Label',
+        font: TEXT_STYLE[StyleContext.DOWNLOAD].font,
+        fill: TEXT_STYLE[StyleContext.DOWNLOAD].fill,
+        stroke: TEXT_STYLE[StyleContext.DOWNLOAD].stroke,
+        scale: TEXT_STYLE[StyleContext.DOWNLOAD].scale,
         placement: 'point',
-        fill: TEXT_STYLE.DOWNLOAD.fill,
-        backgroundFill: TEXT_STYLE.DOWNLOAD.backgroundFill,
-        stroke: TEXT_STYLE.DOWNLOAD.stroke,
         textBaseline: 'bottom',
         offsetY: -25,
         textAlign: 'center',
@@ -187,18 +169,37 @@ describe('Map Style Functions', () => {
         padding: [2, 5, 2, 5],
         rotateWithView: false,
         declutterMode: 'declutter',
-        scale: 1.3,
+      });
+    });
+
+    it('creates Text style for line type with map display styles', () => {
+      createTextStyle('Test Label', true, false, StyleContext.MAP_DISPLAY);
+      expect(Text).toHaveBeenCalledWith({
+        text: 'Test Label',
+        font: TEXT_STYLE[StyleContext.MAP_DISPLAY].font,
+        fill: TEXT_STYLE[StyleContext.MAP_DISPLAY].fill,
+        stroke: TEXT_STYLE[StyleContext.MAP_DISPLAY].stroke,
+        scale: TEXT_STYLE[StyleContext.MAP_DISPLAY].scale,
+        placement: 'line',
+        textBaseline: 'middle',
+        offsetY: 0,
+        textAlign: 'center',
+        repeat: 300,
+        padding: [2, 5, 2, 5],
+        rotateWithView: true,
+        declutterMode: 'declutter',
       });
     });
 
     it('creates Text style for point type with map display styles', () => {
-      createTextStyle('Test Label', false, true, StyleContext.DOWNLOAD);
+      createTextStyle('Test Label', false, true, StyleContext.MAP_DISPLAY);
       expect(Text).toHaveBeenCalledWith({
         text: 'Test Label',
+        font: TEXT_STYLE[StyleContext.MAP_DISPLAY].font,
+        fill: TEXT_STYLE[StyleContext.MAP_DISPLAY].fill,
+        stroke: TEXT_STYLE[StyleContext.MAP_DISPLAY].stroke,
+        scale: TEXT_STYLE[StyleContext.MAP_DISPLAY].scale,
         placement: 'point',
-        fill: TEXT_STYLE.DOWNLOAD.fill,
-        backgroundFill: TEXT_STYLE.DOWNLOAD.backgroundFill,
-        stroke: TEXT_STYLE.DOWNLOAD.stroke,
         textBaseline: 'bottom',
         offsetY: -25,
         textAlign: 'center',
@@ -206,7 +207,6 @@ describe('Map Style Functions', () => {
         padding: [2, 5, 2, 5],
         rotateWithView: false,
         declutterMode: 'declutter',
-        scale: 1.3,
       });
     });
   });

--- a/public/frontend/src/components/rec-resource/RecreationResourceMap/helpers/layerStyleHelpers.ts
+++ b/public/frontend/src/components/rec-resource/RecreationResourceMap/helpers/layerStyleHelpers.ts
@@ -10,8 +10,6 @@ import {
 import { isRecreationTrail } from '@/utils/recreationResourceUtils';
 import locationDotOrange from '@/assets/location-dot-orange.png';
 
-const TEXT_SCALE = 1.3;
-
 /**
  * Returns the appropriate icon URL for a given recreation resource.
  * Checks the resource type using utility functions and selects the icon accordingly.
@@ -91,10 +89,11 @@ export const createTextStyle = (
   const textStyle = TEXT_STYLE[styleContext];
   return new Text({
     text: label,
-    placement: isLineType ? 'line' : 'point',
+    font: textStyle.font,
     fill: textStyle.fill,
-    backgroundFill: textStyle.backgroundFill,
     stroke: textStyle.stroke,
+    scale: textStyle.scale,
+    placement: isLineType ? 'line' : 'point',
     textBaseline: isLineType ? 'middle' : 'bottom',
     offsetY: isPoint ? -25 : 0, // Offset label above point
     textAlign: 'center',
@@ -102,6 +101,5 @@ export const createTextStyle = (
     padding: [2, 5, 2, 5],
     rotateWithView: isLineType,
     declutterMode: 'declutter',
-    scale: TEXT_SCALE,
   });
 };


### PR DESCRIPTION
Before:
<img width="749" height="511" alt="Screenshot 2025-09-25 at 12 04 47 PM" src="https://github.com/user-attachments/assets/91555169-b6c4-400d-94e0-335ee827be40" />

After:
<img width="749" height="511" alt="Screenshot 2025-09-25 at 12 04 34 PM" src="https://github.com/user-attachments/assets/8ca59850-1edb-4965-b405-049bea7e15b4" />
