### PR TITLE
feat(auth): handle session expiry with user notification and login re…

### DIFF
--- a/admin/frontend/src/components/notification-bar/NotificationBar.scss
+++ b/admin/frontend/src/components/notification-bar/NotificationBar.scss
@@ -23,4 +23,29 @@
     border-radius: $border-radius;
     margin-bottom: unset;
   }
+
+  &__content {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.5rem;
+  }
+
+  &__title {
+    font-weight: 700;
+    margin-bottom: 0.25rem;
+  }
+
+  &__actions {
+    flex-shrink: 0;
+    align-self: flex-end;
+    justify-content: flex-end;
+  }
+
+  &__spinner,
+  .notification-bar-container__alert svg {
+    flex-shrink: 0;
+    align-self: flex-start;
+    margin-top: 0.25rem;
+  }
 }

--- a/admin/frontend/src/components/notification-bar/NotificationToast.tsx
+++ b/admin/frontend/src/components/notification-bar/NotificationToast.tsx
@@ -1,5 +1,5 @@
 import { NotificationMessage } from '@/store/notificationStore';
-import { Alert, Stack, Toast } from 'react-bootstrap';
+import { Alert, Button, Stack, Toast } from 'react-bootstrap';
 import { NotificationBarIcon } from './NotificationBarIcon';
 
 interface NotificationToastProps {
@@ -9,18 +9,27 @@ interface NotificationToastProps {
 
 export function NotificationToast({ msg, onClose }: NotificationToastProps) {
   const isSpinner = msg.type === 'spinner';
+  const actions = msg.type === 'status' ? msg.actions : undefined;
+  const title = msg.type === 'status' ? msg.title : undefined;
   const alertVariant = isSpinner
     ? 'info'
     : msg.type === 'status'
       ? msg.variant
       : 'info';
 
+  const handleClose = () => {
+    if (msg.type === 'status' && msg.onDismiss) {
+      msg.onDismiss();
+    }
+    onClose();
+  };
+
   return (
     <Toast
       autohide={!isSpinner && msg.autoDismiss}
       delay={!isSpinner ? msg.timeout : undefined}
       key={msg.id}
-      onClose={onClose}
+      onClose={handleClose}
       className="notification-bar-container__toast"
       role="status"
       aria-live="polite"
@@ -30,13 +39,43 @@ export function NotificationToast({ msg, onClose }: NotificationToastProps) {
           key={msg.id}
           variant={alertVariant}
           dismissible={!isSpinner}
-          onClose={!isSpinner ? onClose : undefined}
+          onClose={handleClose}
           className="notification-bar-container__alert"
         >
-          <Stack direction="horizontal" gap={2}>
-            <NotificationBarIcon msg={msg} />
-            <span>{msg.message}</span>
-          </Stack>
+          <div className="notification-bar-container__content">
+            <Stack direction="horizontal" gap={2}>
+              <NotificationBarIcon msg={msg} />
+              <div>
+                {title && (
+                  <div className="notification-bar-container__title">
+                    {title}
+                  </div>
+                )}
+                <span>{msg.message}</span>
+              </div>
+            </Stack>
+            {!!actions?.length && (
+              <Stack
+                direction="horizontal"
+                gap={2}
+                className="notification-bar-container__actions"
+              >
+                {actions.map((action, index) => (
+                  <Button
+                    key={`${msg.id}-action-${index}`}
+                    size="sm"
+                    variant={action.variant ?? 'primary'}
+                    onClick={() => {
+                      if (action.dismissOnClick !== false) onClose();
+                      action.onClick();
+                    }}
+                  >
+                    {action.label}
+                  </Button>
+                ))}
+              </Stack>
+            )}
+          </div>
         </Alert>
       </Toast.Body>
     </Toast>

--- a/admin/frontend/src/routeTree.gen.ts
+++ b/admin/frontend/src/routeTree.gen.ts
@@ -127,11 +127,11 @@ export interface FileRoutesByFullPath {
   '/rec-resource/$id/geospatial/edit': typeof RecResourceIdGeospatialEditRoute
   '/rec-resource/$id/overview/edit': typeof RecResourceIdOverviewEditRoute
   '/rec-resource/$id/reservation/edit': typeof RecResourceIdReservationEditRoute
-  '/rec-resource/$id/activities-features/': typeof RecResourceIdActivitiesFeaturesIndexRoute
-  '/rec-resource/$id/fees/': typeof RecResourceIdFeesIndexRoute
-  '/rec-resource/$id/geospatial/': typeof RecResourceIdGeospatialIndexRoute
-  '/rec-resource/$id/overview/': typeof RecResourceIdOverviewIndexRoute
-  '/rec-resource/$id/reservation/': typeof RecResourceIdReservationIndexRoute
+  '/rec-resource/$id/activities-features': typeof RecResourceIdActivitiesFeaturesIndexRoute
+  '/rec-resource/$id/fees': typeof RecResourceIdFeesIndexRoute
+  '/rec-resource/$id/geospatial': typeof RecResourceIdGeospatialIndexRoute
+  '/rec-resource/$id/overview': typeof RecResourceIdOverviewIndexRoute
+  '/rec-resource/$id/reservation': typeof RecResourceIdReservationIndexRoute
   '/rec-resource/$id/fees/$feeId/edit': typeof RecResourceIdFeesFeeIdEditRoute
 }
 export interface FileRoutesByTo {
@@ -183,11 +183,11 @@ export interface FileRouteTypes {
     | '/rec-resource/$id/geospatial/edit'
     | '/rec-resource/$id/overview/edit'
     | '/rec-resource/$id/reservation/edit'
-    | '/rec-resource/$id/activities-features/'
-    | '/rec-resource/$id/fees/'
-    | '/rec-resource/$id/geospatial/'
-    | '/rec-resource/$id/overview/'
-    | '/rec-resource/$id/reservation/'
+    | '/rec-resource/$id/activities-features'
+    | '/rec-resource/$id/fees'
+    | '/rec-resource/$id/geospatial'
+    | '/rec-resource/$id/overview'
+    | '/rec-resource/$id/reservation'
     | '/rec-resource/$id/fees/$feeId/edit'
   fileRoutesByTo: FileRoutesByTo
   to:
@@ -272,35 +272,35 @@ declare module '@tanstack/react-router' {
     '/rec-resource/$id/reservation/': {
       id: '/rec-resource/$id/reservation/'
       path: '/reservation'
-      fullPath: '/rec-resource/$id/reservation/'
+      fullPath: '/rec-resource/$id/reservation'
       preLoaderRoute: typeof RecResourceIdReservationIndexRouteImport
       parentRoute: typeof RecResourceIdRoute
     }
     '/rec-resource/$id/overview/': {
       id: '/rec-resource/$id/overview/'
       path: '/overview'
-      fullPath: '/rec-resource/$id/overview/'
+      fullPath: '/rec-resource/$id/overview'
       preLoaderRoute: typeof RecResourceIdOverviewIndexRouteImport
       parentRoute: typeof RecResourceIdRoute
     }
     '/rec-resource/$id/geospatial/': {
       id: '/rec-resource/$id/geospatial/'
       path: '/geospatial'
-      fullPath: '/rec-resource/$id/geospatial/'
+      fullPath: '/rec-resource/$id/geospatial'
       preLoaderRoute: typeof RecResourceIdGeospatialIndexRouteImport
       parentRoute: typeof RecResourceIdRoute
     }
     '/rec-resource/$id/fees/': {
       id: '/rec-resource/$id/fees/'
       path: '/fees'
-      fullPath: '/rec-resource/$id/fees/'
+      fullPath: '/rec-resource/$id/fees'
       preLoaderRoute: typeof RecResourceIdFeesIndexRouteImport
       parentRoute: typeof RecResourceIdRoute
     }
     '/rec-resource/$id/activities-features/': {
       id: '/rec-resource/$id/activities-features/'
       path: '/activities-features'
-      fullPath: '/rec-resource/$id/activities-features/'
+      fullPath: '/rec-resource/$id/activities-features'
       preLoaderRoute: typeof RecResourceIdActivitiesFeaturesIndexRouteImport
       parentRoute: typeof RecResourceIdRoute
     }

--- a/admin/frontend/src/services/auth/AuthService.ts
+++ b/admin/frontend/src/services/auth/AuthService.ts
@@ -1,9 +1,16 @@
 import { AuthServiceEvent } from '@/services/auth/AuthService.constants';
 import { UserInfo } from '@/services/auth/AuthService.types';
+import {
+  addStatusNotification,
+  removeNotification,
+} from '@/store/notificationStore';
 import Keycloak from 'keycloak-js';
 
 export class AuthService {
   private static _instance: AuthService;
+  private static readonly SESSION_EXPIRY_NOTIFICATION_ID =
+    'session-expired-notification';
+  private reauthInProgress = false;
 
   public static getInstance(): AuthService {
     if (!AuthService._instance) {
@@ -34,6 +41,47 @@ export class AuthService {
     this.keycloak = new Keycloak(keycloakConfig);
   }
 
+  private async triggerLoginRedirect(): Promise<void> {
+    if (this.reauthInProgress) return;
+    this.reauthInProgress = true;
+    removeNotification(AuthService.SESSION_EXPIRY_NOTIFICATION_ID);
+
+    try {
+      await this.login();
+    } catch (err) {
+      this.reauthInProgress = false;
+      window.dispatchEvent(
+        new CustomEvent(AuthServiceEvent.AUTH_ERROR, { detail: err }),
+      );
+    }
+  }
+
+  private promptToStayLoggedIn(): void {
+    if (this.reauthInProgress) return;
+
+    addStatusNotification(
+      'Your session has expired because it reached the 10-hour limit.',
+      'warning',
+      AuthService.SESSION_EXPIRY_NOTIFICATION_ID,
+      false,
+      0,
+      [
+        {
+          label: 'Sign in again',
+          onClick: () => {
+            void this.triggerLoginRedirect();
+          },
+          variant: 'outline-primary',
+        },
+      ],
+      'Session expired',
+      () => {
+        // Called when user dismisses/closes the notification
+        void this.triggerLoginRedirect();
+      },
+    );
+  }
+
   async init(): Promise<boolean> {
     if (this.keycloak.didInitialize) {
       return this.keycloak.authenticated ?? false;
@@ -59,23 +107,14 @@ export class AuthService {
 
     // Refresh token when Keycloak reports it has expired (background refresh)
     this.keycloak.onTokenExpired = () => {
-      this.keycloak.updateToken(70).catch((err) => {
-        window.dispatchEvent(
-          new CustomEvent(AuthServiceEvent.AUTH_ERROR, { detail: err }),
-        );
+      this.keycloak.updateToken(70).catch(() => {
+        this.promptToStayLoggedIn();
       });
     };
 
     // When refresh fails (e.g. session expired), notify the app
     this.keycloak.onAuthRefreshError = () => {
-      window.dispatchEvent(
-        new CustomEvent(AuthServiceEvent.AUTH_ERROR, {
-          detail: {
-            error: 'session_expired',
-            error_description: 'Your session has expired. Please log in again.',
-          },
-        }),
-      );
+      this.promptToStayLoggedIn();
     };
 
     return this.keycloak.init({

--- a/admin/frontend/src/store/notificationStore.ts
+++ b/admin/frontend/src/store/notificationStore.ts
@@ -3,19 +3,29 @@
  * Provides global notification management as a collection of messages.
  */
 import { Store } from '@tanstack/store';
-import { AlertProps } from 'react-bootstrap';
+import { AlertProps, ButtonProps } from 'react-bootstrap';
+
+export interface NotificationAction {
+  label: string;
+  onClick: () => void;
+  variant?: ButtonProps['variant'];
+  dismissOnClick?: boolean;
+}
 
 export type NotificationMessage =
   | {
       id: string | number;
       type: 'status';
+      title?: string;
       message: string;
       variant: Extract<
         AlertProps['variant'],
         'success' | 'danger' | 'warning' | 'info'
       >;
+      actions?: NotificationAction[];
       autoDismiss?: boolean;
       timeout?: number;
+      onDismiss?: () => void;
     }
   | {
       id: string | number;
@@ -41,6 +51,9 @@ export const addStatusNotification = (
   id?: string | number,
   autoDismiss = true,
   timeout = 3000,
+  actions?: NotificationAction[],
+  title?: string,
+  onDismiss?: () => void,
 ): void => {
   notificationStore.setState((prev) =>
     id && prev.messages.some((msg) => msg.id === id)
@@ -51,10 +64,13 @@ export const addStatusNotification = (
             {
               id: getId(id),
               type: 'status',
+              title,
               message,
               variant,
+              actions,
               autoDismiss,
               timeout,
+              onDismiss,
             },
           ],
         },

--- a/admin/frontend/test/components/notification-bar/NotificationToast.test.tsx
+++ b/admin/frontend/test/components/notification-bar/NotificationToast.test.tsx
@@ -24,6 +24,23 @@ describe('NotificationToast', () => {
     autoDismiss: false,
   };
 
+  const statusWithActions: NotificationMessage = {
+    id: 4,
+    type: 'status',
+    title: 'Session expired',
+    message: 'Your session has expired because it reached the 10-hour limit.',
+    variant: 'warning',
+    autoDismiss: false,
+    timeout: 0,
+    actions: [
+      {
+        label: 'Sign in again',
+        onClick: vi.fn(),
+        variant: 'outline-secondary',
+      },
+    ],
+  };
+
   it('renders status notification with correct variant', () => {
     render(<NotificationToast msg={baseStatus} onClose={() => {}} />);
     expect(screen.getByText('Status message')).toBeInTheDocument();
@@ -72,5 +89,57 @@ describe('NotificationToast', () => {
     expect(screen.getByText('Custom message').closest('.alert')).toHaveClass(
       'alert-info',
     );
+  });
+
+  it('renders status actions when provided', () => {
+    render(<NotificationToast msg={statusWithActions} onClose={() => {}} />);
+    expect(
+      screen.getByRole('button', { name: 'Sign in again' }),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Session expired')).toBeInTheDocument();
+  });
+
+  it('runs action callback and closes by default when action is clicked', () => {
+    const onClose = vi.fn();
+    const actionClick = vi.fn();
+    const messageWithAction: NotificationMessage = {
+      ...statusWithActions,
+      actions: [
+        {
+          label: 'Sign in again',
+          onClick: actionClick,
+          variant: 'primary',
+        },
+      ],
+    };
+
+    render(<NotificationToast msg={messageWithAction} onClose={onClose} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Sign in again' }));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(actionClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not close when dismissOnClick is false', () => {
+    const onClose = vi.fn();
+    const actionClick = vi.fn();
+    const messageWithPersistentAction: NotificationMessage = {
+      ...statusWithActions,
+      actions: [
+        {
+          label: 'Retry',
+          onClick: actionClick,
+          dismissOnClick: false,
+        },
+      ],
+    };
+
+    render(
+      <NotificationToast msg={messageWithPersistentAction} onClose={onClose} />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
+
+    expect(onClose).not.toHaveBeenCalled();
+    expect(actionClick).toHaveBeenCalledTimes(1);
   });
 });

--- a/admin/frontend/test/services/auth/AuthService.test.ts
+++ b/admin/frontend/test/services/auth/AuthService.test.ts
@@ -1,5 +1,6 @@
 import { AuthService, UserInfo } from '@/services/auth';
 import { AuthServiceEvent } from '@/services/auth/AuthService.constants';
+import * as notificationStoreModule from '@/store/notificationStore';
 import Keycloak from 'keycloak-js';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -9,6 +10,8 @@ describe('AuthService', () => {
   let authService: AuthService;
   let mockKeycloak: any;
   let dispatchEventSpy: ReturnType<typeof vi.spyOn>;
+  let addStatusNotificationSpy: ReturnType<typeof vi.spyOn>;
+  let removeNotificationSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
     vi.stubEnv('VITE_KEYCLOAK_AUTH_SERVER_URL', 'http://localhost:8080');
@@ -38,10 +41,19 @@ describe('AuthService', () => {
     (Keycloak as any).mockImplementation(function () {
       return mockKeycloak;
     });
+    notificationStoreModule.notificationStore.setState({ messages: [] });
     dispatchEventSpy = vi.spyOn(
       window,
       'dispatchEvent',
     ) as unknown as ReturnType<typeof vi.spyOn>;
+    addStatusNotificationSpy = vi.spyOn(
+      notificationStoreModule,
+      'addStatusNotification',
+    );
+    removeNotificationSpy = vi.spyOn(
+      notificationStoreModule,
+      'removeNotification',
+    );
   });
 
   afterEach(() => {
@@ -144,7 +156,7 @@ describe('AuthService', () => {
       await expect(authService.init()).rejects.toThrow('fail');
     });
 
-    it('onTokenExpired calls updateToken(70) and dispatches AUTH_ERROR on reject', async () => {
+    it('onTokenExpired calls updateToken(70) and shows session-expiry notification on reject', async () => {
       await authService.init();
       mockKeycloak.updateToken.mockRejectedValueOnce(
         new Error('refresh failed'),
@@ -153,29 +165,110 @@ describe('AuthService', () => {
       expect(mockKeycloak.updateToken).toHaveBeenCalledWith(70);
       await vi.waitFor(
         () => {
-          expect(dispatchEventSpy).toHaveBeenCalledWith(
-            expect.objectContaining({
-              type: AuthServiceEvent.AUTH_ERROR,
-              detail: expect.any(Error),
-            }),
-          );
+          expect(addStatusNotificationSpy).toHaveBeenCalledOnce();
         },
         { timeout: 500 },
       );
+      expect(addStatusNotificationSpy).toHaveBeenCalledWith(
+        'Your session has expired because it reached the 10-hour limit.',
+        'warning',
+        'session-expired-notification',
+        false,
+        0,
+        expect.arrayContaining([
+          expect.objectContaining({ label: 'Sign in again' }),
+        ]),
+        'Session expired',
+        expect.any(Function),
+      );
+      expect(mockKeycloak.login).not.toHaveBeenCalled();
+      expect(dispatchEventSpy).not.toHaveBeenCalledWith(
+        expect.objectContaining({ type: AuthServiceEvent.AUTH_ERROR }),
+      );
     });
 
-    it('onAuthRefreshError dispatches AUTH_ERROR with session-expired message', async () => {
+    it('onAuthRefreshError shows session-expiry notification', async () => {
       await authService.init();
       mockKeycloak.onAuthRefreshError!();
-      expect(dispatchEventSpy).toHaveBeenCalledWith(
-        expect.objectContaining({
-          type: AuthServiceEvent.AUTH_ERROR,
-          detail: expect.objectContaining({
-            error: 'session_expired',
-            error_description: 'Your session has expired. Please log in again.',
-          }),
-        }),
+      expect(addStatusNotificationSpy).toHaveBeenCalledOnce();
+      expect(addStatusNotificationSpy).toHaveBeenCalledWith(
+        'Your session has expired because it reached the 10-hour limit.',
+        'warning',
+        'session-expired-notification',
+        false,
+        0,
+        expect.arrayContaining([
+          expect.objectContaining({ label: 'Sign in again' }),
+        ]),
+        'Session expired',
+        expect.any(Function),
       );
+      expect(mockKeycloak.login).not.toHaveBeenCalled();
+      expect(dispatchEventSpy).not.toHaveBeenCalledWith(
+        expect.objectContaining({ type: AuthServiceEvent.AUTH_ERROR }),
+      );
+    });
+
+    it('clicking Sign in again action triggers login redirect and clears notification', async () => {
+      await authService.init();
+      mockKeycloak.onAuthRefreshError!();
+
+      const actions = addStatusNotificationSpy.mock.calls[0]?.[5];
+      expect(Array.isArray(actions)).toBe(true);
+
+      const signInAgainAction = (actions as any[]).find(
+        (action) => action.label === 'Sign in again',
+      );
+      expect(signInAgainAction).toBeDefined();
+
+      signInAgainAction.onClick();
+
+      await vi.waitFor(() => {
+        expect(mockKeycloak.login).toHaveBeenCalledTimes(1);
+      });
+      expect(removeNotificationSpy).toHaveBeenCalledWith(
+        'session-expired-notification',
+      );
+    });
+
+    it('dispatches AUTH_ERROR when login redirect fails after refresh error', async () => {
+      await authService.init();
+      mockKeycloak.login.mockRejectedValueOnce(
+        new Error('login redirect failed'),
+      );
+
+      mockKeycloak.onAuthRefreshError!();
+      const actions = addStatusNotificationSpy.mock.calls[0]?.[5] as any[];
+      const signInAgainAction = actions.find(
+        (action) => action.label === 'Sign in again',
+      );
+      signInAgainAction.onClick();
+
+      await vi.waitFor(() => {
+        expect(dispatchEventSpy).toHaveBeenCalledWith(
+          expect.objectContaining({
+            type: AuthServiceEvent.AUTH_ERROR,
+            detail: expect.any(Error),
+          }),
+        );
+      });
+    });
+
+    it('keeps only one session-expiry notification when both expiry handlers fire', async () => {
+      await authService.init();
+
+      mockKeycloak.updateToken.mockRejectedValueOnce(
+        new Error('refresh failed'),
+      );
+      mockKeycloak.onTokenExpired!();
+      mockKeycloak.onAuthRefreshError!();
+
+      expect(
+        notificationStoreModule.notificationStore.state.messages,
+      ).toHaveLength(1);
+      expect(
+        notificationStoreModule.notificationStore.state.messages[0]?.id,
+      ).toBe('session-expired-notification');
     });
 
     it.each([

--- a/admin/frontend/test/store/notificationStore.test.ts
+++ b/admin/frontend/test/store/notificationStore.test.ts
@@ -33,6 +33,40 @@ describe('notificationStore', () => {
     ]);
   });
 
+  it('adds a status notification with actions', () => {
+    const actionHandler = vi.fn();
+    const actions = [
+      {
+        label: 'Retry',
+        onClick: actionHandler,
+        variant: 'primary' as const,
+      },
+    ];
+
+    addStatusNotification(
+      'Needs action',
+      'warning',
+      'id-actions',
+      false,
+      0,
+      actions,
+      'Action needed',
+    );
+
+    expect(notificationStore.state.messages).toEqual([
+      {
+        id: 'id-actions',
+        type: 'status',
+        title: 'Action needed',
+        message: 'Needs action',
+        variant: 'warning',
+        actions,
+        autoDismiss: false,
+        timeout: 0,
+      },
+    ]);
+  });
+
   it('adds a spinner notification', () => {
     addSpinnerNotification('Loading', 'spin1');
     expect(notificationStore.state.messages).toEqual([


### PR DESCRIPTION
**Card:** https://bcparksdigital.atlassian.net/browse/ORCA-746

**Changes:**
- Updated the Auth service and added triggerLoginRedirect and promptToStayLoggedIn.
- Updated the notification toast to include a button and its click handler.
- Updated actions in the notification store.

**To Test:**
- To manually test the notification bar, expire the client token (Keycloak token).
- Alternatively, after 10 hours of active screen time, the prompt to log in again will appear.