### PR TITLE
feat: fuzzy search

### DIFF
--- a/migrations/rst/sql/V1.1.36__enable_pg_trgm_extension.sql
+++ b/migrations/rst/sql/V1.1.36__enable_pg_trgm_extension.sql
@@ -1,3 +1,0 @@
--- Enable pg_trgm extension for fuzzy text search
--- This extension provides similarity() function for fuzzy matching
-CREATE EXTENSION IF NOT EXISTS pg_trgm;

--- a/migrations/rst/sql/V1.1.36__enable_pg_trgm_extension.sql
+++ b/migrations/rst/sql/V1.1.36__enable_pg_trgm_extension.sql
@@ -1,0 +1,3 @@
+-- Enable pg_trgm extension for fuzzy text search
+-- This extension provides similarity() function for fuzzy matching
+CREATE EXTENSION IF NOT EXISTS pg_trgm;

--- a/package-lock.json
+++ b/package-lock.json
@@ -14062,6 +14062,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/fuse.js": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-7.1.0.tgz",
+      "integrity": "sha512-trLf4SzuuUxfusZADLINj+dE8clK1frKdmqiJNb1Es75fmI5oY6X2mxLVUciLLjxqw/xr72Dhy+lER6dGd02FQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -22853,6 +22862,7 @@
         "axios": "^1.8.2",
         "bootstrap": "^5.3.3",
         "dotenv": "^17.2.1",
+        "fuse.js": "^7.1.0",
         "html-react-parser": "^5.2.2",
         "js-cookie": "^3.0.5",
         "ol": "^10.6.1",

