### PR TITLE
chore: display suggestions with no districts

### DIFF
--- a/admin/backend/src/recreation-resource/recreation-resource.service.ts
+++ b/admin/backend/src/recreation-resource/recreation-resource.service.ts
@@ -62,10 +62,6 @@ export class RecreationResourceService {
   private isValidSuggestion(
     item: getRecreationResourceSuggestions.Result,
   ): item is SuggestionDto {
-    return (
-      Boolean(item.rec_resource_id) &&
-      Boolean(item.name) &&
-      Boolean(item.district_description)
-    );
+    return Boolean(item.rec_resource_id) && Boolean(item.name);
   }
 }


### PR DESCRIPTION
Display resources with no districts on suggestion.

This cover the case of REC0001 not being shown on admin suggestions.

<img width="1382" height="741" alt="image" src="https://github.com/user-attachments/assets/0ccb8ed6-7ddf-473e-8321-0c18a4be9903" />
