### PR TITLE
feat(cronjob): add prov_forest_use and org_unit extraction

### DIFF
--- a/backend-el/Dockerfile
+++ b/backend-el/Dockerfile
@@ -12,6 +12,7 @@ ARG DEPENDENCY=/app/target/
 COPY --from=build ${DEPENDENCY}/*.jar /app/app.jar
 COPY run_app.sh .
 RUN apt-get update && apt-get install -y --no-install-recommends
+RUN sed -i '/jdk.tls.disabledAlgorithms=/,/[^\\]$/c jdk.tls.disabledAlgorithms=SSLv3' "$JAVA_HOME/conf/security/java.security"
 RUN chmod -R 777 /opt && chmod -R 777 /etc/ca-certificates && chmod -R 777 "${JAVA_HOME}"/lib/security
 RUN useradd -ms /bin/bash appuser
 USER appuser

--- a/backend-el/src/main/java/ca/bc/gov/nrs/environment/fta/el/entities/OrgUnit.java
+++ b/backend-el/src/main/java/ca/bc/gov/nrs/environment/fta/el/entities/OrgUnit.java
@@ -1,0 +1,182 @@
+package ca.bc.gov.nrs.environment.fta.el.entities;
+
+import java.time.LocalDate;
+
+import org.springframework.data.annotation.Immutable;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "ORG_UNIT", schema = "THE")
+@Immutable
+public class OrgUnit {
+
+  @Id
+  @Column(name = "ORG_UNIT_NO", nullable = false, precision = 10)
+  private Long orgUnitNo;
+
+  @Column(name = "ORG_UNIT_CODE", nullable = false, length = 6)
+  private String orgUnitCode;
+
+  @Column(name = "ORG_UNIT_NAME", nullable = false, length = 100)
+  private String orgUnitName;
+
+  @Column(name = "LOCATION_CODE", nullable = false, length = 3)
+  private String locationCode;
+
+  @Column(name = "AREA_CODE", nullable = false, length = 3)
+  private String areaCode;
+
+  @Column(name = "TELEPHONE_NO", nullable = false, length = 7)
+  private String telephoneNo;
+
+  @Column(name = "ORG_LEVEL_CODE", nullable = false, length = 1)
+  private String orgLevelCode;
+
+  @Column(name = "OFFICE_NAME_CODE", nullable = false, length = 2)
+  private String officeNameCode;
+
+  @Column(name = "ROLLUP_REGION_NO", nullable = false, precision = 10)
+  private Long rollupRegionNo;
+
+  @Column(name = "ROLLUP_REGION_CODE", nullable = false, length = 6)
+  private String rollupRegionCode;
+
+  @Column(name = "ROLLUP_DIST_NO", nullable = false, precision = 10)
+  private Long rollupDistNo;
+
+  @Column(name = "ROLLUP_DIST_CODE", nullable = false, length = 6)
+  private String rollupDistCode;
+
+  @Column(name = "EFFECTIVE_DATE", nullable = false)
+  private LocalDate effectiveDate;
+
+  @Column(name = "EXPIRY_DATE", nullable = false)
+  private LocalDate expiryDate;
+
+  @Column(name = "UPDATE_TIMESTAMP")
+  private LocalDate updateTimestamp;
+
+  public Long getOrgUnitNo() {
+    return orgUnitNo;
+  }
+
+  public void setOrgUnitNo(Long orgUnitNo) {
+    this.orgUnitNo = orgUnitNo;
+  }
+
+  public String getOrgUnitCode() {
+    return orgUnitCode;
+  }
+
+  public void setOrgUnitCode(String orgUnitCode) {
+    this.orgUnitCode = orgUnitCode;
+  }
+
+  public String getOrgUnitName() {
+    return orgUnitName;
+  }
+
+  public void setOrgUnitName(String orgUnitName) {
+    this.orgUnitName = orgUnitName;
+  }
+
+  public String getLocationCode() {
+    return locationCode;
+  }
+
+  public void setLocationCode(String locationCode) {
+    this.locationCode = locationCode;
+  }
+
+  public String getAreaCode() {
+    return areaCode;
+  }
+
+  public void setAreaCode(String areaCode) {
+    this.areaCode = areaCode;
+  }
+
+  public String getTelephoneNo() {
+    return telephoneNo;
+  }
+
+  public void setTelephoneNo(String telephoneNo) {
+    this.telephoneNo = telephoneNo;
+  }
+
+  public String getOrgLevelCode() {
+    return orgLevelCode;
+  }
+
+  public void setOrgLevelCode(String orgLevelCode) {
+    this.orgLevelCode = orgLevelCode;
+  }
+
+  public String getOfficeNameCode() {
+    return officeNameCode;
+  }
+
+  public void setOfficeNameCode(String officeNameCode) {
+    this.officeNameCode = officeNameCode;
+  }
+
+  public Long getRollupRegionNo() {
+    return rollupRegionNo;
+  }
+
+  public void setRollupRegionNo(Long rollupRegionNo) {
+    this.rollupRegionNo = rollupRegionNo;
+  }
+
+  public String getRollupRegionCode() {
+    return rollupRegionCode;
+  }
+
+  public void setRollupRegionCode(String rollupRegionCode) {
+    this.rollupRegionCode = rollupRegionCode;
+  }
+
+  public Long getRollupDistNo() {
+    return rollupDistNo;
+  }
+
+  public void setRollupDistNo(Long rollupDistNo) {
+    this.rollupDistNo = rollupDistNo;
+  }
+
+  public String getRollupDistCode() {
+    return rollupDistCode;
+  }
+
+  public void setRollupDistCode(String rollupDistCode) {
+    this.rollupDistCode = rollupDistCode;
+  }
+
+  public LocalDate getEffectiveDate() {
+    return effectiveDate;
+  }
+
+  public void setEffectiveDate(LocalDate effectiveDate) {
+    this.effectiveDate = effectiveDate;
+  }
+
+  public LocalDate getExpiryDate() {
+    return expiryDate;
+  }
+
+  public void setExpiryDate(LocalDate expiryDate) {
+    this.expiryDate = expiryDate;
+  }
+
+  public LocalDate getUpdateTimestamp() {
+    return updateTimestamp;
+  }
+
+  public void setUpdateTimestamp(LocalDate updateTimestamp) {
+    this.updateTimestamp = updateTimestamp;
+  }
+}

--- a/backend-el/src/main/java/ca/bc/gov/nrs/environment/fta/el/entities/ProvForestUse.java
+++ b/backend-el/src/main/java/ca/bc/gov/nrs/environment/fta/el/entities/ProvForestUse.java
@@ -1,0 +1,193 @@
+package ca.bc.gov.nrs.environment.fta.el.entities;
+
+import java.time.LocalDateTime;
+
+import org.springframework.data.annotation.Immutable;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "PROV_FOREST_USE", schema = "THE")
+@Immutable
+public class ProvForestUse {
+
+  @Id
+  @Column(name = "FOREST_FILE_ID", nullable = false, length = 10)
+  private String forestFileId;
+
+  @Column(name = "FILE_STATUS_ST", length = 3)
+  private String fileStatusCode;
+
+  @Column(name = "FILE_STATUS_DATE")
+  private LocalDateTime fileStatusDate;
+
+  @Column(name = "FILE_TYPE_CODE", length = 10)
+  private String fileTypeCode;
+
+  @Column(name = "FOREST_REGION")
+  private Integer forestRegion;
+
+  @Column(name = "BCTS_ORG_UNIT")
+  private Long bctsOrgUnit;
+
+  @Column(name = "SB_FUNDED_IND", nullable = false, length = 1)
+  private String sbFundedInd;
+
+  @Column(name = "DISTRICT_ADMIN_ZONE", length = 4)
+  private String districtAdminZone;
+
+  @Column(name = "MGMT_UNIT_TYPE", length = 1)
+  private String mgmtUnitType;
+
+  @Column(name = "MGMT_UNIT_ID")
+  private Integer mgmtUnitId;
+
+  @Column(name = "REVISION_COUNT", nullable = false)
+  private Integer revisionCount;
+
+  @Column(name = "ENTRY_USERID", nullable = false, length = 30)
+  private String entryUserid;
+
+  @Column(name = "ENTRY_TIMESTAMP", nullable = false)
+  private LocalDateTime entryTimestamp;
+
+  @Column(name = "UPDATE_USERID", nullable = false, length = 30)
+  private String updateUserid;
+
+  @Column(name = "UPDATE_TIMESTAMP", nullable = false)
+  private LocalDateTime updateTimestamp;
+
+  @Column(name = "FOREST_TENURE_GUID", nullable = false)
+  private byte[] forestTenureGuid;
+
+  public String getForestFileId() {
+    return forestFileId;
+  }
+
+  public void setForestFileId(String forestFileId) {
+    this.forestFileId = forestFileId;
+  }
+
+  public String getFileStatusCode() {
+    return fileStatusCode;
+  }
+
+  public void setFileStatusCode(String fileStatusCode) {
+    this.fileStatusCode = fileStatusCode;
+  }
+
+  public LocalDateTime getFileStatusDate() {
+    return fileStatusDate;
+  }
+
+  public void setFileStatusDate(LocalDateTime fileStatusDate) {
+    this.fileStatusDate = fileStatusDate;
+  }
+
+  public String getFileTypeCode() {
+    return fileTypeCode;
+  }
+
+  public void setFileTypeCode(String fileTypeCode) {
+    this.fileTypeCode = fileTypeCode;
+  }
+
+  public Integer getForestRegion() {
+    return forestRegion;
+  }
+
+  public void setForestRegion(Integer forestRegion) {
+    this.forestRegion = forestRegion;
+  }
+
+  public Long getBctsOrgUnit() {
+    return bctsOrgUnit;
+  }
+
+  public void setBctsOrgUnit(Long bctsOrgUnit) {
+    this.bctsOrgUnit = bctsOrgUnit;
+  }
+
+  public String getSbFundedInd() {
+    return sbFundedInd;
+  }
+
+  public void setSbFundedInd(String sbFundedInd) {
+    this.sbFundedInd = sbFundedInd;
+  }
+
+  public String getDistrictAdminZone() {
+    return districtAdminZone;
+  }
+
+  public void setDistrictAdminZone(String districtAdminZone) {
+    this.districtAdminZone = districtAdminZone;
+  }
+
+  public String getMgmtUnitType() {
+    return mgmtUnitType;
+  }
+
+  public void setMgmtUnitType(String mgmtUnitType) {
+    this.mgmtUnitType = mgmtUnitType;
+  }
+
+  public Integer getMgmtUnitId() {
+    return mgmtUnitId;
+  }
+
+  public void setMgmtUnitId(Integer mgmtUnitId) {
+    this.mgmtUnitId = mgmtUnitId;
+  }
+
+  public Integer getRevisionCount() {
+    return revisionCount;
+  }
+
+  public void setRevisionCount(Integer revisionCount) {
+    this.revisionCount = revisionCount;
+  }
+
+  public String getEntryUserid() {
+    return entryUserid;
+  }
+
+  public void setEntryUserid(String entryUserid) {
+    this.entryUserid = entryUserid;
+  }
+
+  public LocalDateTime getEntryTimestamp() {
+    return entryTimestamp;
+  }
+
+  public void setEntryTimestamp(LocalDateTime entryTimestamp) {
+    this.entryTimestamp = entryTimestamp;
+  }
+
+  public String getUpdateUserid() {
+    return updateUserid;
+  }
+
+  public void setUpdateUserid(String updateUserid) {
+    this.updateUserid = updateUserid;
+  }
+
+  public LocalDateTime getUpdateTimestamp() {
+    return updateTimestamp;
+  }
+
+  public void setUpdateTimestamp(LocalDateTime updateTimestamp) {
+    this.updateTimestamp = updateTimestamp;
+  }
+
+  public byte[] getForestTenureGuid() {
+    return forestTenureGuid;
+  }
+
+  public void setForestTenureGuid(byte[] forestTenureGuid) {
+    this.forestTenureGuid = forestTenureGuid;
+  }
+}

--- a/backend-el/src/main/java/ca/bc/gov/nrs/environment/fta/el/repositories/OrgUnitRepository.java
+++ b/backend-el/src/main/java/ca/bc/gov/nrs/environment/fta/el/repositories/OrgUnitRepository.java
@@ -1,0 +1,7 @@
+package ca.bc.gov.nrs.environment.fta.el.repositories;
+
+import ca.bc.gov.nrs.environment.fta.el.entities.OrgUnit;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrgUnitRepository extends JpaRepository<OrgUnit, Long> {
+}

--- a/backend-el/src/main/java/ca/bc/gov/nrs/environment/fta/el/repositories/ProvForestUseRepository.java
+++ b/backend-el/src/main/java/ca/bc/gov/nrs/environment/fta/el/repositories/ProvForestUseRepository.java
@@ -1,0 +1,11 @@
+package ca.bc.gov.nrs.environment.fta.el.repositories;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import ca.bc.gov.nrs.environment.fta.el.entities.ProvForestUse;
+
+public interface ProvForestUseRepository extends JpaRepository<ProvForestUse, String> {
+  List<ProvForestUse> findByFileTypeCode(String fileTypeCode);
+}

--- a/backend-el/src/main/java/ca/bc/gov/nrs/environment/fta/el/services/ApplicationService.java
+++ b/backend-el/src/main/java/ca/bc/gov/nrs/environment/fta/el/services/ApplicationService.java
@@ -52,6 +52,8 @@ public class ApplicationService {
   private final RecreationObjectiveRepository recreationObjectiveRepository;
   private final RecreationOccupancyCodeRepository recreationOccupancyCodeRepository;
   private final RecreationPlanRepository recreationPlanRepository;
+  private final ProvForestUseRepository provForestUseRepository;
+  private final OrgUnitRepository orgUnitRepository;
   private final RecreationProjectRepository recreationProjectRepository;
   private final RecreationRemedRepairCodeRepository recreationRemedRepairCodeRepository;
   private final RecreationRiskEvaluationRepository recreationRiskEvaluationRepository;
@@ -101,6 +103,8 @@ public class ApplicationService {
                             RecreationObjectiveRepository recreationObjectiveRepository,
                             RecreationOccupancyCodeRepository recreationOccupancyCodeRepository,
                             RecreationPlanRepository recreationPlanRepository,
+                            ProvForestUseRepository provForestUseRepository,
+                            OrgUnitRepository orgUnitRepository,
                             RecreationProjectRepository recreationProjectRepository,
                             RecreationRemedRepairCodeRepository recreationRemedRepairCodeRepository,
                             RecreationRiskEvaluationRepository recreationRiskEvaluationRepository,
@@ -148,6 +152,8 @@ public class ApplicationService {
     this.recreationObjectiveRepository = recreationObjectiveRepository;
     this.recreationOccupancyCodeRepository = recreationOccupancyCodeRepository;
     this.recreationPlanRepository = recreationPlanRepository;
+    this.provForestUseRepository = provForestUseRepository;
+    this.orgUnitRepository = orgUnitRepository;
     this.recreationProjectRepository = recreationProjectRepository;
     this.recreationRemedRepairCodeRepository = recreationRemedRepairCodeRepository;
     this.recreationRiskEvaluationRepository = recreationRiskEvaluationRepository;
@@ -196,6 +202,8 @@ public class ApplicationService {
     extractAndUploadRecreationObjective();
     extractAndUploadRecreationOccupancyCode();
     extractAndUploadRecreationPlan();
+    extractAndUploadProvForestUse();
+    extractAndUploadOrgUnit();
     extractAndUploadRecreationProject();
     extractAndUploadRecreationRemedRepairCode();
     extractAndUploadRecreationRiskEvaluation();
@@ -592,6 +600,79 @@ public class ApplicationService {
       for (var item : results) {
         printer.printRecord(item.getForestFileId(), item.getRecProjectSkey(),
           item.getPlanTypeCode(), item.getRemarks());
+      }
+      printer.flush();
+      this.s3UploaderService.uploadFileToS3(entityMetadata.filePath(), entityMetadata.fileName());
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+  }
+
+private void extractAndUploadProvForestUse() {
+  var results = this.provForestUseRepository.findByFileTypeCode("F05");
+  var entityMetadata = getEntityMetadata(ProvForestUse.class);
+
+  try (
+    var out = new FileWriter(entityMetadata.filePath());
+    var printer = new CSVPrinter(out, entityMetadata.csvFormatBuilder().build());
+  ) {
+    for (var item : results) {
+      printer.printRecord(
+        item.getForestFileId(),
+        item.getFileStatusCode(),
+        item.getFileStatusDate(),
+        item.getFileTypeCode(),
+        item.getForestRegion(),
+        item.getBctsOrgUnit(),
+        item.getSbFundedInd(),
+        item.getDistrictAdminZone(),
+        item.getMgmtUnitType(),
+        item.getMgmtUnitId(),
+        item.getRevisionCount(),
+        item.getEntryUserid(),
+        item.getEntryTimestamp(),
+        item.getUpdateUserid(),
+        item.getUpdateTimestamp(),
+        item.getForestTenureGuid()
+      );
+    }
+
+    printer.flush();
+    this.s3UploaderService.uploadFileToS3(
+      entityMetadata.filePath(),
+      entityMetadata.fileName()
+    );
+
+  } catch (IOException e) {
+    e.printStackTrace();
+  }
+}
+
+  private void extractAndUploadOrgUnit() {
+    var results = this.orgUnitRepository.findAll();
+    var entityMetadata = getEntityMetadata(OrgUnit.class);
+    try (
+      var out = new FileWriter(entityMetadata.filePath());
+      var printer = new CSVPrinter(out, entityMetadata.csvFormatBuilder().build());
+    ) {
+      for (var item : results) {
+        printer.printRecord(
+          item.getOrgUnitNo(),
+          item.getOrgUnitCode(),
+          item.getOrgUnitName(),
+          item.getLocationCode(),
+          item.getAreaCode(),
+          item.getTelephoneNo(),
+          item.getOrgLevelCode(),
+          item.getOfficeNameCode(),
+          item.getRollupRegionNo(),
+          item.getRollupRegionCode(),
+          item.getRollupDistNo(),
+          item.getRollupDistCode(),
+          item.getEffectiveDate(),
+          item.getExpiryDate(),
+          item.getUpdateTimestamp()
+        );
       }
       printer.flush();
       this.s3UploaderService.uploadFileToS3(entityMetadata.filePath(), entityMetadata.fileName());


### PR DESCRIPTION
Card: https://bcparksdigital.atlassian.net/browse/ORCA-856
**Changes:**
- Added new entities:
    - ProvForestUse mapped to THE.PROV_FOREST_USE
    - OrgUnit mapped to THE.ORG_UNIT
- Created repositories:
    - ProvForestUseRepository with support for filtering by fileTypeCode
    - OrgUnitRepository for org unit reference data extraction
- Integrated both datasets into ApplicationService CSV export flow
- Updated extractAndUploadCSVToS3() to include:
    - extractAndUploadProvForestUse()
    - extractAndUploadOrgUnit()
- Ensured both datasets are exported through the same S3 CSV pipeline as existing tables

**Notes:**
prov_forest_use is filtered using fileTypeCode = "F05" for cron job execution