### PR TITLE
fix: filter counts regression

### DIFF
--- a/public/backend/src/recreation-resource/utils/buildSearchFilterOptionCountsQuery.spec.ts
+++ b/public/backend/src/recreation-resource/utils/buildSearchFilterOptionCountsQuery.spec.ts
@@ -29,6 +29,8 @@ describe('buildFilterOptionCountsQuery', () => {
       isOnlyDistrictFilter: true,
       isOnlyAccessFilter: true,
       isOnlyTypeFilter: true,
+      isOnlyStatusFilter: false,
+      isOnlyFeesFilter: false,
     };
 
     const query = buildFilterOptionCountsQuery({
@@ -38,13 +40,13 @@ describe('buildFilterOptionCountsQuery', () => {
     const queryStr = query.sql;
 
     expect(queryStr).toContain(
-      'WHEN ? THEN (SELECT COUNT(*) FROM recreation_resource_search_view WHERE district_code = dcv.district_code  )::INT',
+      'WHEN ? THEN (SELECT COUNT(*) FROM recreation_resource_search_view WHERE district_code = dcv.district_code AND display_on_public_site = true  )::INT',
     );
     expect(queryStr).toContain(
-      'WHEN ? THEN (SELECT COUNT(*) FROM recreation_resource_search_view WHERE access_code = acv.access_code  )::INT',
+      'WHEN ? THEN (SELECT COUNT(*) FROM recreation_resource_search_view WHERE access_code = acv.access_code AND display_on_public_site = true  )::INT',
     );
     expect(queryStr).toContain(
-      'WHEN ? THEN (SELECT COUNT(*) FROM recreation_resource_search_view WHERE recreation_resource_type_code = acv.rec_resource_type_code  )::INT',
+      'WHEN ? THEN (SELECT COUNT(*) FROM recreation_resource_search_view WHERE recreation_resource_type_code = acv.rec_resource_type_code AND display_on_public_site = true  )::INT',
     );
 
     expect(query.values).toContain('AC1');
@@ -91,6 +93,8 @@ describe('buildFilterOptionCountsQuery', () => {
       isOnlyDistrictFilter: false,
       isOnlyAccessFilter: false,
       isOnlyTypeFilter: false,
+      isOnlyStatusFilter: false,
+      isOnlyFeesFilter: false,
     };
     const query = buildFilterOptionCountsQuery({ whereClause, filterTypes });
 
@@ -109,6 +113,8 @@ describe('buildFilterOptionCountsQuery', () => {
       isOnlyDistrictFilter: true,
       isOnlyAccessFilter: false,
       isOnlyTypeFilter: true,
+      isOnlyStatusFilter: false,
+      isOnlyFeesFilter: false,
     };
     const lat = 50.0;
     const lon = -120.0;
@@ -128,11 +134,11 @@ describe('buildFilterOptionCountsQuery', () => {
     expect(query.values).toContain(-120.0);
     // Check that both true and false branches are present
     expect(query.sql).toContain(
-      'WHEN ? THEN (SELECT COUNT(*) FROM recreation_resource_search_view WHERE district_code = dcv.district_code',
+      'WHEN ? THEN (SELECT COUNT(*) FROM recreation_resource_search_view WHERE district_code = dcv.district_code AND display_on_public_site = true',
     );
     expect(query.sql).toContain('ELSE COUNT(fr.access_code)::INT');
     expect(query.sql).toContain(
-      'WHEN ? THEN (SELECT COUNT(*) FROM recreation_resource_search_view WHERE recreation_resource_type_code = acv.rec_resource_type_code',
+      'WHEN ? THEN (SELECT COUNT(*) FROM recreation_resource_search_view WHERE recreation_resource_type_code = acv.rec_resource_type_code AND display_on_public_site = true',
     );
   });
 });

--- a/public/backend/src/recreation-resource/utils/buildSearchFilterOptionCountsQuery.ts
+++ b/public/backend/src/recreation-resource/utils/buildSearchFilterOptionCountsQuery.ts
@@ -29,7 +29,7 @@ export function buildFilterOptionCountsQuery({
       )`
       : Prisma.empty;
 
-  const extraFilters = Prisma.sql`${textSearchCondition} ${locationFilter}`;
+  const extraFilters = Prisma.sql`AND display_on_public_site = true ${textSearchCondition} ${locationFilter}`;
 
   return Prisma.sql`
   WITH filtered_resources AS (
@@ -136,21 +136,21 @@ export function buildFilterOptionCountsQuery({
       CASE
         WHEN ${filterTypes?.isOnlyFeesFilter ?? false} THEN (
           SELECT COUNT(*) FROM recreation_resource_search_view
-          WHERE is_reservable = true AND display_on_public_site = true ${extraFilters}
+          WHERE is_reservable = true ${extraFilters}
         )::INT
         ELSE COALESCE(SUM(CASE WHEN is_reservable = true THEN 1 ELSE 0 END), 0)::INT
       END AS reservable_count,
       CASE
         WHEN ${filterTypes?.isOnlyFeesFilter ?? false} THEN (
           SELECT COUNT(*) FROM recreation_resource_search_view
-          WHERE is_fees = true AND display_on_public_site = true ${extraFilters}
+          WHERE is_fees = true ${extraFilters}
         )::INT
         ELSE COALESCE(SUM(CASE WHEN is_fees = true THEN 1 ELSE 0 END), 0)::INT
       END AS fees_count,
       CASE
         WHEN ${filterTypes?.isOnlyFeesFilter ?? false} THEN (
           SELECT COUNT(*) FROM recreation_resource_search_view
-          WHERE (is_fees = false OR is_fees IS NULL) AND display_on_public_site = true ${extraFilters}
+          WHERE (is_fees = false OR is_fees IS NULL) ${extraFilters}
         )::INT
         ELSE COALESCE(SUM(CASE WHEN (is_fees = false OR is_fees IS NULL) THEN 1 ELSE 0 END), 0)::INT
       END AS no_fees_count


### PR DESCRIPTION
Fixed a regression I made when I added the status and fees filter groups, the updates to the filter counts weren't considering `display_on_public_site = true` anymore. 

Fixed:
<img width="430" height="368" alt="Screenshot 2025-10-01 at 2 40 34 PM" src="https://github.com/user-attachments/assets/d3642331-de31-49e9-b178-ae5a9dd70426" />

Buggy counts in test:
<img width="430" height="368" alt="Screenshot 2025-10-01 at 2 41 03 PM" src="https://github.com/user-attachments/assets/376da3c6-5e64-423f-9c16-db4ee191131b" />
