### PR TITLE
fix: Update BC Parks API response parsing

### DIFF
--- a/public/frontend/src/components/recreation-suggestion-form/hooks/useSearchCitiesApi.test.tsx
+++ b/public/frontend/src/components/recreation-suggestion-form/hooks/useSearchCitiesApi.test.tsx
@@ -6,24 +6,22 @@ import { TestQueryClientProvider } from '@/test-utils';
 const mockCitiesResponse = {
   data: [
     {
-      id: '1',
-      attributes: {
-        cityName: 'Vancouver',
-        rank: 1,
-        provinceCode: 'BC',
-        latitude: 49.2827,
-        longitude: -123.1207,
-      },
+      id: 1,
+      documentId: 'abc001',
+      cityName: 'Vancouver',
+      rank: 1,
+      provinceCode: 'BC',
+      latitude: 49.2827,
+      longitude: -123.1207,
     },
     {
-      id: '2',
-      attributes: {
-        cityName: 'Victoria',
-        rank: 2,
-        provinceCode: 'BC',
-        latitude: 48.4284,
-        longitude: -123.3656,
-      },
+      id: 2,
+      documentId: 'abc002',
+      cityName: 'Victoria',
+      rank: 2,
+      provinceCode: 'BC',
+      latitude: 48.4284,
+      longitude: -123.3656,
     },
   ],
 };

--- a/public/frontend/src/components/recreation-suggestion-form/hooks/useSearchCitiesApi.ts
+++ b/public/frontend/src/components/recreation-suggestion-form/hooks/useSearchCitiesApi.ts
@@ -25,7 +25,7 @@ const fetchCities = async (): Promise<City[]> => {
   const json = await response.json();
   const cities = json.data.map(
     (city: RawCity): City => ({
-      id: city.id,
+      id: Number(city.id),
       name: city.cityName,
       latitude: city.latitude,
       longitude: city.longitude,

--- a/public/frontend/src/components/recreation-suggestion-form/hooks/useSearchCitiesApi.ts
+++ b/public/frontend/src/components/recreation-suggestion-form/hooks/useSearchCitiesApi.ts
@@ -7,14 +7,13 @@ const SEARCH_CITIES_API_PARAMS =
   '?pagination[page]=1&pagination[pageSize]=1000&filters[rank][$ne]=5&sort=cityName:asc';
 
 interface RawCity {
-  id: string;
-  attributes: {
-    cityName: string;
-    rank: number;
-    provinceCode: string;
-    latitude: number;
-    longitude: number;
-  };
+  id: number;
+  documentId: string;
+  cityName: string;
+  rank: number;
+  provinceCode: string;
+  latitude: number;
+  longitude: number;
 }
 
 const fetchCities = async (): Promise<City[]> => {
@@ -26,11 +25,11 @@ const fetchCities = async (): Promise<City[]> => {
   const json = await response.json();
   const cities = json.data.map(
     (city: RawCity): City => ({
-      id: Number(city.id),
-      name: city.attributes.cityName,
-      latitude: city.attributes.latitude,
-      longitude: city.attributes.longitude,
-      rank: city.attributes.rank,
+      id: city.id,
+      name: city.cityName,
+      latitude: city.latitude,
+      longitude: city.longitude,
+      rank: city.rank,
       option_type: OPTION_TYPE.CITY,
     }),
   );


### PR DESCRIPTION
The BC Parks API was updated from Strapi 4 to Strapi 5. 
As part of this change, the objects returned by the API are no longer wrapped in an `attributes` object. 
Our code was not updated to handle this new format and we were failing to parse the response.

