### PR TITLE
chore: updated upload message

### DIFF
--- a/admin/frontend/src/pages/rec-resource-page/components/RecResourceFileSection/GalleryFileCard/constants.ts
+++ b/admin/frontend/src/pages/rec-resource-page/components/RecResourceFileSection/GalleryFileCard/constants.ts
@@ -118,3 +118,6 @@ export const DOCUMENT_VIEWER_CARD_ACTIONS: ReadonlyArray<{
   icon: IconDefinition;
   label: string;
 }> = [ACTION_VIEW, ACTION_DOWNLOAD] as const;
+
+export const MAX_FILES_REACHED_MESSAGE =
+  'You’ve reached the maximum number of files. Remove a file to upload a new one.';

--- a/admin/frontend/src/pages/rec-resource-page/components/RecResourceFileSection/RecResourceFileSection.tsx
+++ b/admin/frontend/src/pages/rec-resource-page/components/RecResourceFileSection/RecResourceFileSection.tsx
@@ -24,6 +24,7 @@ import {
   IMAGE_PREVIEW_ACTIONS,
   IMAGE_VIEWER_CARD_ACTIONS,
   IMAGE_VIEWER_PREVIEW_ACTIONS,
+  MAX_FILES_REACHED_MESSAGE,
 } from './GalleryFileCard/constants';
 import { ImageLightboxModal } from './ImageLightboxModal';
 import { PhotoDetailsModal } from './PhotoDetailsModal';
