### PR TITLE
ci: change release workflow to scheduled and manual dispatch

### DIFF
--- a/.github/workflows/.release.yml
+++ b/.github/workflows/.release.yml
@@ -1,12 +1,7 @@
 name: Make Release
 
 on:
-  workflow_call:
-    inputs:
-      app:
-        description: Application name
-        required: true
-        type: string
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -30,7 +25,6 @@ jobs:
           skip-version-file: true
           skip-commit: true
           git-push: false
-          tag-prefix: ${{ inputs.app }}-
 
       - name: Create Release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/.release.yml
+++ b/.github/workflows/.release.yml
@@ -1,6 +1,11 @@
 name: Make Release
 
+# Release workflow to create a new release on the 1st of every month
+# or manually via workflow_dispatch
+
 on:
+  schedule:
+    - cron: '0 0 1 * *' # 1st day of every month at midnight UTC
   workflow_dispatch:
 
 permissions:
@@ -14,6 +19,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
+          ref: main
 
       - name: Conventional Changelog Update
         uses: TriPSs/conventional-changelog-action@v6

--- a/.github/workflows/.review-and-deploy.yml
+++ b/.github/workflows/.review-and-deploy.yml
@@ -89,13 +89,6 @@ jobs:
       - name: Review Prod Deployment
         run: echo "Reviewing Prod Deployment"
 
-  release:
-    name: Release
-    needs: review-prod-deployment
-    uses: ./.github/workflows/.release.yml
-    with:
-      app: ${{ inputs.app }}
-
   promote:
     name: Promote
     needs: release
@@ -106,7 +99,7 @@ jobs:
 
   deploy-to-aws-prod:
     name: Deploy Application to AWS prod
-    needs: release
+    needs: promote
     uses: ./.github/workflows/.deploy-app.yml
     concurrency:
       group: deploy-${{ inputs.app }}-to-aws-prod

--- a/.github/workflows/.review-and-deploy.yml
+++ b/.github/workflows/.review-and-deploy.yml
@@ -91,7 +91,7 @@ jobs:
 
   promote:
     name: Promote
-    needs: release
+    needs: review-prod-deployment
     uses: ./.github/workflows/.promote.yml
     with:
       app: ${{ inputs.app }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,20 +13,6 @@ on:
 
 
 jobs:
-  ################################################
-  # Merging these in to verify the release process works as expected
-  # -- will remove these in a follow up PR
-  release-admin:
-    name: Release Admin
-    uses: ./.github/workflows/.release.yml
-    with:
-      app: admin
-  release-public:
-    name: Release Public
-    uses: ./.github/workflows/.release.yml
-    with:
-      app: public
-  ###############################################
   build-containers:
     name: Build containers
     concurrency:


### PR DESCRIPTION
Okay, last one I think. Since we have no easy way to separate admin/public commits I'm not sure it makes sense to have separate releases.

My idea for this now is to schedule releases on the first of every month as well as add the ability to manually trigger them from the actions tab. We can decide as a team when to make releases (besides the automated monthly ones) and manually call them.
