### PR TITLE
chore: relax TLS restrictions for legacy compatibility

### DIFF
--- a/backend-el/Dockerfile
+++ b/backend-el/Dockerfile
@@ -12,7 +12,12 @@ ARG DEPENDENCY=/app/target/
 COPY --from=build ${DEPENDENCY}/*.jar /app/app.jar
 COPY run_app.sh .
 RUN apt-get update && apt-get install -y --no-install-recommends
+
+# RELAX SECURITY: Enable legacy TLS versions and algorithms (e.g., TLS 1.0/1.1, SHA1, DH keys).
+# This replaces the entire multi-line 'jdk.tls.disabledAlgorithms' block with a minimal
+# restriction (SSLv3 only) to allow connections to legacy servers/databases.
 RUN sed -i '/jdk.tls.disabledAlgorithms=/,/[^\\]$/c jdk.tls.disabledAlgorithms=SSLv3' "$JAVA_HOME/conf/security/java.security"
+
 RUN chmod -R 777 /opt && chmod -R 777 /etc/ca-certificates && chmod -R 777 "${JAVA_HOME}"/lib/security
 RUN useradd -ms /bin/bash appuser
 USER appuser


### PR DESCRIPTION
**Card:** https://bcparksdigital.atlassian.net/browse/ORCA-814
**Problem**
The default JVM `jdk.tls.disabledAlgorithms` policy blocks the legacy TLS versions required by the FTA Oracle DB, resulting in:
```
ORA-17967: SSL Handshake failure: (handshake_failure) Received fatal alert: handshake_failure
javax.net.ssl.SSLHandshakeException: Received fatal alert: handshake_failure
```

**Changes**
- Replaced the multi-line `jdk.tls.disabledAlgorithms` block in `java.security` with a minimal restriction (`SSLv3` only)
- Enables support for legacy protocols (TLS 1.0/1.1) and SHA1 signatures
- Required for connecting to FTA oracle DB


**Security Note**
This intentionally weakens JVM TLS defaults on the client side. The tradeoff is accepted because:
- FTA Oracle DB is a legacy system that cannot be upgraded
- We are actively working to cut off the dependency on FTA entirely