### PR TITLE
feat: add extra sub header links and create mobile navigation menu

### DIFF
--- a/public/frontend/src/components/layout/Footer.scss
+++ b/public/frontend/src/components/layout/Footer.scss
@@ -14,7 +14,7 @@
     left: 50%;
     transform: translate(-50%, -50%);
     background-color: $colorBlueMed;
-    z-index: 10;
+    z-index: $zIndexFooter;
     width: calc(100% - 2rem);
     height: $landAckBoxHeight;
 

--- a/public/frontend/src/components/layout/HamburgerButton.scss
+++ b/public/frontend/src/components/layout/HamburgerButton.scss
@@ -18,7 +18,7 @@
   border-radius: 4px;
   transition: background-color 0.2s ease;
 
-  @include media-breakpoint-up(lg) {
+  @include media-breakpoint-up(md) {
     display: none;
   }
 

--- a/public/frontend/src/components/layout/HamburgerButton.scss
+++ b/public/frontend/src/components/layout/HamburgerButton.scss
@@ -1,0 +1,28 @@
+@import '@/styles/variables.scss';
+@import '@/styles/global.scss';
+@import 'bootstrap/scss/functions';
+@import 'bootstrap/scss/variables';
+@import 'bootstrap/scss/mixins/_breakpoints';
+
+.hamburger-toggle {
+  display: flex;
+  background: none;
+  border: none;
+  color: $colorWhite;
+  font-size: 1.5rem;
+  padding: 1rem;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border-radius: 4px;
+  transition: background-color 0.2s ease;
+
+  @include media-breakpoint-up(lg) {
+    display: none;
+  }
+
+  &:hover {
+    background-color: rgba(255, 255, 255, 0.1);
+  }
+}

--- a/public/frontend/src/components/layout/HamburgerButton.test.tsx
+++ b/public/frontend/src/components/layout/HamburgerButton.test.tsx
@@ -1,0 +1,76 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import HamburgerButton from '@/components/layout/HamburgerButton';
+
+vi.mock('@fortawesome/react-fontawesome', () => ({
+  FontAwesomeIcon: ({ icon }: any) => (
+    <span data-testid="font-awesome-icon" data-icon={icon.iconName} />
+  ),
+}));
+
+describe('HamburgerButton', () => {
+  const defaultProps = {
+    isOpen: false,
+    onToggle: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders correctly when closed', () => {
+    render(<HamburgerButton {...defaultProps} />);
+
+    const button = screen.getByRole('button');
+    expect(button).toBeInTheDocument();
+    expect(button).toHaveClass('hamburger-toggle');
+    expect(button).toHaveAttribute('aria-label', 'Open menu');
+    expect(button).toHaveAttribute('aria-expanded', 'false');
+
+    const icon = screen.getByTestId('font-awesome-icon');
+    expect(icon).toHaveAttribute('data-icon', 'bars');
+  });
+
+  it('renders correctly when open', () => {
+    render(<HamburgerButton {...defaultProps} isOpen={true} />);
+
+    const button = screen.getByRole('button');
+    expect(button).toHaveAttribute('aria-label', 'Close menu');
+    expect(button).toHaveAttribute('aria-expanded', 'true');
+
+    const icon = screen.getByTestId('font-awesome-icon');
+    expect(icon).toHaveAttribute('data-icon', 'xmark');
+  });
+
+  it('calls onToggle when clicked', () => {
+    const mockOnToggle = vi.fn();
+    render(<HamburgerButton {...defaultProps} onToggle={mockOnToggle} />);
+
+    const button = screen.getByRole('button');
+    fireEvent.click(button);
+
+    expect(mockOnToggle).toHaveBeenCalledTimes(1);
+  });
+
+  it('toggles icon between bars and xmark', () => {
+    const { rerender } = render(<HamburgerButton {...defaultProps} />);
+
+    let icon = screen.getByTestId('font-awesome-icon');
+    expect(icon).toHaveAttribute('data-icon', 'bars');
+
+    rerender(<HamburgerButton {...defaultProps} isOpen={true} />);
+    icon = screen.getByTestId('font-awesome-icon');
+    expect(icon).toHaveAttribute('data-icon', 'xmark');
+
+    rerender(<HamburgerButton {...defaultProps} isOpen={false} />);
+    icon = screen.getByTestId('font-awesome-icon');
+    expect(icon).toHaveAttribute('data-icon', 'bars');
+  });
+
+  it('has correct accessibility attributes', () => {
+    render(<HamburgerButton {...defaultProps} />);
+
+    const button = screen.getByRole('button');
+    expect(button).toHaveAttribute('aria-label');
+    expect(button).toHaveAttribute('aria-expanded');
+  });
+});

--- a/public/frontend/src/components/layout/HamburgerButton.tsx
+++ b/public/frontend/src/components/layout/HamburgerButton.tsx
@@ -1,0 +1,27 @@
+import { forwardRef } from 'react';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faBars, faXmark } from '@fortawesome/free-solid-svg-icons';
+import '@/components/layout/HamburgerButton.scss';
+
+interface HamburgerButtonProps {
+  isOpen: boolean;
+  onToggle: () => void;
+}
+
+const HamburgerButton = forwardRef<HTMLButtonElement, HamburgerButtonProps>(
+  ({ isOpen, onToggle }, ref) => {
+    return (
+      <button
+        ref={ref}
+        className="hamburger-toggle"
+        onClick={onToggle}
+        aria-label={isOpen ? 'Close menu' : 'Open menu'}
+        aria-expanded={isOpen}
+      >
+        <FontAwesomeIcon icon={isOpen ? faXmark : faBars} />
+      </button>
+    );
+  },
+);
+
+export default HamburgerButton;

--- a/public/frontend/src/components/layout/Header.scss
+++ b/public/frontend/src/components/layout/Header.scss
@@ -33,7 +33,7 @@
     justify-content: flex-start;
     height: 40px;
 
