### PR TITLE
chore: Update cash text under 'know before you go'

### DIFF
--- a/public/frontend/src/components/rec-resource/section/KnowBeforeYouGo.test.tsx
+++ b/public/frontend/src/components/rec-resource/section/KnowBeforeYouGo.test.tsx
@@ -35,6 +35,11 @@ describe('KnowBeforeYouGo', () => {
     expect(
       screen.getByText(/Most sites operate on a cash-only basis/i),
     ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /some site operators may be able to accept card payments/i,
+      ),
+    ).toBeInTheDocument();
   });
 
   it('renders FCFS content when isReservable = false and isCampingAvailable = true', () => {
@@ -69,9 +74,9 @@ describe('KnowBeforeYouGo', () => {
       />,
     );
 
-    // Cash only section appears
+    // Cash section appears
     expect(screen.getByAltText(/Cash Only icon/i)).toBeInTheDocument();
-    expect(screen.getByText(/Cash Only/i)).toBeInTheDocument();
+    expect(screen.getByText(/Bring cash/i)).toBeInTheDocument();
   });
 
   it('always renders safety and visit responsibly sections', () => {

--- a/public/frontend/src/components/rec-resource/section/KnowBeforeYouGo.tsx
+++ b/public/frontend/src/components/rec-resource/section/KnowBeforeYouGo.tsx
@@ -39,10 +39,11 @@ const KnowBeforeYouGo = forwardRef<HTMLElement, KnowBeforeYouGoProps>(
                   <p className="small-tittle">Bring cash</p>
                   <p>
                     Most sites operate on a cash-only basis, and fees are often
-                    collected directly by site operators unless you have paid
-                    through an online reservation ahead of time. Please come
-                    prepared with enough cash to cover your stay and any
-                    additional services.
+                    collected directly by site operators unless you have paid in
+                    advance through an online reservation system. While some
+                    site operators may be able to accept card payments on site,
+                    this is not guaranteed. Please arrive prepared with enough
+                    cash to cover your stay and any additional services.
                   </p>
                 </div>
               </div>
@@ -67,12 +68,14 @@ const KnowBeforeYouGo = forwardRef<HTMLElement, KnowBeforeYouGoProps>(
                   <img src={cash} alt="Cash Only icon" height={40} width={40} />
                 </div>
                 <div className="col-sm">
-                  <p className="small-tittle">Cash only</p>
+                  <p className="small-tittle">Bring cash</p>
                   <p>
                     Most sites operate on a cash-only basis, and fees are often
-                    collected directly by site operators. Please come prepared
-                    with enough cash to cover your stay and any additional
-                    services.
+                    collected directly by site operators unless you have paid in
+                    advance through an online reservation system. While some
+                    site operators may be able to accept card payments on site,
+                    this is not guaranteed. Please arrive prepared with enough
+                    cash to cover your stay and any additional services.
                   </p>
                 </div>
               </div>


### PR DESCRIPTION
Update "bring cash" text under "know before you go" section to match wireframe/ticket. 

Note:
- The previous text was slightly different for reservable and non-reservable sites. Now, both show the same text. 
- The wireframe shows "Cash only" as the subtitle, but the ticket implies that we should use "Bring Cash". I went for "Bring cash" since it makes more sense for the description and intent of the message. 