@@ -38,7 +39,9 @@ export const RecResourceFileSection = () => {
     getImageGeneralActionHandler,
     galleryDocuments,
     galleryImages,
+    isDocumentMaxFilesReached,
     isDocumentUploadDisabled,
+    isImageMaxFilesReached,
     isImageUploadDisabled,
     isFetching,
     isFetchingImages,
@@ -87,7 +90,11 @@ export const RecResourceFileSection = () => {
       <GalleryAccordion<GalleryImage>
         eventKey="images"
         title="Public images"
-        description={`Upload up to ${FILE_TYPE_CONFIGS.image.maxFiles} JPG, PNG, or WEBP images (max ${MAX_FILE_SIZE_MB.image}MB each).`}
+        description={
+          isImageMaxFilesReached
+            ? MAX_FILES_REACHED_MESSAGE
+            : `Upload up to ${FILE_TYPE_CONFIGS.image.maxFiles} JPG, PNG, or WEBP images (max ${MAX_FILE_SIZE_MB.image}MB each).`
+        }
         items={galleryImages}
         uploadLabel="Upload"
         isLoading={isFetchingImages}
@@ -104,7 +111,11 @@ export const RecResourceFileSection = () => {
       <GalleryAccordion<GalleryDocument>
         eventKey="documents"
         title="Public documents"
-        description={`Documents are only accepted in PDF format with a ${MAX_FILE_SIZE_MB.document}MB file size limit. Maximum ${FILE_TYPE_CONFIGS.document.maxFiles} documents.`}
+        description={
+          isDocumentMaxFilesReached
+            ? MAX_FILES_REACHED_MESSAGE
+            : `Documents are only accepted in PDF format with a ${MAX_FILE_SIZE_MB.document}MB file size limit. Maximum ${FILE_TYPE_CONFIGS.document.maxFiles} documents.`
+        }
         items={galleryDocuments}
         uploadLabel="Upload"
         isLoading={isFetching}

--- a/admin/frontend/src/pages/rec-resource-page/hooks/useRecResourceFileTransferState.ts
+++ b/admin/frontend/src/pages/rec-resource-page/hooks/useRecResourceFileTransferState.ts
@@ -97,23 +97,25 @@ export function useRecResourceFileTransferState() {
     [createGeneralActionHandler, refetchImages],
   );
 
-  // Calculate upload disabled state based on total documents (server + pending)
-  const isDocumentUploadDisabled = useMemo(() => {
-    const totalDocCount = galleryDocuments.length;
-    const hasUploadingDoc = galleryDocuments.some((doc) => doc.isUploading);
-    return (
-      totalDocCount >= getMaxFilesByFileType('document') || hasUploadingDoc
-    );
+  const isDocumentMaxFilesReached = useMemo(() => {
+    return galleryDocuments.length >= getMaxFilesByFileType('document');
   }, [galleryDocuments]);
 
-  // Calculate upload disabled state based on total images (server + pending)
-  const isImageUploadDisabled = useMemo(() => {
-    const totalImageCount = galleryImages.length;
-    const hasUploadingImage = galleryImages.some((image) => image.isUploading);
-    return (
-      totalImageCount >= getMaxFilesByFileType('image') || hasUploadingImage
-    );
+  const isImageMaxFilesReached = useMemo(() => {
+    return galleryImages.length >= getMaxFilesByFileType('image');
   }, [galleryImages]);
+
+  // Calculate upload disabled state based on total documents (server + pending)
+  const isDocumentUploadDisabled = useMemo(() => {
+    const hasUploadingDoc = galleryDocuments.some((doc) => doc.isUploading);
+    return isDocumentMaxFilesReached || hasUploadingDoc;
+  }, [galleryDocuments, isDocumentMaxFilesReached]);
+
+  // Calculate upload disabled state based on total images (server + pending)a
+  const isImageUploadDisabled = useMemo(() => {
+    const hasUploadingImage = galleryImages.some((image) => image.isUploading);
+    return isImageMaxFilesReached || hasUploadingImage;
+  }, [galleryImages, isImageMaxFilesReached]);
 
   // File name validation
   const { fileNameError } = useFileNameValidation();
@@ -128,11 +130,13 @@ export function useRecResourceFileTransferState() {
 
     // Document list
     galleryDocuments,
+    isDocumentMaxFilesReached,
     isDocumentUploadDisabled,
     isFetching,
 
     // Image list
     galleryImages,
+    isImageMaxFilesReached,
     isImageUploadDisabled,
     isFetchingImages,
 

--- a/admin/frontend/test/pages/rec-resource-page/components/RecResourceFileSection/RecResourceFileSection.test.tsx
+++ b/admin/frontend/test/pages/rec-resource-page/components/RecResourceFileSection/RecResourceFileSection.test.tsx
@@ -31,6 +31,7 @@ vi.mock(
       onFileUploadTileClick,
       uploadDisabled,
       uploadLabel,
+      description,
     }: any) => (
       <div data-testid="gallery-accordion">
         <span
@@ -39,6 +40,7 @@ vi.mock(
         >
           {uploadLabel}
         </span>
+        <span data-testid="accordion-description">{description}</span>
         {items.map(renderItem)}
       </div>
     ),
@@ -126,7 +128,9 @@ describe('RecResourceFileSection', () => {
     },
     galleryDocuments: [],
     galleryImages: [],
+    isDocumentMaxFilesReached: false,
     isDocumentUploadDisabled: false,
+    isImageMaxFilesReached: false,
     isImageUploadDisabled: false,
     isFetching: false,
     isFetchingImages: false,
@@ -320,5 +324,35 @@ describe('RecResourceFileSection', () => {
       fireEvent.click(imageUploadLabel!);
       expect(defaultState.getImageGeneralActionHandler).toHaveBeenCalled();
     }
+  });
+
+  it('replaces image info text and announces when image max is reached', () => {
+    mockUseRecResourceFileTransferState.mockReturnValue({
+      ...defaultState,
+      isImageMaxFilesReached: true,
+      isImageUploadDisabled: true,
+    });
+
+    render(<RecResourceFileSection />);
+
+    const descriptions = screen.getAllByTestId('accordion-description');
+    expect(descriptions[0]).toHaveTextContent(
+      'You’ve reached the maximum number of files. Remove a file to upload a new one.',
+    );
+  });
+
+  it('replaces document info text and announces when document max is reached', () => {
+    mockUseRecResourceFileTransferState.mockReturnValue({
+      ...defaultState,
+      isDocumentMaxFilesReached: true,
+      isDocumentUploadDisabled: true,
+    });
+
+    render(<RecResourceFileSection />);
+
+    const descriptions = screen.getAllByTestId('accordion-description');
+    expect(descriptions[1]).toHaveTextContent(
+      'You’ve reached the maximum number of files. Remove a file to upload a new one.',
+    );
   });
 });

--- a/admin/frontend/test/pages/rec-resource-page/hooks/useRecResourceFileTransferState.test.ts
+++ b/admin/frontend/test/pages/rec-resource-page/hooks/useRecResourceFileTransferState.test.ts
@@ -1,3 +1,4 @@
+import { getMaxFilesByFileType } from '@/pages/rec-resource-page/helpers';
 import { useRecResource } from '@/pages/rec-resource-page/hooks/useRecResource';
 import { useRecResourceFileTransferState } from '@/pages/rec-resource-page/hooks/useRecResourceFileTransferState';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
@@ -5,29 +6,49 @@ import { renderHook } from '@testing-library/react';
 import { type ReactNode, createElement } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const mockDocumentListState = {
-  galleryDocumentsFromServer: [] as any[],
-  isFetching: false,
-  refetch: vi.fn(),
-};
-
-const mockImageListState = {
-  galleryImagesFromServer: [] as any[],
-  isFetching: false,
-  refetch: vi.fn(),
-};
-
-const mockGalleryActions = {
-  handleFileAction: vi.fn(),
-  handleGeneralAction: vi.fn(),
-};
-
-const mockFileNameValidation = {
-  fileNameError: undefined as string | undefined,
-  validateFileName: vi.fn(),
-  hasError: false,
-  isValid: false,
-};
+const {
+  mockStoreState,
+  mockGetMaxFilesByFileType,
+  mockDocumentListState,
+  mockImageListState,
+  mockGalleryActions,
+  mockFileNameValidation,
+} = vi.hoisted(() => ({
+  mockStoreState: {
+    showUploadOverlay: false,
+    showDeleteModal: false,
+    fileToDelete: undefined,
+    uploadFileName: '',
+    selectedFileForUpload: null,
+    pendingDocs: [] as any[],
+    galleryDocuments: [] as any[],
+    pendingImages: [] as any[],
+    galleryImages: [] as any[],
+  },
+  mockGetMaxFilesByFileType: vi.fn((fileType: 'document' | 'image') =>
+    fileType === 'document' ? 5 : 5,
+  ),
+  mockDocumentListState: {
+    galleryDocumentsFromServer: [] as any[],
+    isFetching: false,
+    refetch: vi.fn(),
+  },
+  mockImageListState: {
+    galleryImagesFromServer: [] as any[],
+    isFetching: false,
+    refetch: vi.fn(),
+  },
+  mockGalleryActions: {
+    handleFileAction: vi.fn(),
+    handleGeneralAction: vi.fn(),
+  },
+  mockFileNameValidation: {
+    fileNameError: undefined as string | undefined,
+    validateFileName: vi.fn(),
+    hasError: false,
+    isValid: false,
+  },
+}));
 
 vi.mock('@/contexts/AuthContext', () => ({
   useAuthContext: () => ({
@@ -54,7 +75,7 @@ vi.mock('@/pages/rec-resource-page/hooks/useFileNameValidation', () => ({
 }));
 
 vi.mock('@/pages/rec-resource-page/helpers', () => ({
-  getMaxFilesByFileType: vi.fn().mockReturnValue(5),
+  getMaxFilesByFileType: mockGetMaxFilesByFileType,
 }));
 
 vi.mock('@/pages/rec-resource-page/hooks/useRecResource', () => ({
@@ -63,34 +84,14 @@ vi.mock('@/pages/rec-resource-page/hooks/useRecResource', () => ({
 
 vi.mock('@/pages/rec-resource-page/store/recResourceFileTransferStore', () => ({
   recResourceFileTransferStore: {
-    state: {
-      showUploadOverlay: false,
-      showDeleteModal: false,
-      docToDelete: null,
-      uploadFileName: '',
-      selectedFileForUpload: null,
-      pendingDocs: [],
-      galleryDocuments: [],
-      pendingImages: [],
-      galleryImages: [],
-    },
+    state: mockStoreState,
   },
   setGalleryDocuments: vi.fn(),
   setGalleryImages: vi.fn(),
 }));
 
 vi.mock('@tanstack/react-store', () => ({
-  useStore: () => ({
-    showUploadOverlay: false,
-    showDeleteModal: false,
-    docToDelete: null,
-    uploadFileName: '',
-    selectedFileForUpload: null,
-    pendingDocs: [],
-    galleryDocuments: [],
-    pendingImages: [],
-    galleryImages: [],
-  }),
+  useStore: () => mockStoreState,
 }));
 
 // Create a wrapper with QueryClient for tests
@@ -108,8 +109,20 @@ const createWrapper = () => {
 };
 
 describe('useRecResourceFileTransferState', () => {
+  const setGalleryByType = (fileType: 'document' | 'image', files: any[]) => {
+    if (fileType === 'document') {
+      mockStoreState.galleryDocuments = files;
+      return;
+    }
+
+    mockStoreState.galleryImages = files;
+  };
+
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(getMaxFilesByFileType).mockImplementation((fileType) =>
+      fileType === 'document' ? 5 : 5,
+    );
 
     // Mock useRecResource
     vi.mocked(useRecResource).mockReturnValue({
@@ -136,6 +149,16 @@ describe('useRecResourceFileTransferState', () => {
     mockFileNameValidation.hasError = false;
     mockFileNameValidation.isValid = false;
     mockFileNameValidation.validateFileName.mockReset();
+
+    mockStoreState.showUploadOverlay = false;
+    mockStoreState.showDeleteModal = false;
+    mockStoreState.fileToDelete = undefined;
+    mockStoreState.uploadFileName = '';
+    mockStoreState.selectedFileForUpload = null;
+    mockStoreState.pendingDocs = [];
+    mockStoreState.galleryDocuments = [];
+    mockStoreState.pendingImages = [];
+    mockStoreState.galleryImages = [];
   });
 
   it('returns state and handlers from composed hooks', () => {
@@ -152,11 +175,13 @@ describe('useRecResourceFileTransferState', () => {
 
       // Document list
       galleryDocuments: expect.any(Array),
+      isDocumentMaxFilesReached: expect.any(Boolean),
       isDocumentUploadDisabled: expect.any(Boolean),
       isFetching: expect.any(Boolean),
 
       // Image list
       galleryImages: expect.any(Array),
+      isImageMaxFilesReached: expect.any(Boolean),
       isImageUploadDisabled: expect.any(Boolean),
       isFetchingImages: expect.any(Boolean),
 
@@ -249,57 +274,97 @@ describe('useRecResourceFileTransferState', () => {
     );
   });
 
-  it('returns values from all composed hooks', () => {
-    const { result } = renderHook(() => useRecResourceFileTransferState(), {
-      wrapper: createWrapper(),
-    });
+  it.each([
+    {
+      name: 'disables document upload at max files',
+      fileType: 'document' as const,
+      max: 2,
+      files: [{ id: '1' }, { id: '2' }],
+      expectedMaxReached: true,
+      expectedDisabled: true,
+      maxReachedKey: 'isDocumentMaxFilesReached' as const,
+      uploadDisabledKey: 'isDocumentUploadDisabled' as const,
+    },
+    {
+      name: 'disables document upload when a file is uploading below max',
+      fileType: 'document' as const,
+      max: 3,
+      files: [
+        { id: '1', isUploading: true },
+        { id: '2', isUploading: false },
+      ],
+      expectedMaxReached: false,
+      expectedDisabled: true,
+      maxReachedKey: 'isDocumentMaxFilesReached' as const,
+      uploadDisabledKey: 'isDocumentUploadDisabled' as const,
+    },
+    {
+      name: 'keeps document upload enabled below max without uploading files',
+      fileType: 'document' as const,
+      max: 3,
+      files: [{ id: '1' }, { id: '2' }],
+      expectedMaxReached: false,
+      expectedDisabled: false,
+      maxReachedKey: 'isDocumentMaxFilesReached' as const,
+      uploadDisabledKey: 'isDocumentUploadDisabled' as const,
+    },
+    {
+      name: 'disables image upload at max files',
+      fileType: 'image' as const,
+      max: 2,
+      files: [{ id: '1' }, { id: '2' }],
+      expectedMaxReached: true,
+      expectedDisabled: true,
+      maxReachedKey: 'isImageMaxFilesReached' as const,
+      uploadDisabledKey: 'isImageUploadDisabled' as const,
+    },
+    {
+      name: 'disables image upload when a file is uploading below max',
+      fileType: 'image' as const,
+      max: 3,
+      files: [
+        { id: '1', isUploading: true },
+        { id: '2', isUploading: false },
+      ],
+      expectedMaxReached: false,
+      expectedDisabled: true,
+      maxReachedKey: 'isImageMaxFilesReached' as const,
+      uploadDisabledKey: 'isImageUploadDisabled' as const,
+    },
+    {
+      name: 'keeps image upload enabled below max without uploading files',
+      fileType: 'image' as const,
+      max: 3,
+      files: [{ id: '1' }, { id: '2' }],
+      expectedMaxReached: false,
+      expectedDisabled: false,
+      maxReachedKey: 'isImageMaxFilesReached' as const,
+      uploadDisabledKey: 'isImageUploadDisabled' as const,
+    },
+  ])(
+    '$name',
+    ({
+      fileType,
+      max,
+      files,
+      expectedMaxReached,
+      expectedDisabled,
+      maxReachedKey,
+      uploadDisabledKey,
+    }) => {
+      vi.mocked(getMaxFilesByFileType).mockImplementation((currentType) =>
+        currentType === fileType ? max : 5,
+      );
+      setGalleryByType(fileType, files as any[]);
 
-    // Verify it includes properties from document list hook
-    expect(result.current.galleryDocuments).toEqual([]);
-    expect(result.current.isFetching).toBe(false);
+      const { result } = renderHook(() => useRecResourceFileTransferState(), {
+        wrapper: createWrapper(),
+      });
 
-    // Verify it includes properties from image list hook
-    expect(result.current.galleryImages).toEqual([]);
-    expect(result.current.isFetchingImages).toBe(false);
-
-    // Verify upload modal state structure
-    expect(result.current.uploadModalState).toEqual({
-      showUploadOverlay: false,
-      uploadFileName: '',
-      selectedFileForUpload: null,
-      fileNameError: undefined,
-    });
-
-    // Verify delete modal state structure
-    expect(result.current.deleteModalState).toEqual({
-      showDeleteModal: false,
-      fileToDelete: undefined,
-    });
-  });
-
-  it('calculates document upload disabled state based on max files', () => {
-    // Mock getMaxFilesByFileType to return 2 for this test
-    const mockGetMaxFiles = vi.fn().mockReturnValue(2);
-    vi.doMock('@/pages/rec-resource-page/helpers', () => ({
-      getMaxFilesByFileType: mockGetMaxFiles,
-    }));
-
-    const { result } = renderHook(() => useRecResourceFileTransferState(), {
-      wrapper: createWrapper(),
-    });
-
-    // With 0 documents, should not be disabled
-    expect(result.current.isDocumentUploadDisabled).toBe(false);
-  });
-
-  it('calculates image upload disabled state based on max files', () => {
-    const { result } = renderHook(() => useRecResourceFileTransferState(), {
-      wrapper: createWrapper(),
-    });
-
-    // With 0 images and max of 5, should not be disabled
-    expect(result.current.isImageUploadDisabled).toBe(false);
-  });
+      expect(result.current[maxReachedKey]).toBe(expectedMaxReached);
+      expect(result.current[uploadDisabledKey]).toBe(expectedDisabled);
+    },
+  );
 
   it('includes file name validation properties in upload modal state', () => {
     // Set up mock with validation error


### PR DESCRIPTION
**Card:** https://bcparksdigital.atlassian.net/browse/ORCA-576
**Changes:**
- Updated RecResourceFileSection to enforce max image and document limits and dynamically update the section description.
- Added isDocumentMaxFilesReached and isImageMaxFilesReached hooks .
- Added unit tests 

**To Test:**
1. Go to the Admin URL: http://localhost:3001
2. Select a recreation site: http://localhost:3001/rec-resource/REC3176/files
3. Upload 20 images or 30 documents.
4. Verify that once the limit is reached:
     - The Upload button is disabled.
     - The message displays: "You’ve reached the maximum number of files. Remove a file to upload a new one."