-    @include media-breakpoint-up(lg) {
+    @include media-breakpoint-up(md) {
       display: flex;
     }
 

--- a/public/frontend/src/components/layout/Header.scss
+++ b/public/frontend/src/components/layout/Header.scss
@@ -4,15 +4,18 @@
 @import 'bootstrap/scss/variables';
 @import 'bootstrap/scss/mixins/_breakpoints';
 
+#header {
+  position: relative;
+}
+
 .header-nav {
   @extend .page;
   position: relative;
   display: flex;
-  flex-wrap: wrap;
   align-items: center;
+  justify-content: space-between;
   margin: 0px auto;
   padding: 0.5rem 1rem;
-  justify-content: space-between;
 
   @include media-breakpoint-up(sm) {
     height: 96px;
@@ -25,11 +28,13 @@
   }
 
   &.sub {
+    display: none;
     background-color: $colorBlueMed;
     justify-content: flex-start;
+    height: 40px;
 
-    @include media-breakpoint-up(sm) {
-      height: 40px;
+    @include media-breakpoint-up(lg) {
+      display: flex;
     }
 
     & a {
@@ -47,6 +52,13 @@
     @include media-breakpoint-up(sm) {
       height: 64px;
     }
+  }
+
+  .header-actions {
+    max-width: fit-content;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
   }
 
   .header-feedback-btn {

--- a/public/frontend/src/components/layout/Header.test.tsx
+++ b/public/frontend/src/components/layout/Header.test.tsx
@@ -1,38 +1,194 @@
-import { render, screen, within } from '@testing-library/react';
-import Header from './Header';
+import { render, screen, within, fireEvent } from '@testing-library/react';
+import Header from '@/components/layout/Header';
+import { HEADER_LINKS } from '@/components/layout/constants';
 
-// Mock the Link component from react-router to avoid router context issues
 vi.mock('react-router', async () => {
   const actual = await vi.importActual('react-router');
   return {
     ...actual,
-    Link: ({ children, to, ...props }: any) => (
-      <a href={to} {...props}>
+    Link: ({ children, to, onClick, ...props }: any) => (
+      <a href={to} onClick={onClick} {...props}>
         {children}
       </a>
     ),
   };
 });
 
-describe('the Header component', () => {
-  it('renders the component correctly', () => {
-    render(<Header />);
-    const findSiteLink = screen.getByText('Find a site or trail');
-    expect(findSiteLink).toBeInTheDocument();
+vi.mock('@/components/layout/BetaBanner', () => ({
+  default: () => <div data-testid="beta-banner">Beta Banner</div>,
+}));
+
+vi.mock('@/utils/matomo', () => ({
+  trackClickEvent: vi.fn(() => vi.fn()),
+}));
+
+vi.mock('@fortawesome/react-fontawesome', () => ({
+  FontAwesomeIcon: ({ icon }: any) => (
+    <span data-testid="font-awesome-icon" data-icon={icon.iconName} />
+  ),
+}));
+
+import { trackClickEvent } from '@/utils/matomo';
+
+const mockTrackClickEvent = vi.mocked(trackClickEvent);
+
+describe('Header component', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockTrackClickEvent.mockReturnValue(vi.fn());
   });
 
-  it('shows the "Share feedback" button for mobile inside main nav', () => {
+  it('renders the component correctly', () => {
     render(<Header />);
 
-    const mainNav = screen.getByRole('navigation', {
-      name: /main header navigation/i,
+    expect(screen.getByRole('banner')).toBeInTheDocument();
+    expect(
+      screen.getByAltText('Recreation Sites and Trails BC Logo'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('navigation', { name: /main header navigation/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('navigation', {
+        name: /secondary header site navigation/i,
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it('renders hamburger button with correct initial state', () => {
+    render(<Header />);
+    const hamburgerButton = screen.getByRole('button', { name: /open menu/i });
+    expect(hamburgerButton).toBeInTheDocument();
+    expect(hamburgerButton).toHaveAttribute('aria-expanded', 'false');
+    expect(hamburgerButton).toHaveAttribute('aria-label', 'Open menu');
+  });
+
+  it('renders navigation drawer with correct initial state', () => {
+    render(<Header />);
+    const navigationDrawer = screen.getByRole('navigation', {
+      name: /mobile navigation menu/i,
+    });
+    expect(navigationDrawer).toBeInTheDocument();
+    expect(navigationDrawer).toHaveClass('menu-closed');
+  });
+
+  it('renders all header links correctly', () => {
+    render(<Header />);
+
+    const desktopNav = screen.getByRole('navigation', {
+      name: /secondary header site navigation/i,
     });
 
-    const feedbackButton = within(mainNav).getByRole('button', {
-      name: /share your feedback/i,
+    HEADER_LINKS.forEach((link) => {
+      const linkElement = within(desktopNav).getByText(link.label);
+      expect(linkElement).toBeInTheDocument();
+
+      if (link.isExternal) {
+        expect(linkElement.closest('a')).toHaveAttribute('href', link.url);
+        expect(linkElement.closest('a')).toHaveAttribute('target', '_blank');
+        expect(linkElement.closest('a')).toHaveAttribute(
+          'rel',
+          'noopener noreferrer',
+        );
+
+        const icon = within(linkElement.closest('a')!).getByTestId(
+          'font-awesome-icon',
+        );
+        expect(icon).toHaveAttribute('data-icon', 'arrow-up-right-from-square');
+      } else {
+        expect(linkElement.closest('a')).toHaveAttribute('href', link.url);
+        expect(linkElement.closest('a')).not.toHaveAttribute('target');
+      }
+    });
+  });
+
+  it('toggles hamburger menu when hamburger button is clicked', () => {
+    render(<Header />);
+
+    const hamburgerButton = screen.getByRole('button', { name: /open menu/i });
+    const navigationDrawer = screen.getByRole('navigation', {
+      name: /mobile navigation menu/i,
     });
 
-    expect(feedbackButton).toBeInTheDocument();
-    expect(feedbackButton).toHaveClass('header-feedback-btn');
+    expect(hamburgerButton).toHaveAttribute('aria-expanded', 'false');
+    expect(navigationDrawer).toHaveClass('menu-closed');
+
+    fireEvent.click(hamburgerButton);
+
+    expect(hamburgerButton).toHaveAttribute('aria-expanded', 'true');
+    expect(hamburgerButton).toHaveAttribute('aria-label', 'Close menu');
+    expect(navigationDrawer).toHaveClass('menu-open');
+
+    fireEvent.click(hamburgerButton);
+
+    expect(hamburgerButton).toHaveAttribute('aria-expanded', 'false');
+    expect(hamburgerButton).toHaveAttribute('aria-label', 'Open menu');
+    expect(navigationDrawer).toHaveClass('menu-closed');
+  });
+
+  it('navigation drawer can be toggled multiple times', () => {
+    render(<Header />);
+
+    const hamburgerButton = screen.getByRole('button', { name: /open menu/i });
+    const navigationDrawer = screen.getByRole('navigation', {
+      name: /mobile navigation menu/i,
+    });
+
+    fireEvent.click(hamburgerButton);
+    expect(navigationDrawer).toHaveClass('menu-open');
+
+    fireEvent.click(hamburgerButton);
+    expect(navigationDrawer).toHaveClass('menu-closed');
+
+    fireEvent.click(hamburgerButton);
+    expect(navigationDrawer).toHaveClass('menu-open');
+  });
+
+  it('tracks analytics when header links are clicked', () => {
+    render(<Header />);
+
+    const firstLink = HEADER_LINKS[0];
+    const desktopNav = screen.getByRole('navigation', {
+      name: /secondary header site navigation/i,
+    });
+    const linkElement = within(desktopNav).getByText(firstLink.label);
+
+    fireEvent.click(linkElement);
+
+    expect(mockTrackClickEvent).toHaveBeenCalledWith({
+      category: 'Header Navigation',
+      name: `Sub Header - ${firstLink.label}`,
+    });
+  });
+
+  it('tracks analytics when mobile navigation links are clicked', () => {
+    render(<Header />);
+
+    const hamburgerButton = screen.getByRole('button', { name: /open menu/i });
+    fireEvent.click(hamburgerButton);
+
+    const firstLink = HEADER_LINKS[0];
+    const mobileNav = screen.getByRole('navigation', {
+      name: /mobile navigation menu/i,
+    });
+    const mobileLink = within(mobileNav).getByText(firstLink.label);
+
+    fireEvent.click(mobileLink);
+
+    expect(mockTrackClickEvent).toHaveBeenCalledWith({
+      category: 'Mobile Navigation',
+      name: `Hamburger Menu - ${firstLink.label}`,
+    });
+  });
+
+  it('renders logo link correctly', () => {
+    render(<Header />);
+
+    const logoLink = screen.getByRole('link', {
+      name: /recreation sites and trails bc logo/i,
+    });
+    expect(logoLink).toHaveAttribute('href', '/');
+
+    expect(within(logoLink).getByRole('img')).toBeInTheDocument();
   });
 });

--- a/public/frontend/src/components/layout/Header.tsx
+++ b/public/frontend/src/components/layout/Header.tsx
@@ -1,15 +1,36 @@
-import RSTLogo from '@/images/RST_nav_logo.svg';
-import '@/components/layout/Header.scss';
-import BetaBanner from './BetaBanner';
-import { Button, Stack } from 'react-bootstrap';
-import { trackClickEvent } from '@/utils/matomo';
-import { ROUTE_PATHS } from '@/routes';
-import { EXTERNAL_LINKS } from '@/data/urls';
+import { useState, useRef } from 'react';
+import { Link } from 'react-router';
+import { Stack } from 'react-bootstrap';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faExternalLink } from '@fortawesome/free-solid-svg-icons';
-import { Link } from 'react-router';
+import RSTLogo from '@/images/RST_nav_logo.svg';
+import BetaBanner from '@/components/layout/BetaBanner';
+import HamburgerButton from '@/components/layout/HamburgerButton';
+import NavigationDrawer from '@/components/layout/NavigationDrawer';
+import { trackClickEvent } from '@/utils/matomo';
+import { ROUTE_PATHS } from '@/routes';
+import { HEADER_LINKS } from '@/components/layout/constants';
+import '@/components/layout/Header.scss';
 
 const Header = () => {
+  const [isHamburgerMenuOpen, setIsHamburgerMenuOpen] = useState(false);
+  const hamburgerButtonRef = useRef<HTMLButtonElement>(null);
+
+  const handleHeaderLinkClick = (linkLabel: string) => {
+    trackClickEvent({
+      category: 'Header Navigation',
+      name: `Sub Header - ${linkLabel}`,
+    });
+  };
+
+  const handleHamburgerMenuToggle = () => {
+    setIsHamburgerMenuOpen(!isHamburgerMenuOpen);
+  };
+
+  const handleHamburgerMenuClose = () => {
+    setIsHamburgerMenuOpen(false);
+  };
+
   return (
     <header id="header">
       <BetaBanner />
@@ -24,19 +45,13 @@ const Header = () => {
               />
             </Link>
           </div>
-          <Button
-            href={EXTERNAL_LINKS.FEEDBACK_FORM}
-            target="_blank"
-            rel="noopener noreferrer"
-            aria-label="Share your feedback (opens in a new tab)"
-            className="header-feedback-btn"
-            onClick={trackClickEvent({
-              category: 'Feedback',
-              name: 'Beta Banner Feedback Button - mobile',
-            })}
-          >
-            Share feedback
-          </Button>
+          <div className="header-actions">
+            <HamburgerButton
+              ref={hamburgerButtonRef}
+              isOpen={isHamburgerMenuOpen}
+              onToggle={handleHamburgerMenuToggle}
+            />
+          </div>
         </nav>
       </div>
       <div className="page-nav-container sub">
@@ -44,21 +59,39 @@ const Header = () => {
           aria-label="Secondary header site navigation"
           className="header-nav sub"
         >
-          <Stack direction="horizontal" gap={3}>
-            <Link to="/search">Find a site or trail</Link>
-            <a
-              href={EXTERNAL_LINKS.LEGACY_SITE}
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              <Stack direction={'horizontal'} gap={1}>
-                Legacy site
-                <FontAwesomeIcon icon={faExternalLink} />
-              </Stack>
-            </a>
+          <Stack direction="horizontal" gap={4}>
+            {HEADER_LINKS.map((link, index) => (
+              <div key={index}>
+                {link.isExternal ? (
+                  <a
+                    href={link.url}
+                    rel="noopener noreferrer"
+                    target="_blank"
+                    onClick={() => handleHeaderLinkClick(link.label)}
+                  >
+                    <Stack direction={'horizontal'} gap={1}>
+                      {link.label}
+                      <FontAwesomeIcon icon={faExternalLink} />
+                    </Stack>
+                  </a>
+                ) : (
+                  <Link
+                    to={link.url}
+                    onClick={() => handleHeaderLinkClick(link.label)}
+                  >
+                    {link.label}
+                  </Link>
+                )}
+              </div>
+            ))}
           </Stack>
         </nav>
       </div>
+      <NavigationDrawer
+        isOpen={isHamburgerMenuOpen}
+        onClose={handleHamburgerMenuClose}
+        buttonRef={hamburgerButtonRef}
+      />
     </header>
   );
 };

--- a/public/frontend/src/components/layout/NavigationDrawer.scss
+++ b/public/frontend/src/components/layout/NavigationDrawer.scss
@@ -1,0 +1,88 @@
+@import '@/styles/variables.scss';
+@import '@/styles/global.scss';
+@import 'bootstrap/scss/functions';
+@import 'bootstrap/scss/variables';
+@import 'bootstrap/scss/mixins/_breakpoints';
+
+.navigation-drawer {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  width: 100vw;
+  background-color: $colorWhite;
+  box-shadow: 0px 5px 3px 3px rgba(0, 0, 0, 0.3);
+  z-index: 1300;
+  overflow: hidden;
+  transition: max-height 0.5s ease;
+  max-height: 0;
+
+  @include media-breakpoint-up(lg) {
+    display: none;
+  }
+
+  &.menu-open {
+    max-height: 500px;
+    overflow-y: auto;
+  }
+
+  &.menu-closed {
+    max-height: 0;
+    box-shadow: none;
+    border-bottom: none;
+  }
+}
+
+.navigation-drawer-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  width: 100%;
+}
+
+.navigation-drawer-item {
+  width: 100%;
+  border-bottom: 1px solid $colorGreyLight;
+  transition: background-color 0.1s;
+  cursor: pointer;
+
+  &:last-child {
+    border-bottom: none;
+  }
+
+  a {
+    display: block;
+    width: 100%;
+    padding: 8px 20px;
+    color: $colorBlue;
+    text-decoration: none;
+    font-weight: 500;
+    line-height: 40px;
+    transition: background-color 0.2s ease;
+
+    &:hover {
+      background-color: $colorGreyLight;
+      color: $colorBlue;
+    }
+
+    &:focus {
+      outline: 2px solid $colorBlue;
+      outline-offset: -2px;
+    }
+  }
+
+  svg {
+    margin-left: 4px;
+  }
+
+  &.feedback {
+    background-color: $colorBackgroundGrey;
+    border-left: 10px solid $colorGold;
+
+    a {
+      color: $colorBlue;
+      font-weight: 600;
+      font-size: 1.2rem;
+    }
+  }
+}

--- a/public/frontend/src/components/layout/NavigationDrawer.scss
+++ b/public/frontend/src/components/layout/NavigationDrawer.scss
@@ -17,7 +17,7 @@
   transition: max-height 0.5s ease;
   max-height: 0;
 
-  @include media-breakpoint-up(lg) {
+  @include media-breakpoint-up(md) {
     display: none;
   }
 

--- a/public/frontend/src/components/layout/NavigationDrawer.test.tsx
+++ b/public/frontend/src/components/layout/NavigationDrawer.test.tsx
@@ -1,0 +1,324 @@
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import { createRef } from 'react';
+import NavigationDrawer from './NavigationDrawer';
+import { HEADER_LINKS } from './constants';
+import { EXTERNAL_LINKS } from '@/data/urls';
+
+vi.mock('react-router', async () => {
+  const actual = await vi.importActual('react-router');
+  return {
+    ...actual,
+    Link: ({ children, to, onClick, ...props }: any) => (
+      <a href={to} onClick={onClick} {...props}>
+        {children}
+      </a>
+    ),
+  };
+});
+
+vi.mock('@shared/hooks', () => ({
+  useClickOutside: vi.fn(),
+}));
+
+vi.mock('react-remove-scroll', () => ({
+  RemoveScroll: ({ children, enabled }: any) => (
+    <div data-testid="remove-scroll" data-enabled={enabled}>
+      {children}
+    </div>
+  ),
+}));
+
+vi.mock('@/utils/matomo', () => ({
+  trackClickEvent: vi.fn(() => vi.fn()),
+}));
+
+vi.mock('@fortawesome/react-fontawesome', () => ({
+  FontAwesomeIcon: ({ icon }: any) => (
+    <span data-testid="font-awesome-icon" data-icon={icon.iconName} />
+  ),
+}));
+
+import { useClickOutside } from '@shared/hooks';
+import { trackClickEvent } from '@/utils/matomo';
+
+const mockUseClickOutside = vi.mocked(useClickOutside);
+const mockTrackClickEvent = vi.mocked(trackClickEvent);
+
+describe('NavigationDrawer', () => {
+  const defaultProps = {
+    isOpen: false,
+    onClose: vi.fn(),
+    buttonRef: createRef<HTMLButtonElement>(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockTrackClickEvent.mockReturnValue(vi.fn());
+  });
+
+  it('renders the navigation drawer with correct structure', () => {
+    render(<NavigationDrawer {...defaultProps} />);
+
+    const drawer = screen.getByRole('navigation', {
+      name: 'Mobile navigation menu',
+    });
+    expect(drawer).toBeInTheDocument();
+    expect(drawer).toHaveClass('navigation-drawer', 'menu-closed');
+
+    const list = screen.getByRole('list');
+    expect(list).toHaveClass('navigation-drawer-list');
+  });
+
+  it('applies correct classes when open', () => {
+    render(<NavigationDrawer {...defaultProps} isOpen={true} />);
+
+    const drawer = screen.getByRole('navigation', {
+      name: 'Mobile navigation menu',
+    });
+    expect(drawer).toHaveClass('navigation-drawer', 'menu-open');
+  });
+
+  it('enables RemoveScroll when drawer is open', () => {
+    render(<NavigationDrawer {...defaultProps} isOpen={true} />);
+
+    const removeScroll = screen.getByTestId('remove-scroll');
+    expect(removeScroll).toHaveAttribute('data-enabled', 'true');
+  });
+
+  it('disables RemoveScroll when drawer is closed', () => {
+    render(<NavigationDrawer {...defaultProps} isOpen={false} />);
+
+    const removeScroll = screen.getByTestId('remove-scroll');
+    expect(removeScroll).toHaveAttribute('data-enabled', 'false');
+  });
+
+  it('renders all header links correctly', () => {
+    render(<NavigationDrawer {...defaultProps} />);
+
+    HEADER_LINKS.forEach((link) => {
+      const linkElement = screen.getByText(link.label);
+      expect(linkElement).toBeInTheDocument();
+
+      if (link.isExternal) {
+        expect(linkElement.closest('a')).toHaveAttribute('href', link.url);
+        expect(linkElement.closest('a')).toHaveAttribute('target', '_blank');
+        expect(linkElement.closest('a')).toHaveAttribute(
+          'rel',
+          'noopener noreferrer',
+        );
+
+        const icon = within(linkElement.closest('a')!).getByTestId(
+          'font-awesome-icon',
+        );
+        expect(icon).toHaveAttribute('data-icon', 'arrow-up-right-from-square');
+      } else {
+        expect(linkElement.closest('a')).toHaveAttribute('href', link.url);
+        expect(linkElement.closest('a')).not.toHaveAttribute('target');
+      }
+    });
+  });
+
+  it('renders feedback link correctly', () => {
+    render(<NavigationDrawer {...defaultProps} />);
+
+    const feedbackLink = screen.getByText('Share feedback');
+    expect(feedbackLink).toBeInTheDocument();
+    expect(feedbackLink.closest('a')).toHaveAttribute(
+      'href',
+      EXTERNAL_LINKS.FEEDBACK_FORM,
+    );
+    expect(feedbackLink.closest('a')).toHaveAttribute('target', '_blank');
+    expect(feedbackLink.closest('a')).toHaveAttribute(
+      'rel',
+      'noopener noreferrer',
+    );
+
+    const feedbackItem = feedbackLink.closest('li');
+    expect(feedbackItem).toHaveClass('navigation-drawer-item', 'feedback');
+
+    // Should have external link icon
+    const icon = within(feedbackLink.closest('a')!).getByTestId(
+      'font-awesome-icon',
+    );
+    expect(icon).toHaveAttribute('data-icon', 'arrow-up-right-from-square');
+  });
+
+  it('calls onClose when internal link is clicked', () => {
+    const mockOnClose = vi.fn();
+    render(<NavigationDrawer {...defaultProps} onClose={mockOnClose} />);
+
+    // Find an internal link (first one should be internal)
+    const internalLink = HEADER_LINKS.find((link) => !link.isExternal);
+    const linkElement = screen.getByText(internalLink!.label);
+
+    fireEvent.click(linkElement);
+
+    expect(mockOnClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onClose when external link is clicked', () => {
+    const mockOnClose = vi.fn();
+    render(<NavigationDrawer {...defaultProps} onClose={mockOnClose} />);
+
+    // Find an external link
+    const externalLink = HEADER_LINKS.find((link) => link.isExternal);
+    const linkElement = screen.getByText(externalLink!.label);
+
+    fireEvent.click(linkElement);
+
+    expect(mockOnClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onClose when feedback link is clicked', () => {
+    const mockOnClose = vi.fn();
+    render(<NavigationDrawer {...defaultProps} onClose={mockOnClose} />);
+
+    const feedbackLink = screen.getByText('Share feedback');
+    fireEvent.click(feedbackLink);
+
+    expect(mockOnClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('tracks analytics for internal link clicks', () => {
+    const mockTracker = vi.fn();
+    mockTrackClickEvent.mockReturnValue(mockTracker);
+
+    render(<NavigationDrawer {...defaultProps} />);
+
+    const internalLink = HEADER_LINKS.find((link) => !link.isExternal);
+    const linkElement = screen.getByText(internalLink!.label);
+
+    fireEvent.click(linkElement);
+
+    expect(mockTrackClickEvent).toHaveBeenCalledWith({
+      category: 'Mobile Navigation',
+      name: `Hamburger Menu - ${internalLink!.label}`,
+    });
+  });
+
+  it('tracks analytics for external link clicks', () => {
+    const mockTracker = vi.fn();
+    mockTrackClickEvent.mockReturnValue(mockTracker);
+
+    render(<NavigationDrawer {...defaultProps} />);
+
+    const externalLink = HEADER_LINKS.find((link) => link.isExternal);
+    const linkElement = screen.getByText(externalLink!.label);
+
+    fireEvent.click(linkElement);
+
+    expect(mockTrackClickEvent).toHaveBeenCalledWith({
+      category: 'Mobile Navigation',
+      name: `Hamburger Menu - ${externalLink!.label}`,
+    });
+  });
+
+  it('tracks analytics for feedback link clicks', () => {
+    const mockTracker = vi.fn();
+    mockTrackClickEvent.mockReturnValue(mockTracker);
+
+    render(<NavigationDrawer {...defaultProps} />);
+
+    const feedbackLink = screen.getByText('Share feedback');
+    fireEvent.click(feedbackLink);
+
+    expect(mockTrackClickEvent).toHaveBeenCalledWith({
+      category: 'Mobile Navigation',
+      name: 'Hamburger Menu - Share feedback',
+    });
+
+    expect(mockTrackClickEvent).toHaveBeenCalledWith({
+      category: 'Feedback',
+      name: 'Beta Banner Feedback Button - mobile navigation drawer',
+    });
+  });
+
+  it('sets up click outside handler correctly', () => {
+    render(<NavigationDrawer {...defaultProps} />);
+
+    expect(mockUseClickOutside).toHaveBeenCalledTimes(1);
+    expect(mockUseClickOutside).toHaveBeenCalledWith(
+      expect.any(Object), // ref
+      expect.any(Function), // callback
+    );
+  });
+
+  describe('click outside behavior', () => {
+    it('calls onClose when clicking outside and drawer is open', () => {
+      const mockOnClose = vi.fn();
+      let clickOutsideCallback: (event: MouseEvent) => void;
+
+      mockUseClickOutside.mockImplementation((ref, callback) => {
+        clickOutsideCallback = callback;
+      });
+
+      render(
+        <NavigationDrawer
+          {...defaultProps}
+          isOpen={true}
+          onClose={mockOnClose}
+        />,
+      );
+
+      // Simulate click outside
+      const mockEvent = new MouseEvent('mousedown');
+      Object.defineProperty(mockEvent, 'target', {
+        value: document.body,
+        enumerable: true,
+      });
+
+      clickOutsideCallback!(mockEvent);
+
+      expect(mockOnClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not call onClose when clicking outside and drawer is closed', () => {
+      const mockOnClose = vi.fn();
+      let clickOutsideCallback: (event: MouseEvent) => void;
+
+      mockUseClickOutside.mockImplementation((ref, callback) => {
+        clickOutsideCallback = callback;
+      });
+
+      render(
+        <NavigationDrawer
+          {...defaultProps}
+          isOpen={false}
+          onClose={mockOnClose}
+        />,
+      );
+
+      // Simulate click outside
+      const mockEvent = new MouseEvent('mousedown');
+      Object.defineProperty(mockEvent, 'target', {
+        value: document.body,
+        enumerable: true,
+      });
+
+      clickOutsideCallback!(mockEvent);
+
+      expect(mockOnClose).not.toHaveBeenCalled();
+    });
+  });
+
+  it('has correct accessibility attributes', () => {
+    render(<NavigationDrawer {...defaultProps} />);
+
+    const drawer = screen.getByRole('navigation', {
+      name: 'Mobile navigation menu',
+    });
+    expect(drawer).toHaveAttribute('aria-label', 'Mobile navigation menu');
+  });
+
+  it('renders all navigation items as list items', () => {
+    render(<NavigationDrawer {...defaultProps} />);
+
+    const listItems = screen.getAllByRole('listitem');
+    // Should have all header links plus feedback link
+    expect(listItems).toHaveLength(HEADER_LINKS.length + 1);
+
+    listItems.forEach((item) => {
+      expect(item).toHaveClass('navigation-drawer-item');
+    });
+  });
+});

--- a/public/frontend/src/components/layout/NavigationDrawer.tsx
+++ b/public/frontend/src/components/layout/NavigationDrawer.tsx
@@ -1,0 +1,101 @@
+import { useRef } from 'react';
+import { Link } from 'react-router';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faExternalLink } from '@fortawesome/free-solid-svg-icons';
+import { RemoveScroll } from 'react-remove-scroll';
+import { useClickOutside } from '@shared/hooks';
+import { HEADER_LINKS } from './constants';
+import { EXTERNAL_LINKS } from '@/data/urls';
+import { trackClickEvent } from '@/utils/matomo';
+import '@/components/layout/NavigationDrawer.scss';
+
+interface NavigationDrawerProps {
+  isOpen: boolean;
+  onClose: () => void;
+  buttonRef: React.RefObject<HTMLButtonElement | null>;
+}
+
+const NavigationDrawer = ({
+  isOpen,
+  onClose,
+  buttonRef,
+}: NavigationDrawerProps) => {
+  const dropdownRef = useRef<HTMLElement>(null);
+
+  useClickOutside(dropdownRef, (event) => {
+    // Don't close if clicking on the hamburger button
+    if (buttonRef.current && buttonRef.current.contains(event.target as Node)) {
+      return;
+    }
+    if (isOpen) {
+      onClose();
+    }
+  });
+
+  const handleMenuLinkClick = (linkLabel: string) => {
+    trackClickEvent({
+      category: 'Mobile Navigation',
+      name: `Hamburger Menu - ${linkLabel}`,
+    });
+    onClose();
+  };
+
+  const handleFeedbackClick = () => {
+    trackClickEvent({
+      category: 'Feedback',
+      name: 'Beta Banner Feedback Button - mobile navigation drawer',
+    });
+  };
+
+  return (
+    <RemoveScroll enabled={isOpen}>
+      <nav
+        ref={dropdownRef}
+        className={`navigation-drawer ${isOpen ? 'menu-open' : 'menu-closed'}`}
+        aria-label="Mobile navigation menu"
+      >
+        <ul className="navigation-drawer-list">
+          {HEADER_LINKS.map((link, index) => (
+            <li key={index} className="navigation-drawer-item">
+              {link.isExternal ? (
+                <a
+                  href={link.url}
+                  rel="noopener noreferrer"
+                  target="_blank"
+                  onClick={() => handleMenuLinkClick(link.label)}
+                >
+                  {link.label}
+                  <FontAwesomeIcon icon={faExternalLink} />
+                </a>
+              ) : (
+                <Link
+                  to={link.url}
+                  onClick={() => handleMenuLinkClick(link.label)}
+                >
+                  {link.label}
+                </Link>
+              )}
+            </li>
+          ))}
+
+          <li className="navigation-drawer-item feedback">
+            <a
+              href={EXTERNAL_LINKS.FEEDBACK_FORM}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={() => {
+                handleMenuLinkClick('Share feedback');
+                handleFeedbackClick();
+              }}
+            >
+              Share feedback
+              <FontAwesomeIcon icon={faExternalLink} />
+            </a>
+          </li>
+        </ul>
+      </nav>
+    </RemoveScroll>
+  );
+};
+
+export default NavigationDrawer;

--- a/public/frontend/src/components/layout/PageMenu.scss
+++ b/public/frontend/src/components/layout/PageMenu.scss
@@ -13,7 +13,7 @@
     position: sticky;
     position: -webkit-sticky;
     background-color: #fff;
-    z-index: 100;
+    z-index: $zIndexPhotoGallery;
   }
 
   a {

--- a/public/frontend/src/components/layout/ScrollToTop.scss
+++ b/public/frontend/src/components/layout/ScrollToTop.scss
@@ -7,7 +7,7 @@
   padding: 0;
   position: fixed;
   right: 2%;
-  z-index: 100;
+  z-index: $zIndexScrollToTop;
   border-radius: 4px;
 }
 

--- a/public/frontend/src/components/layout/constants.ts
+++ b/public/frontend/src/components/layout/constants.ts
@@ -18,18 +18,18 @@ export const HEADER_LINKS: HeaderLink[] = [
     isExternal: false,
   },
   {
-    url: EXTERNAL_LINKS.LEGACY_SITE,
-    label: 'Legacy site',
+    url: EXTERNAL_LINKS.ALERTS,
+    label: 'Alerts',
     isExternal: true,
   },
   {
     url: EXTERNAL_LINKS.ABOUT_RST,
-    label: 'About Recreation Sites and Trails',
+    label: 'About',
     isExternal: true,
   },
   {
-    url: EXTERNAL_LINKS.ALERTS,
-    label: 'Alerts',
+    url: EXTERNAL_LINKS.LEGACY_SITE,
+    label: 'Legacy site',
     isExternal: true,
   },
 ];

--- a/public/frontend/src/components/layout/constants.ts
+++ b/public/frontend/src/components/layout/constants.ts
@@ -1,0 +1,35 @@
+import { EXTERNAL_LINKS } from '@/data/urls';
+
+export interface HeaderLink {
+  url: string;
+  label: string;
+  isExternal: boolean;
+}
+
+export const HEADER_LINKS: HeaderLink[] = [
+  {
+    url: '/search',
+    label: 'Find a site or trail',
+    isExternal: false,
+  },
+  {
+    url: '/search?view=map',
+    label: 'Search by map',
+    isExternal: false,
+  },
+  {
+    url: EXTERNAL_LINKS.LEGACY_SITE,
+    label: 'Legacy site',
+    isExternal: true,
+  },
+  {
+    url: EXTERNAL_LINKS.ABOUT_RST,
+    label: 'About Recreation Sites and Trails',
+    isExternal: true,
+  },
+  {
+    url: EXTERNAL_LINKS.ALERTS,
+    label: 'Alerts',
+    isExternal: true,
+  },
+];

--- a/public/frontend/src/components/notifications/NotificationToast.scss
+++ b/public/frontend/src/components/notifications/NotificationToast.scss
@@ -6,7 +6,7 @@
   min-height: 100px;
   position: fixed;
   right: calc(50% - 150px);
-  z-index: 1000;
+  z-index: $zIndexNotification;
   border: none;
   border-radius: 0;
   box-shadow: 0px 4px 8px 0px rgba($colorBlack, 0.2);

--- a/public/frontend/src/components/rec-resource/PhotoGallery.scss
+++ b/public/frontend/src/components/rec-resource/PhotoGallery.scss
@@ -45,7 +45,7 @@
   position: absolute;
   right: 16px;
   bottom: 16px;
-  z-index: 100;
+  z-index: $zIndexPhotoGallery;
   width: fit-content;
 
   @media (min-width: $lgBreakpoint) {

--- a/public/frontend/src/components/rec-resource/RecreationResourceMap/MapDisclaimerModal.scss
+++ b/public/frontend/src/components/rec-resource/RecreationResourceMap/MapDisclaimerModal.scss
@@ -12,7 +12,7 @@
     flex-direction: column;
     align-items: center;
     justify-content: center;
-    z-index: 1000;
+    z-index: $zIndexModal;
   }
   .modal-body {
     padding: 0;

--- a/public/frontend/src/components/recreation-suggestion-form/RecreationSuggestionForm.scss
+++ b/public/frontend/src/components/recreation-suggestion-form/RecreationSuggestionForm.scss
@@ -44,7 +44,7 @@
     color: #999;
     font-size: 24px;
     cursor: pointer;
-    z-index: 10;
+    z-index: $zIndexFormOverlay;
     transition: font-size 0.2s ease;
 
     &:hover {

--- a/public/frontend/src/components/search-map/SearchMap.scss
+++ b/public/frontend/src/components/search-map/SearchMap.scss
@@ -9,7 +9,7 @@
   left: 0;
   width: 100vw;
   height: 100vh;
-  z-index: 999;
+  z-index: $zIndexMapOverlay;
   overflow: hidden;
   background-color: white;
 
@@ -46,7 +46,7 @@
 
 .search-map-controls {
   position: fixed;
-  top: 106px;
+  top: 64px;
   left: 0;
   right: 0;
   margin: 0 auto;
@@ -55,12 +55,12 @@
   max-width: none;
   display: flex;
   flex-direction: column;
-  z-index: 10000;
+  z-index: $zIndexMapControls;
   border-radius: 4px;
   transform: none;
 
   @include media-breakpoint-up(sm) {
-    top: 192px;
+    top: 96px;
   }
 
   // Collapse and center on larger screens

--- a/public/frontend/src/components/search/filters/FilterMenuSearchMap.scss
+++ b/public/frontend/src/components/search/filters/FilterMenuSearchMap.scss
@@ -83,5 +83,5 @@
 }
 
 .filter-modal {
-  z-index: 3000;
+  z-index: $zIndexFilterMenu;
 }

--- a/public/frontend/src/components/search/filters/Filters.scss
+++ b/public/frontend/src/components/search/filters/Filters.scss
@@ -69,6 +69,10 @@
       margin-left: 8px;
       white-space: pre-line;
     }
+
+    .form-check-input:disabled ~ .form-check-label {
+      opacity: 0.7;
+    }
   }
 }
 

--- a/public/frontend/src/data/urls.ts
+++ b/public/frontend/src/data/urls.ts
@@ -7,6 +7,10 @@ export const EXTERNAL_LINKS = {
   CONTACT: 'https://www.sitesandtrailsbc.ca/contact-us.aspx',
   FACEBOOK_BC_REC: 'https://www.facebook.com/BCRecSitesandTrails',
   CLOSURE: 'https://www.sitesandtrailsbc.ca/closures.aspx',
+  ALERTS:
+    'https://www2.gov.bc.ca/gov/content/sports-culture/recreation/camping-hiking/sites-trails/alerts',
+  ABOUT_RST:
+    'https://www2.gov.bc.ca/gov/content/sports-culture/recreation/camping-hiking/sites-trails',
   RULES_ETIQUETE:
     'https://www2.gov.bc.ca/gov/content/sports-culture/recreation/camping-hiking/sites-trails/planning/rules',
   AUTHORIZATIONS:

--- a/public/frontend/src/styles/variables.scss
+++ b/public/frontend/src/styles/variables.scss
@@ -1,1 +1,25 @@
 @import '@shared/styles/variables';
+
+// Z-Index Variables - organized by layer hierarchy
+
+// Base layers (content)
+$zIndexBase: 0;
+$zIndexContent: 1;
+
+// Overlay layers
+$zIndexFooter: 10;
+$zIndexFormOverlay: 10;
+$zIndexPhotoGallery: 100;
+$zIndexScrollToTop: 100;
+
+// Modal and notification layers
+$zIndexMapOverlay: 999;
+$zIndexModal: 1000;
+$zIndexNotification: 1000;
+
+// Top-level controls
+$zIndexMapControls: 1200;
+$zIndexFilterMenu: 1200;
+
+// Navigation layers
+$zIndexHamburgerMenu: 1300;

--- a/shared/src/hooks/index.ts
+++ b/shared/src/hooks/index.ts
@@ -1,0 +1,1 @@
+export * from './useClickOutside';

--- a/shared/src/hooks/useClickOutside.ts
+++ b/shared/src/hooks/useClickOutside.ts
@@ -1,0 +1,25 @@
+import { useEffect, RefObject } from 'react';
+
+/**
+ * Custom hook that handles clicking outside of a referenced element
+ * @param ref - React ref object pointing to the element to detect clicks outside of
+ * @param handler - Function to call when a click outside is detected
+ */
+export const useClickOutside = <T extends HTMLElement = HTMLElement>(
+  ref: RefObject<T | null>,
+  handler: (event: MouseEvent) => void,
+) => {
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (ref.current && !ref.current.contains(event.target as Node)) {
+        handler(event);
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [ref, handler]);
+};

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -2,3 +2,4 @@
 export * from './components/suggestion-typeahead';
 export * from './components/breadcrumbs';
 export * from './utils';
+export * from './hooks';

--- a/shared/src/test/hooks/useClickOutside.test.ts
+++ b/shared/src/test/hooks/useClickOutside.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useRef } from 'react';
+import { useClickOutside } from '../../hooks/useClickOutside';
+
+const mockAddEventListener = vi.fn();
+const mockRemoveEventListener = vi.fn();
+
+Object.defineProperty(document, 'addEventListener', {
+  value: mockAddEventListener,
+  writable: true,
+});
+
+Object.defineProperty(document, 'removeEventListener', {
+  value: mockRemoveEventListener,
+  writable: true,
+});
+
+describe('useClickOutside', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should add event listener on mount and remove on unmount', () => {
+    const handler = vi.fn();
+    const { unmount } = renderHook(() => {
+      const ref = useRef<HTMLDivElement>(null);
+      useClickOutside(ref, handler);
+      return ref;
+    });
+
+    expect(mockAddEventListener).toHaveBeenCalledWith(
+      'mousedown',
+      expect.any(Function),
+    );
+
+    unmount();
+  });
+
+  it('should call handler when clicking outside the referenced element', () => {
+    const handler = vi.fn();
+    const div = document.createElement('div');
+    const ref = { current: div };
+
+    renderHook(() => useClickOutside(ref, handler));
+
+    const outsideElement = document.createElement('span');
+    const mockEvent = {
+      target: outsideElement,
+    } as unknown as MouseEvent;
+
+    const eventHandler = mockAddEventListener.mock.calls[0][1];
+    eventHandler(mockEvent);
+
+    expect(handler).toHaveBeenCalledWith(mockEvent);
+  });
+
+  it('should not call handler when clicking inside the referenced element', () => {
+    const handler = vi.fn();
+    const div = document.createElement('div');
+    const ref = { current: div };
+
+    renderHook(() => useClickOutside(ref, handler));
+
+    const insideElement = document.createElement('span');
+    div.appendChild(insideElement);
+
+    const mockEvent = {
+      target: insideElement,
+    } as unknown as MouseEvent;
+
+    const eventHandler = mockAddEventListener.mock.calls[0][1];
+    eventHandler(mockEvent);
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('should not call handler when ref is null', () => {
+    const handler = vi.fn();
+    const ref = { current: null };
+
+    renderHook(() => useClickOutside(ref, handler));
+
+    const outsideElement = document.createElement('span');
+    const mockEvent = {
+      target: outsideElement,
+    } as unknown as MouseEvent;
+
+    const eventHandler = mockAddEventListener.mock.calls[0][1];
+    eventHandler(mockEvent);
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Add new sub header links and mobile navigation menu

<img width="905" height="199" alt="Screenshot 2025-09-26 at 1 04 11 PM" src="https://github.com/user-attachments/assets/e4faa38f-bf02-4feb-a4ce-403d315d9fa0" />
<img width="753" height="491" alt="Screenshot 2025-09-26 at 1 04 24 PM" src="https://github.com/user-attachments/assets/e9217d5b-e01c-4dee-a44b-568f9ddc04f8" />
<img width="252" height="453" alt="Screenshot 2025-09-26 at 1 11 58 PM" src="https://github.com/user-attachments/assets/6ea871ce-b88b-4040-a568-65a7e2f8c849" />