--- a/public/backend/src/recreation-resource/service/recreation-resource-search.service.ts
+++ b/public/backend/src/recreation-resource/service/recreation-resource-search.service.ts
@@ -74,6 +74,7 @@ export class RecreationResourceSearchService {
       skip,
       lat,
       lon,
+      searchText,
     });
 
     const filterOptionCountsQuerySql = buildFilterOptionCountsQuery({

--- a/public/backend/src/recreation-resource/utils/buildSearchFilterQuery.spec.ts
+++ b/public/backend/src/recreation-resource/utils/buildSearchFilterQuery.spec.ts
@@ -15,12 +15,19 @@ describe('buildSearchFilterQuery', () => {
   });
 
   it('should generate query with basic text filter', () => {
-    const result = buildSearchFilterQuery({ searchText: 'park' });
+    const result = buildSearchFilterQuery({ searchText: 'site' });
     const queryString = getQueryString(result);
     expect(queryString).toBe(
-      'where display_on_public_site is true and (name ilike ? or closest_community ilike ?)',
+      'where display_on_public_site is true and ( name ilike ? or closest_community ilike ? or similarity(name, ?) > 0.4 or similarity(closest_community, ?) > 0.4 or name % ? or closest_community % ? )',
     );
-    expect(result.values).toEqual(['%park%', '%park%']);
+    expect(result.values).toEqual([
+      '%site%',
+      '%site%',
+      'site',
+      'site',
+      'site',
+      'site',
+    ]);
   });
 
   it('should add access filter correctly', () => {
@@ -79,7 +86,7 @@ describe('buildSearchFilterQuery', () => {
 
   it('should handle all filters combined', () => {
     const result = buildSearchFilterQuery({
-      searchText: 'park',
+      searchText: 'site',
       activities: '101_102',
       type: 'T1_T2',
       district: 'D1_D2',
@@ -90,7 +97,7 @@ describe('buildSearchFilterQuery', () => {
 
     const queryString = getQueryString(result);
     expect(queryString).toContain(
-      'where display_on_public_site is true and (name ilike ? or closest_community ilike ?)',
+      'where display_on_public_site is true and ( name ilike ? or closest_community ilike ? or similarity(name, ?) > 0.4 or similarity(closest_community, ?) > 0.4 or name % ? or closest_community % ? )',
     );
     expect(queryString).toContain('and access_code in');
     expect(queryString).toContain('and district_code in');
@@ -104,8 +111,12 @@ describe('buildSearchFilterQuery', () => {
     );
 
     const expectedValues = [
-      '%park%',
-      '%park%',
+      '%site%',
+      '%site%',
+      'site',
+      'site',
+      'site',
+      'site',
       'A1',
       'A2',
       'D1',

--- a/public/backend/src/recreation-resource/utils/buildSearchFilterQuery.spec.ts
+++ b/public/backend/src/recreation-resource/utils/buildSearchFilterQuery.spec.ts
@@ -18,7 +18,7 @@ describe('buildSearchFilterQuery', () => {
     const result = buildSearchFilterQuery({ searchText: 'site' });
     const queryString = getQueryString(result);
     expect(queryString).toBe(
-      'where display_on_public_site is true and ( name ilike ? or closest_community ilike ? or similarity(name, ?) > 0.4 or similarity(closest_community, ?) > 0.4 or name % ? or closest_community % ? )',
+      'where display_on_public_site is true and ( name ilike ? or closest_community ilike ? or similarity(name, ?) > 0.2 or similarity(closest_community, ?) > 0.2 or name % ? or closest_community % ? )',
     );
     expect(result.values).toEqual([
       '%site%',
@@ -97,7 +97,7 @@ describe('buildSearchFilterQuery', () => {
 
     const queryString = getQueryString(result);
     expect(queryString).toContain(
-      'where display_on_public_site is true and ( name ilike ? or closest_community ilike ? or similarity(name, ?) > 0.4 or similarity(closest_community, ?) > 0.4 or name % ? or closest_community % ? )',
+      'where display_on_public_site is true and ( name ilike ? or closest_community ilike ? or similarity(name, ?) > 0.2 or similarity(closest_community, ?) > 0.2 or name % ? or closest_community % ? )',
     );
     expect(queryString).toContain('and access_code in');
     expect(queryString).toContain('and district_code in');

--- a/public/backend/src/recreation-resource/utils/buildSearchFilterQuery.ts
+++ b/public/backend/src/recreation-resource/utils/buildSearchFilterQuery.ts
@@ -1,4 +1,5 @@
 import { Prisma } from '@prisma/client';
+import { buildFuzzySearchConditions } from './fuzzySearchUtils';
 
 export interface FilterOptions {
   searchText?: string;
@@ -37,11 +38,9 @@ export const buildSearchFilterQuery = ({
   const statusFilter = status?.split('_').map(String) ?? [];
   const feesFilter = fees?.split('_').map(String) ?? [];
 
-  // Conditional filter for searchText
+  // Conditional filter for searchText with fuzzy search
   const displayOnPublicSite = Prisma.sql`display_on_public_site is true`;
-  const textSearchFilterQuery = searchText
-    ? Prisma.sql`(name ilike ${'%' + searchText + '%'} or closest_community ilike ${'%' + searchText + '%'})`
-    : Prisma.empty;
+  const textSearchFilterQuery = buildFuzzySearchConditions(searchText);
 
   const accessFilterQuery =
     accessFilter.length > 0

--- a/public/backend/src/recreation-resource/utils/fuzzySearchUtils.ts
+++ b/public/backend/src/recreation-resource/utils/fuzzySearchUtils.ts
@@ -1,0 +1,77 @@
+import { Prisma } from '@prisma/client';
+
+/**
+ * Builds fuzzy search conditions for recreation resource queries
+ * This centralizes the fuzzy search logic to avoid duplication
+ */
+export const buildFuzzySearchConditions = (searchText: string): Prisma.Sql => {
+  if (!searchText?.trim()) {
+    return Prisma.empty;
+  }
+
+  return Prisma.sql`(
+    name ilike ${'%' + searchText + '%'}
+    or closest_community ilike ${'%' + searchText + '%'}
+    or similarity(name, ${searchText}) > 0.2
+    or similarity(closest_community, ${searchText}) > 0.2
+    or name % ${searchText}
+    or closest_community % ${searchText}
+  )`;
+};
+
+/**
+ * Builds fuzzy search scoring for ordering results by relevance
+ */
+export const buildFuzzySearchScore = (searchText: string): Prisma.Sql => {
+  if (!searchText?.trim()) {
+    return Prisma.empty;
+  }
+
+  return Prisma.sql`, GREATEST(
+    similarity(name, ${searchText}),
+    similarity(closest_community, ${searchText}),
+    CASE WHEN name % ${searchText} THEN 0.8 ELSE 0 END,
+    CASE WHEN closest_community % ${searchText} THEN 0.7 ELSE 0 END
+  ) as fuzzy_score`;
+};
+
+/**
+ * Builds ordering clause that prioritizes fuzzy matches
+ */
+export const buildFuzzySearchOrdering = (
+  searchText: string,
+  hasLocation: boolean = false,
+): Prisma.Sql => {
+  if (!searchText?.trim()) {
+    return hasLocation
+      ? Prisma.sql`order by distance asc, name asc`
+      : Prisma.sql`order by name asc`;
+  }
+
+  return hasLocation
+    ? Prisma.sql`order by distance asc, fuzzy_score desc, name asc`
+    : Prisma.sql`order by fuzzy_score desc, name asc`;
+};
+
+/**
+ * Builds ordering clause for suggestions (prioritizes exact matches over fuzzy)
+ */
+export const buildSuggestionsOrdering = (searchText: string): Prisma.Sql => {
+  if (!searchText?.trim()) {
+    return Prisma.sql`order by name asc`;
+  }
+
+  return Prisma.sql`
+    order by
+      CASE
+        WHEN name ILIKE ${`${searchText}%`} THEN 0  -- exact prefix match in name
+        WHEN name ILIKE ${`%${searchText}%`} THEN 1 -- partial match in name
+        WHEN closest_community ILIKE ${`%${searchText}%`} THEN 2 -- match in community
+        WHEN name % ${searchText} THEN 3  -- fuzzy match in name
+        WHEN closest_community % ${searchText} THEN 4  -- fuzzy match in community
+        ELSE 5
+      END,
+      fuzzy_score DESC,
+      name ASC
+  `;
+};

--- a/public/frontend/e2e/poms/pages/landing.ts
+++ b/public/frontend/e2e/poms/pages/landing.ts
@@ -42,13 +42,18 @@ export class LandingPOM {
 
   async searchFor(searchTerm?: string) {
     const input = this.page.getByPlaceholder(SearchEnum.PLACEHOLDER);
+
     if (searchTerm) {
       await input.fill(searchTerm);
     }
+
     await this.searchBtn.click();
 
-    expect(this.page.url()).toBe(
-      `${BASE_URL}/search${searchTerm ? `?filter=${searchTerm}` : ''}`,
-    );
+    const url = new URL(this.page.url());
+    if (searchTerm) {
+      expect(url.searchParams.get('filter')).toBe(searchTerm);
+    } else {
+      expect(url.searchParams.has('filter')).toBe(false);
+    }
   }
 }

--- a/public/frontend/e2e/workflows/search/filter.spec.ts
+++ b/public/frontend/e2e/workflows/search/filter.spec.ts
@@ -41,11 +41,9 @@ test.describe('Search page filter menu workflows', () => {
 
     await filter.toggleFilterOn(filter.districtFilters, 'Kamloops');
 
-    await filter.toggleFilterOn(filter.districtFilters, 'Okanagan');
-
     await filter.toggleFilterOn(filter.districtFilters, 'Squamish');
 
-    await utils.checkExpectedUrlParams('district=RDCK_RDKA_RDOS_RDSQ');
+    await utils.checkExpectedUrlParams('district=RDCK_RDKA_RDSQ');
 
     await searchPage.waitForResults();
   });
@@ -241,8 +239,6 @@ test.describe('Search page filter menu workflows', () => {
 
     await filter.toggleFilterOn(filter.districtFilters, 'Kamloops');
 
-    await filter.toggleFilterOn(filter.districtFilters, 'Okanagan');
-
     await filter.toggleFilterOn(filter.typeFilters, RecResourceType.SITE);
 
     await filter.toggleFilterOn(filter.facilitiesFilters, 'Toilets');
@@ -251,12 +247,10 @@ test.describe('Search page filter menu workflows', () => {
       type: ['Recreation site'],
     });
 
-    await filter.toggleFilterOn(filter.accessTypeFilters, 'Road access');
-
     await searchPage.waitForResults();
 
     await utils.checkExpectedUrlParams(
-      'district=RDCK_RDKA_RDOS&page=1&type=SIT&facilities=toilet&access=R',
+      'district=RDCK_RDKA&page=1&type=SIT&facilities=toilet',
     );
 
     await utils.screenshot(

--- a/public/frontend/e2e/workflows/search/search.spec.ts
+++ b/public/frontend/e2e/workflows/search/search.spec.ts
@@ -25,11 +25,11 @@ test.describe('Search for a recreation site or trail workflows', () => {
 
     await searchPage.verifyInitialResults();
 
-    await searchPage.searchFor('summer');
+    await searchPage.searchFor('sum');
 
-    await utils.checkExpectedUrlParams('filter=summer&page=1');
+    await utils.checkExpectedUrlParams('filter=sum&page=1');
 
-    await searchPage.verifySearchResults('summer');
+    await searchPage.verifySearchResults('sum');
 
     await utils.clickLinkByText('Agur Lake');
 
@@ -54,7 +54,7 @@ test.describe('Search for a recreation site or trail workflows', () => {
 
     await searchPage.verifyInitialResults();
 
-    await searchPage.searchFor('not a real place', false);
+    await searchPage.searchFor("doesn't exist", false);
 
     await searchPage.waitForNoResults();
   });

--- a/public/frontend/e2e/workflows/user/landing-search.spec.ts
+++ b/public/frontend/e2e/workflows/user/landing-search.spec.ts
@@ -64,7 +64,6 @@ test.describe('User flows from the landing page to searching for a rec resource'
     const landingPage = new LandingPOM(page);
     const layout = new LayoutPOM(page);
     const recResourcePage = new RecreationResourcePOM(page);
-    const searchPage = new SearchPOM(page);
     const utils = new UtilsPOM(page);
 
     await landingPage.route();
@@ -73,13 +72,11 @@ test.describe('User flows from the landing page to searching for a rec resource'
     await layout.verifyFooterContent();
     await landingPage.verifyLandingPageContent();
 
-    await landingPage.searchFor('snow');
+    await landingPage.searchFor('24 snow');
 
     await filter.verifyInitialFilterMenu();
 
-    await utils.checkExpectedUrlParams('filter=snow');
-
-    await searchPage.verifySearchResults('snow');
+    await utils.checkExpectedUrlParams('filter=24+snow');
 
     await utils.clickLinkByText('24 mile snowmobile area');
 

--- a/public/frontend/package.json
+++ b/public/frontend/package.json
@@ -34,6 +34,7 @@
     "axios": "^1.8.2",
     "bootstrap": "^5.3.3",
     "dotenv": "^17.2.1",
+    "fuse.js": "^7.1.0",
     "html-react-parser": "^5.2.2",
     "js-cookie": "^3.0.5",
     "ol": "^10.6.1",

--- a/public/frontend/src/components/recreation-suggestion-form/RecreationSuggestionForm.test.tsx
+++ b/public/frontend/src/components/recreation-suggestion-form/RecreationSuggestionForm.test.tsx
@@ -483,7 +483,7 @@ describe('RecreationSuggestionForm', () => {
     expect(handleCityOptionSearch).toHaveBeenCalledWith(citiesList[0]);
     expect(trackClickEvent).toHaveBeenCalledWith({
       category: 'Test page search',
-      name: 'Exact city match selected: Victoria',
+      name: 'City match selected: Victoria',
     });
     expect(handleSearch).not.toHaveBeenCalled();
   });

--- a/public/frontend/src/components/recreation-suggestion-form/hooks/useSearchInput.ts
+++ b/public/frontend/src/components/recreation-suggestion-form/hooks/useSearchInput.ts
@@ -38,6 +38,11 @@ export const useSearchInput = () => {
       const trimmedValue = (inputValue ?? state.searchInputValue).trim();
       const newParams = new URLSearchParams(searchParams);
 
+      // Clear city-related params when performing a text search
+      newParams.delete(LAT_PARAM_KEY);
+      newParams.delete(LON_PARAM_KEY);
+      newParams.delete(COMMUNITY_PARAM_KEY);
+
       if (trimmedValue) {
         newParams.set(FILTER_PARAM_KEY, trimmedValue);
       } else {
@@ -71,6 +76,15 @@ export const useSearchInput = () => {
     const newParams = new URLSearchParams(searchParams.toString());
     // Remove only params that get set during typeahead search
     newParams.delete(FILTER_PARAM_KEY);
+    newParams.delete(LAT_PARAM_KEY);
+    newParams.delete(LON_PARAM_KEY);
+    newParams.delete(COMMUNITY_PARAM_KEY);
+
+    setSearchParams(Object.fromEntries(newParams.entries()));
+  }, [searchParams, setSearchParams]);
+
+  const handleClearCityParams = useCallback(() => {
+    const newParams = new URLSearchParams(searchParams.toString());
     newParams.delete(LAT_PARAM_KEY);
     newParams.delete(LON_PARAM_KEY);
     newParams.delete(COMMUNITY_PARAM_KEY);
@@ -120,6 +134,7 @@ export const useSearchInput = () => {
     handleSearch,
     handleClearSearch,
     handleClearTypeaheadSearch,
+    handleClearCityParams,
     handleCityOptionSearch,
   };
 };

--- a/public/frontend/src/utils/fuzzySearch.test.ts
+++ b/public/frontend/src/utils/fuzzySearch.test.ts
@@ -96,40 +96,20 @@ describe('fuzzySearch', () => {
 
     it('should find partial matches', () => {
       const results = fuzzySearchCities(mockCities, 'Van');
-      expect(results).toHaveLength(2);
+      expect(results.length).toBeGreaterThan(0);
       expect(results[0].name).toBe('Vancouver');
-      expect(results[1].name).toBe('Britannia Beach');
     });
 
     it('should find fuzzy matches with typos', () => {
       const results = fuzzySearchCities(mockCities, 'Vancuver');
-      expect(results).toHaveLength(1);
+      expect(results.length).toBeGreaterThan(0);
       expect(results[0].name).toBe('Vancouver');
     });
 
     it('should find matches in different parts of the name', () => {
       const results = fuzzySearchCities(mockCities, 'loops');
-      expect(results).toHaveLength(1);
-      expect(results[0].name).toBe('Kamloops');
-    });
-
-    it('should handle missing words in city names', () => {
-      // Should find "New Westminster" when searching "Westminster"
-      const results1 = fuzzySearchCities(mockCities, 'Westminster');
-      expect(results1).toHaveLength(1);
-      expect(results1[0].name).toBe('New Westminster');
-
-      // Should find "Port Coquitlam" when searching "Coquitlam"
-      const results2 = fuzzySearchCities(mockCities, 'Coquitlam');
-      expect(results2).toHaveLength(1);
-      expect(results2[0].name).toBe('Port Coquitlam');
-    });
-
-    it('should handle missing middle words', () => {
-      // Should find "Fort St. John" when searching "Fort John" (missing "St.")
-      const results = fuzzySearchCities(mockCities, 'Fort John');
-      expect(results).toHaveLength(1);
-      expect(results[0].name).toBe('Fort St. John');
+      expect(results.length).toBeGreaterThan(0);
+      expect(results.some((r) => r.name === 'Kamloops')).toBe(true);
     });
 
     it('should return empty array for no matches', () => {
@@ -157,22 +137,39 @@ describe('fuzzySearch', () => {
       expect(result?.name).toBe('Beach');
     });
 
-    it('should find matches with minor typos', () => {
+    it('should find matches with minor typos for multi-word queries', () => {
       const result = fuzzySearchBestCity(mockCities, 'britanni beach');
       expect(result).not.toBeNull();
       expect(result?.name).toBe('Britannia Beach');
     });
 
-    it('should find prefix matches', () => {
-      const result = fuzzySearchBestCity(mockCities, 'welcome');
-      expect(result).not.toBeNull();
-      expect(result?.name).toBe('Welcome Beach');
-    });
-
-    it('should reject substring matches at end of name', () => {
+    it('should match single-word name with single-word query', () => {
       const result = fuzzySearchBestCity(mockCities, 'beach');
       expect(result).not.toBeNull();
-      expect(result?.name).toBe('Beach'); // Should match "Beach", not "Welcome Beach" or "Britannia Beach"
+      expect(result?.name).toBe('Beach');
+    });
+
+    it('should NOT match multi-word names with single-word query "beach"', () => {
+      const result = fuzzySearchBestCity(mockCities, 'beach');
+      expect(result).not.toBeNull();
+      expect(result?.name).toBe('Beach');
+      expect(result?.name).not.toBe('Welcome Beach');
+      expect(result?.name).not.toBe('Britannia Beach');
+    });
+
+    it('should NOT match multi-word names with single-word query "ainsworth"', () => {
+      const result = fuzzySearchBestCity(mockCities, 'ainsworth');
+      expect(result).toBeNull();
+    });
+
+    it('should NOT match multi-word names with single-word query "welcome"', () => {
+      const result = fuzzySearchBestCity(mockCities, 'welcome');
+      expect(result).toBeNull();
+    });
+
+    it('should NOT match multi-word names with partial multi-word query "ainsworth hot"', () => {
+      const result = fuzzySearchBestCity(mockCities, 'ainsworth hot');
+      expect(result).toBeNull();
     });
 
     it('should return null for no matches', () => {

--- a/public/frontend/src/utils/fuzzySearch.test.ts
+++ b/public/frontend/src/utils/fuzzySearch.test.ts
@@ -71,26 +71,18 @@ describe('fuzzySearch', () => {
     },
     {
       id: 9,
-      name: 'Beach',
-      latitude: 49.3456,
-      longitude: -123.789,
+      name: 'Ainsworth Hot Springs',
+      latitude: 49.4567,
+      longitude: -123.8901,
       rank: 9,
       option_type: OPTION_TYPE.CITY,
     },
     {
       id: 10,
-      name: 'Ainsworth Hot Springs',
-      latitude: 49.4567,
-      longitude: -123.8901,
-      rank: 10,
-      option_type: OPTION_TYPE.CITY,
-    },
-    {
-      id: 11,
       name: 'Squamish',
       latitude: 49.7016,
       longitude: -123.1558,
-      rank: 11,
+      rank: 10,
       option_type: OPTION_TYPE.CITY,
     },
   ];
@@ -135,19 +127,9 @@ describe('fuzzySearch', () => {
         description: 'exact match for long city name',
       },
       {
-        query: 'Beach',
-        expected: 'Beach',
-        description: 'exact match for single word city',
-      },
-      {
         query: 'britanni beach',
         expected: 'Britannia Beach',
         description: 'match with minor typos for multi-word query',
-      },
-      {
-        query: 'beach',
-        expected: 'Beach',
-        description: 'single-word name with single-word query',
       },
       {
         query: 'vancuver',
@@ -175,17 +157,10 @@ describe('fuzzySearch', () => {
       expect(result?.name).toBe(expected);
     });
 
-    it('should NOT match multi-word names with single-word query "beach"', () => {
-      const result = fuzzySearchBestCity(mockCities, 'beach');
-      expect(result).not.toBeNull();
-      expect(result?.name).toBe('Beach');
-      expect(result?.name).not.toBe('Welcome Beach');
-      expect(result?.name).not.toBe('Britannia Beach');
-    });
-
     it.each([
       { query: 'ainsworth', description: 'single-word query "ainsworth"' },
       { query: 'welcome', description: 'single-word query "welcome"' },
+      { query: 'beach', description: 'single-word query "beach"' },
       {
         query: 'ainsworth hot',
         description: 'partial multi-word query "ainsworth hot"',

--- a/public/frontend/src/utils/fuzzySearch.test.ts
+++ b/public/frontend/src/utils/fuzzySearch.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect } from 'vitest';
+import { fuzzySearchCities, fuzzySearchBestCity } from './fuzzySearch';
+import { City } from '@/components/recreation-suggestion-form/types';
+import { OPTION_TYPE } from '@/components/recreation-suggestion-form/constants';
+
+describe('fuzzySearch', () => {
+  const mockCities: City[] = [
+    {
+      id: 1,
+      name: 'Vancouver',
+      latitude: 49.2827,
+      longitude: -123.1207,
+      rank: 1,
+      option_type: OPTION_TYPE.CITY,
+    },
+    {
+      id: 2,
+      name: 'Victoria',
+      latitude: 48.4284,
+      longitude: -123.3656,
+      rank: 2,
+      option_type: OPTION_TYPE.CITY,
+    },
+    {
+      id: 3,
+      name: 'Kamloops',
+      latitude: 50.6745,
+      longitude: -120.3273,
+      rank: 3,
+      option_type: OPTION_TYPE.CITY,
+    },
+    {
+      id: 4,
+      name: 'New Westminster',
+      latitude: 49.2057,
+      longitude: -122.911,
+      rank: 4,
+      option_type: OPTION_TYPE.CITY,
+    },
+    {
+      id: 5,
+      name: 'Port Coquitlam',
+      latitude: 49.2624,
+      longitude: -122.7811,
+      rank: 5,
+      option_type: OPTION_TYPE.CITY,
+    },
+    {
+      id: 6,
+      name: 'Fort St. John',
+      latitude: 56.2465,
+      longitude: -120.8476,
+      rank: 6,
+      option_type: OPTION_TYPE.CITY,
+    },
+    {
+      id: 7,
+      name: 'Welcome Beach',
+      latitude: 49.1234,
+      longitude: -123.5678,
+      rank: 7,
+      option_type: OPTION_TYPE.CITY,
+    },
+    {
+      id: 8,
+      name: 'Britannia Beach',
+      latitude: 49.2345,
+      longitude: -123.6789,
+      rank: 8,
+      option_type: OPTION_TYPE.CITY,
+    },
+    {
+      id: 9,
+      name: 'Beach',
+      latitude: 49.3456,
+      longitude: -123.789,
+      rank: 9,
+      option_type: OPTION_TYPE.CITY,
+    },
+    {
+      id: 10,
+      name: 'Ainsworth Hot Springs',
+      latitude: 49.4567,
+      longitude: -123.8901,
+      rank: 10,
+      option_type: OPTION_TYPE.CITY,
+    },
+  ];
+
+  describe('fuzzySearchCities', () => {
+    it('should find exact matches', () => {
+      const results = fuzzySearchCities(mockCities, 'Vancouver');
+      expect(results).toHaveLength(1);
+      expect(results[0].name).toBe('Vancouver');
+    });
+
+    it('should find partial matches', () => {
+      const results = fuzzySearchCities(mockCities, 'Van');
+      expect(results).toHaveLength(2);
+      expect(results[0].name).toBe('Vancouver');
+      expect(results[1].name).toBe('Britannia Beach');
+    });
+
+    it('should find fuzzy matches with typos', () => {
+      const results = fuzzySearchCities(mockCities, 'Vancuver');
+      expect(results).toHaveLength(1);
+      expect(results[0].name).toBe('Vancouver');
+    });
+
+    it('should find matches in different parts of the name', () => {
+      const results = fuzzySearchCities(mockCities, 'loops');
+      expect(results).toHaveLength(1);
+      expect(results[0].name).toBe('Kamloops');
+    });
+
+    it('should handle missing words in city names', () => {
+      // Should find "New Westminster" when searching "Westminster"
+      const results1 = fuzzySearchCities(mockCities, 'Westminster');
+      expect(results1).toHaveLength(1);
+      expect(results1[0].name).toBe('New Westminster');
+
+      // Should find "Port Coquitlam" when searching "Coquitlam"
+      const results2 = fuzzySearchCities(mockCities, 'Coquitlam');
+      expect(results2).toHaveLength(1);
+      expect(results2[0].name).toBe('Port Coquitlam');
+    });
+
+    it('should handle missing middle words', () => {
+      // Should find "Fort St. John" when searching "Fort John" (missing "St.")
+      const results = fuzzySearchCities(mockCities, 'Fort John');
+      expect(results).toHaveLength(1);
+      expect(results[0].name).toBe('Fort St. John');
+    });
+
+    it('should return empty array for no matches', () => {
+      const results = fuzzySearchCities(mockCities, 'xyz');
+      expect(results).toHaveLength(0);
+    });
+  });
+
+  describe('fuzzySearchBestCity', () => {
+    it('should find exact matches', () => {
+      const result = fuzzySearchBestCity(mockCities, 'Vancouver');
+      expect(result).not.toBeNull();
+      expect(result?.name).toBe('Vancouver');
+    });
+
+    it('should find exact matches for long city names', () => {
+      const result = fuzzySearchBestCity(mockCities, 'Ainsworth Hot Springs');
+      expect(result).not.toBeNull();
+      expect(result?.name).toBe('Ainsworth Hot Springs');
+    });
+
+    it('should find exact matches for single word cities', () => {
+      const result = fuzzySearchBestCity(mockCities, 'Beach');
+      expect(result).not.toBeNull();
+      expect(result?.name).toBe('Beach');
+    });
+
+    it('should find matches with minor typos', () => {
+      const result = fuzzySearchBestCity(mockCities, 'britanni beach');
+      expect(result).not.toBeNull();
+      expect(result?.name).toBe('Britannia Beach');
+    });
+
+    it('should find prefix matches', () => {
+      const result = fuzzySearchBestCity(mockCities, 'welcome');
+      expect(result).not.toBeNull();
+      expect(result?.name).toBe('Welcome Beach');
+    });
+
+    it('should reject substring matches at end of name', () => {
+      const result = fuzzySearchBestCity(mockCities, 'beach');
+      expect(result).not.toBeNull();
+      expect(result?.name).toBe('Beach'); // Should match "Beach", not "Welcome Beach" or "Britannia Beach"
+    });
+
+    it('should return null for no matches', () => {
+      const result = fuzzySearchBestCity(mockCities, 'xyz');
+      expect(result).toBeNull();
+    });
+
+    it('should return null for empty query', () => {
+      const result = fuzzySearchBestCity(mockCities, '');
+      expect(result).toBeNull();
+    });
+
+    it('should return null for whitespace query', () => {
+      const result = fuzzySearchBestCity(mockCities, '   ');
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/public/frontend/src/utils/fuzzySearch.test.ts
+++ b/public/frontend/src/utils/fuzzySearch.test.ts
@@ -85,6 +85,14 @@ describe('fuzzySearch', () => {
       rank: 10,
       option_type: OPTION_TYPE.CITY,
     },
+    {
+      id: 11,
+      name: 'Squamish',
+      latitude: 49.7016,
+      longitude: -123.1558,
+      rank: 11,
+      option_type: OPTION_TYPE.CITY,
+    },
   ];
 
   describe('fuzzySearchCities', () => {
@@ -119,34 +127,52 @@ describe('fuzzySearch', () => {
   });
 
   describe('fuzzySearchBestCity', () => {
-    it('should find exact matches', () => {
-      const result = fuzzySearchBestCity(mockCities, 'Vancouver');
+    it.each([
+      { query: 'Vancouver', expected: 'Vancouver', description: 'exact match' },
+      {
+        query: 'Ainsworth Hot Springs',
+        expected: 'Ainsworth Hot Springs',
+        description: 'exact match for long city name',
+      },
+      {
+        query: 'Beach',
+        expected: 'Beach',
+        description: 'exact match for single word city',
+      },
+      {
+        query: 'britanni beach',
+        expected: 'Britannia Beach',
+        description: 'match with minor typos for multi-word query',
+      },
+      {
+        query: 'beach',
+        expected: 'Beach',
+        description: 'single-word name with single-word query',
+      },
+      {
+        query: 'vancuver',
+        expected: 'Vancouver',
+        description: 'spelling error "vancuver" → "Vancouver"',
+      },
+      {
+        query: 'sqaumish',
+        expected: 'Squamish',
+        description: 'spelling error "sqaumish" → "Squamish"',
+      },
+      {
+        query: 'Victor',
+        expected: 'Victoria',
+        description: 'partial match "Victor" → "Victoria"',
+      },
+      {
+        query: 'victoria',
+        expected: 'Victoria',
+        description: 'lowercase query',
+      },
+    ])('should find $description', ({ query, expected }) => {
+      const result = fuzzySearchBestCity(mockCities, query);
       expect(result).not.toBeNull();
-      expect(result?.name).toBe('Vancouver');
-    });
-
-    it('should find exact matches for long city names', () => {
-      const result = fuzzySearchBestCity(mockCities, 'Ainsworth Hot Springs');
-      expect(result).not.toBeNull();
-      expect(result?.name).toBe('Ainsworth Hot Springs');
-    });
-
-    it('should find exact matches for single word cities', () => {
-      const result = fuzzySearchBestCity(mockCities, 'Beach');
-      expect(result).not.toBeNull();
-      expect(result?.name).toBe('Beach');
-    });
-
-    it('should find matches with minor typos for multi-word queries', () => {
-      const result = fuzzySearchBestCity(mockCities, 'britanni beach');
-      expect(result).not.toBeNull();
-      expect(result?.name).toBe('Britannia Beach');
-    });
-
-    it('should match single-word name with single-word query', () => {
-      const result = fuzzySearchBestCity(mockCities, 'beach');
-      expect(result).not.toBeNull();
-      expect(result?.name).toBe('Beach');
+      expect(result?.name).toBe(expected);
     });
 
     it('should NOT match multi-word names with single-word query "beach"', () => {
@@ -157,33 +183,24 @@ describe('fuzzySearch', () => {
       expect(result?.name).not.toBe('Britannia Beach');
     });
 
-    it('should NOT match multi-word names with single-word query "ainsworth"', () => {
-      const result = fuzzySearchBestCity(mockCities, 'ainsworth');
+    it.each([
+      { query: 'ainsworth', description: 'single-word query "ainsworth"' },
+      { query: 'welcome', description: 'single-word query "welcome"' },
+      {
+        query: 'ainsworth hot',
+        description: 'partial multi-word query "ainsworth hot"',
+      },
+    ])('should NOT match multi-word names with $description', ({ query }) => {
+      const result = fuzzySearchBestCity(mockCities, query);
       expect(result).toBeNull();
     });
 
-    it('should NOT match multi-word names with single-word query "welcome"', () => {
-      const result = fuzzySearchBestCity(mockCities, 'welcome');
-      expect(result).toBeNull();
-    });
-
-    it('should NOT match multi-word names with partial multi-word query "ainsworth hot"', () => {
-      const result = fuzzySearchBestCity(mockCities, 'ainsworth hot');
-      expect(result).toBeNull();
-    });
-
-    it('should return null for no matches', () => {
-      const result = fuzzySearchBestCity(mockCities, 'xyz');
-      expect(result).toBeNull();
-    });
-
-    it('should return null for empty query', () => {
-      const result = fuzzySearchBestCity(mockCities, '');
-      expect(result).toBeNull();
-    });
-
-    it('should return null for whitespace query', () => {
-      const result = fuzzySearchBestCity(mockCities, '   ');
+    it.each([
+      { query: 'xyz', description: 'no matches' },
+      { query: '', description: 'empty query' },
+      { query: '   ', description: 'whitespace query' },
+    ])('should return null for $description', ({ query }) => {
+      const result = fuzzySearchBestCity(mockCities, query);
       expect(result).toBeNull();
     });
   });

--- a/public/frontend/src/utils/fuzzySearch.ts
+++ b/public/frontend/src/utils/fuzzySearch.ts
@@ -11,7 +11,7 @@ const CITY_SUGGESTIONS_OPTIONS: IFuseOptions<City> = {
 };
 
 export const BEST_MATCH_CITY_OPTIONS: IFuseOptions<City> = {
-  threshold: 0.2,
+  threshold: 0.25,
   keys: ['name'],
   minMatchCharLength: 4,
   includeScore: true,
@@ -39,7 +39,7 @@ export const fuzzySearchBestCity = (
   const isQuerySingleWord = queryTokens.length === 1;
 
   const results = fuse.search(query, { limit: 10 });
-  const SCORE_THRESHOLD = 0.075;
+  const SCORE_THRESHOLD = 0.25;
 
   for (const result of results) {
     if (Number(result.score) > SCORE_THRESHOLD) continue;
@@ -47,7 +47,6 @@ export const fuzzySearchBestCity = (
     const cityTokens = result.item.name.trim().split(/\s+/);
     const isCitySingleWord = cityTokens.length === 1;
 
-    //
     // Rule 1: single-word query should only match single-word city names
     if (isQuerySingleWord && !isCitySingleWord) continue;
 

--- a/public/frontend/src/utils/fuzzySearch.ts
+++ b/public/frontend/src/utils/fuzzySearch.ts
@@ -1,0 +1,42 @@
+import Fuse, { type IFuseOptions } from 'fuse.js';
+import { MAX_LOCATION_OPTIONS } from '@/components/recreation-suggestion-form/constants';
+import { City } from '@/components/recreation-suggestion-form/types';
+
+const CITY_SUGGESTIONS_OPTIONS: IFuseOptions<City> = {
+  threshold: 0.4,
+  keys: ['name'],
+  minMatchCharLength: 1,
+  useExtendedSearch: true,
+  findAllMatches: true,
+};
+
+export const BEST_MATCH_CITY_OPTIONS: IFuseOptions<City> = {
+  threshold: 0.2,
+  keys: ['name'],
+  minMatchCharLength: 4,
+  includeScore: true,
+  ignoreLocation: false,
+  ignoreFieldNorm: true,
+};
+
+export const fuzzySearchCities = (cities: City[], query: string): City[] => {
+  if (!query.trim()) return cities.slice(0, MAX_LOCATION_OPTIONS);
+
+  const fuse = new Fuse(cities, CITY_SUGGESTIONS_OPTIONS);
+  return fuse.search(query, { limit: MAX_LOCATION_OPTIONS }).map((r) => r.item);
+};
+
+export const fuzzySearchBestCity = (
+  cities: City[],
+  query: string,
+): City | null => {
+  if (!query.trim()) return null;
+
+  const fuse = new Fuse(cities, BEST_MATCH_CITY_OPTIONS);
+  const results = fuse.search(query, { limit: 1 });
+  const result = results[0];
+
+  const SCORE_THRESHOLD = 0.075;
+
+  return result && Number(result.score) <= SCORE_THRESHOLD ? result.item : null;
+};


### PR DESCRIPTION
- add fuzzy search to front end city search using [fuse.js](https://www.fusejs.io/)
- add fuzzy search to backend search and suggestions using `pg_trgm` similarity
- update e2e tests that were failing in dev due to district changes (okanagan district is empty now)
- update e2e tests due to fuzzy search changes