### PR TITLE
feat: display archived status correctly in search table

### DIFF
--- a/admin/backend/src/recreation-resources/dtos/admin-search-response.dto.ts
+++ b/admin/backend/src/recreation-resources/dtos/admin-search-response.dto.ts
@@ -56,6 +56,14 @@ export class AdminSearchResultRowDto {
   status_code: number;
 
   @ApiProperty({
+    description: 'Resource archive status code',
+    example: 'AR',
+    required: false,
+    nullable: true,
+  })
+  rec_status_code?: string | null;
+
+  @ApiProperty({
     description: 'Access types associated with the resource',
     type: [String],
     example: ['Road', '4WD'],

--- a/admin/backend/src/recreation-resources/recreation-resource.select.ts
+++ b/admin/backend/src/recreation-resources/recreation-resource.select.ts
@@ -4,6 +4,7 @@ const baseRecreationResourceSelect = {
   closest_community: true,
   project_established_date: true,
   display_on_public_site: true,
+  rec_status_code: true,
   recreation_resource_type_view_admin: {
     select: {
       rec_resource_type_code: true,

--- a/admin/backend/src/recreation-resources/recreation-resource.service.ts
+++ b/admin/backend/src/recreation-resources/recreation-resource.service.ts
@@ -86,6 +86,7 @@ export class RecreationResourceService {
           OPEN_STATUS.DESCRIPTION,
         status_code:
           resource.recreation_status?.status_code ?? OPEN_STATUS.STATUS_CODE,
+        rec_status_code: resource.rec_status_code,
         activities: this.getUniqueValues(
           resource.recreation_activity?.map(
             (activity) => activity.recreation_activity?.description ?? '',

--- a/admin/backend/test/recreation-resources/recreation-resource.service.spec.ts
+++ b/admin/backend/test/recreation-resources/recreation-resource.service.spec.ts
@@ -137,6 +137,7 @@ describe('RecreationResourceService', () => {
             },
             status_code: 1,
           },
+          rec_status_code: null,
           _count: {
             recreation_defined_campsite: 5,
           },
@@ -164,6 +165,7 @@ describe('RecreationResourceService', () => {
           closest_community: 'Hope',
           status: 'Open',
           status_code: 1,
+          rec_status_code: null,
           activities: ['Fishing', 'Hiking'],
           access_types: ['Walk in'],
           fee_indicators: ['Reservable', 'Has fees'],
@@ -194,6 +196,7 @@ describe('RecreationResourceService', () => {
           recreation_resource_type_view_admin: [],
           recreation_district_code: null,
           recreation_status: null,
+          rec_status_code: null,
           _count: {
             recreation_defined_campsite: 0,
           },
@@ -221,6 +224,7 @@ describe('RecreationResourceService', () => {
           established_date: null,
           updated_at: null,
           display_on_public_site: true,
+          rec_status_code: null,
           recreation_activity: [
             {
               recreation_activity: {
@@ -254,6 +258,7 @@ describe('RecreationResourceService', () => {
             },
           ],
           recreation_district_code: null,
+          recreation_status: null,
           _count: {
             recreation_defined_campsite: 0,
           },
@@ -279,6 +284,7 @@ describe('RecreationResourceService', () => {
           closest_community: null,
           project_established_date: null,
           display_on_public_site: null,
+          rec_status_code: null,
           recreation_activity: [
             {
               recreation_activity: {
@@ -312,6 +318,7 @@ describe('RecreationResourceService', () => {
           recreation_resource_reservation_info: null,
           recreation_resource_type_view_admin: [],
           recreation_district_code: null,
+          recreation_status: null,
           _count: {},
         },
       ],
@@ -339,6 +346,7 @@ describe('RecreationResourceService', () => {
           fee_indicators: ['No fees'],
           status: OPEN_STATUS.DESCRIPTION,
           status_code: OPEN_STATUS.STATUS_CODE,
+          rec_status_code: null,
           established_date: null,
           campsite_count: 0,
         },

--- a/admin/frontend/src/pages/search/hooks/useSearchResultsTable.tsx
+++ b/admin/frontend/src/pages/search/hooks/useSearchResultsTable.tsx
@@ -8,7 +8,8 @@ import {
 } from '@tanstack/react-table';
 import type { KeyboardEvent } from 'react';
 import { useNavigate } from '@tanstack/react-router';
-import { AdminStatusBadge, VisibleOnWebsite } from '@/components';
+import { AdminStatusBadge, CustomBadge, VisibleOnWebsite } from '@/components';
+import { COLOR_RED, COLOR_RED_LIGHT } from '@/styles/colors';
 import { ROUTE_PATHS } from '@/constants/routes';
 import {
   ADMIN_SEARCH_COLUMN_IDS,
@@ -63,12 +64,24 @@ const buildColumns = (
     };
 
     if (id === 'status') {
-      column.cell = ({ row }: { row: Row<AdminSearchResultRow> }) => (
-        <AdminStatusBadge
-          label={row.original.status}
-          statusCode={row.original.statusCode}
-        />
-      );
+      column.cell = ({ row }: { row: Row<AdminSearchResultRow> }) => {
+        const isArchived = row.original.recStatusCode === 'AR';
+        if (isArchived) {
+          return (
+            <CustomBadge
+              label="Archived"
+              bgColor={COLOR_RED_LIGHT}
+              textColor={COLOR_RED}
+            />
+          );
+        }
+        return (
+          <AdminStatusBadge
+            label={row.original.status}
+            statusCode={row.original.statusCode}
+          />
+        );
+      };
     }
 
     if (id === 'display_on_public_site') {

--- a/admin/frontend/src/pages/search/searchResultsMapper.ts
+++ b/admin/frontend/src/pages/search/searchResultsMapper.ts
@@ -23,6 +23,7 @@ export function mapAdminSearchResultRow(
       : '-',
     status: row.status,
     statusCode: row.status_code,
+    recStatusCode: row.rec_status_code,
     visible: row.display_on_public_site,
   };
 }

--- a/admin/frontend/src/pages/search/types.ts
+++ b/admin/frontend/src/pages/search/types.ts
@@ -40,5 +40,6 @@ export interface AdminSearchResultRow {
   closestCommunity: string;
   status: string;
   statusCode: number;
+  recStatusCode?: string | null;
   visible: boolean;
 }

--- a/admin/frontend/src/services/recreation-resource-admin/models/AdminSearchResultRowDto.ts
+++ b/admin/frontend/src/services/recreation-resource-admin/models/AdminSearchResultRowDto.ts
@@ -74,6 +74,12 @@ export interface AdminSearchResultRowDto {
    */
   status_code: number;
   /**
+   * Resource archive status code
+   * @type {string}
+   * @memberof AdminSearchResultRowDto
+   */
+  rec_status_code?: string | null;
+  /**
    * Access types associated with the resource
    * @type {Array<string>}
    * @memberof AdminSearchResultRowDto
@@ -176,6 +182,8 @@ export function AdminSearchResultRowDtoFromJSONTyped(
     closest_community: json['closest_community'],
     status: json['status'],
     status_code: json['status_code'],
+    rec_status_code:
+      json['rec_status_code'] == null ? undefined : json['rec_status_code'],
     access_types: json['access_types'],
     activities: json['activities'],
     fee_indicators: json['fee_indicators'],
@@ -209,6 +217,7 @@ export function AdminSearchResultRowDtoToJSONTyped(
     closest_community: value['closest_community'],
     status: value['status'],
     status_code: value['status_code'],
+    rec_status_code: value['rec_status_code'],
     access_types: value['access_types'],
     activities: value['activities'],
     fee_indicators: value['fee_indicators'],

--- a/admin/frontend/test/pages/admin-search-page/searchResultsMapper.test.ts
+++ b/admin/frontend/test/pages/admin-search-page/searchResultsMapper.test.ts
@@ -53,4 +53,15 @@ describe('mapAdminSearchResultRow', () => {
       statusCode: 1,
     });
   });
+
+  it('maps rec_status_code when provided', () => {
+    expect(
+      mapAdminSearchResultRow({
+        ...baseRow,
+        rec_status_code: 'AR',
+      }),
+    ).toMatchObject({
+      recStatusCode: 'AR',
+    });
+  });
 });

--- a/migrations/fta/sql/V1.0.0__init.sql
+++ b/migrations/fta/sql/V1.0.0__init.sql
@@ -1015,6 +1015,65 @@ comment on column fta.org_unit.expiry_date is 'Date on which the organization un
 comment on column fta.org_unit.update_timestamp is 'Timestamp of the last update to the organization unit record.';
 
 
+create table fta.prov_forest_use(
+                                                    forest_file_id      varchar(10)     not null,
+                                                    file_status_st      varchar(3)      null,
+                                                    file_status_date    date            null,
+                                                    file_type_code      varchar(10)     null,
+                                                    forest_region       numeric(10,0)   not null,
+                                                    bcts_org_unit       numeric(10,0)   null,
+                                                    sb_funded_ind       varchar(1)      not null,
+                                                    district_admin_zone varchar(4)      null,
+                                                    mgmt_unit_type      varchar(1)      null,
+                                                    mgmt_unit_id        varchar(4)      null,
+                                                    revision_count      numeric(5,0)    not null,
+                                                    entry_userid        varchar(30)     not null,
+                                                    entry_timestamp     date            not null,
+                                                    update_userid       varchar(30)     not null,
+                                                    update_timestamp    date            not null,
+                                                    forest_tenure_guid  varchar(36)     null
+);
+
+comment on table fta.prov_forest_use is 'Stores forest tenure file status records imported from the PROV_FOREST_USE source table.';
+
+create table fta.org_unit (
+                              org_unit_no         numeric(10, 0)  not null,
+                              org_unit_code       varchar(6)      not null,
+                              org_unit_name       varchar(100)    not null,
+                              location_code       varchar(3)      not null,
+                              area_code           varchar(3)      not null,
+                              telephone_no        varchar(7)      not null,
+                              org_level_code      varchar(1)      not null,
+                              office_name_code    varchar(2)      not null,
+                              rollup_region_no    numeric(10, 0)  not null,
+                              rollup_region_code  varchar(6)      not null,
+                              rollup_dist_no      numeric(10, 0)  not null,
+                              rollup_dist_code    varchar(6)      not null,
+                              effective_date      date            not null,
+                              expiry_date         date            not null,
+                              update_timestamp    date            null,
+
+                              constraint pk_org_unit primary key (org_unit_no)
+);
+comment on table fta.org_unit is 'Stores fta organization unit details.';
+
+comment on column fta.org_unit.org_unit_no is 'Unique numeric identifier for the ministry organization unit.';
+comment on column fta.org_unit.org_unit_code is 'Short alphanumeric code representing the organization unit.';
+comment on column fta.org_unit.org_unit_name is 'Full descriptive name of the organization unit.';
+comment on column fta.org_unit.location_code is 'Code identifying the physical location of the organization unit.';
+comment on column fta.org_unit.area_code is 'Code identifying the area associated with the organization unit.';
+comment on column fta.org_unit.telephone_no is 'Telephone number for the organization unit.';
+comment on column fta.org_unit.org_level_code is 'Code indicating the hierarchical level of the organization unit.';
+comment on column fta.org_unit.office_name_code is 'Code representing the office name of the organization unit.';
+comment on column fta.org_unit.rollup_region_no is 'Numeric identifier of the region this organization unit rolls up to.';
+comment on column fta.org_unit.rollup_region_code is 'Code of the region this organization unit rolls up to.';
+comment on column fta.org_unit.rollup_dist_no is 'Numeric identifier of the district this organization unit rolls up to.';
+comment on column fta.org_unit.rollup_dist_code is 'Code of the district this organization unit rolls up to.';
+comment on column fta.org_unit.effective_date is 'Date from which the organization unit record is active.';
+comment on column fta.org_unit.expiry_date is 'Date on which the organization unit record expires.';
+comment on column fta.org_unit.update_timestamp is 'Timestamp of the last update to the organization unit record.';
+
+
 create table fta.recreation_struct_dimen_code (
     recreation_struct_dimen_code varchar(2) primary key,
     description varchar(120) null,

--- a/migrations/fta/sql/V1.0.0__init.sql
+++ b/migrations/fta/sql/V1.0.0__init.sql
@@ -1015,65 +1015,6 @@ comment on column fta.org_unit.expiry_date is 'Date on which the organization un
 comment on column fta.org_unit.update_timestamp is 'Timestamp of the last update to the organization unit record.';
 
 
-create table fta.prov_forest_use(
-                                                    forest_file_id      varchar(10)     not null,
-                                                    file_status_st      varchar(3)      null,
-                                                    file_status_date    date            null,
-                                                    file_type_code      varchar(10)     null,
-                                                    forest_region       numeric(10,0)   not null,
-                                                    bcts_org_unit       numeric(10,0)   null,
-                                                    sb_funded_ind       varchar(1)      not null,
-                                                    district_admin_zone varchar(4)      null,
-                                                    mgmt_unit_type      varchar(1)      null,
-                                                    mgmt_unit_id        varchar(4)      null,
-                                                    revision_count      numeric(5,0)    not null,
-                                                    entry_userid        varchar(30)     not null,
-                                                    entry_timestamp     date            not null,
-                                                    update_userid       varchar(30)     not null,
-                                                    update_timestamp    date            not null,
-                                                    forest_tenure_guid  varchar(36)     null
-);
-
-comment on table fta.prov_forest_use is 'Stores forest tenure file status records imported from the PROV_FOREST_USE source table.';
-
-create table fta.org_unit (
-                              org_unit_no         numeric(10, 0)  not null,
-                              org_unit_code       varchar(6)      not null,
-                              org_unit_name       varchar(100)    not null,
-                              location_code       varchar(3)      not null,
-                              area_code           varchar(3)      not null,
-                              telephone_no        varchar(7)      not null,
-                              org_level_code      varchar(1)      not null,
-                              office_name_code    varchar(2)      not null,
-                              rollup_region_no    numeric(10, 0)  not null,
-                              rollup_region_code  varchar(6)      not null,
-                              rollup_dist_no      numeric(10, 0)  not null,
-                              rollup_dist_code    varchar(6)      not null,
-                              effective_date      date            not null,
-                              expiry_date         date            not null,
-                              update_timestamp    date            null,
-
-                              constraint pk_org_unit primary key (org_unit_no)
-);
-comment on table fta.org_unit is 'Stores fta organization unit details.';
-
-comment on column fta.org_unit.org_unit_no is 'Unique numeric identifier for the ministry organization unit.';
-comment on column fta.org_unit.org_unit_code is 'Short alphanumeric code representing the organization unit.';
-comment on column fta.org_unit.org_unit_name is 'Full descriptive name of the organization unit.';
-comment on column fta.org_unit.location_code is 'Code identifying the physical location of the organization unit.';
-comment on column fta.org_unit.area_code is 'Code identifying the area associated with the organization unit.';
-comment on column fta.org_unit.telephone_no is 'Telephone number for the organization unit.';
-comment on column fta.org_unit.org_level_code is 'Code indicating the hierarchical level of the organization unit.';
-comment on column fta.org_unit.office_name_code is 'Code representing the office name of the organization unit.';
-comment on column fta.org_unit.rollup_region_no is 'Numeric identifier of the region this organization unit rolls up to.';
-comment on column fta.org_unit.rollup_region_code is 'Code of the region this organization unit rolls up to.';
-comment on column fta.org_unit.rollup_dist_no is 'Numeric identifier of the district this organization unit rolls up to.';
-comment on column fta.org_unit.rollup_dist_code is 'Code of the district this organization unit rolls up to.';
-comment on column fta.org_unit.effective_date is 'Date from which the organization unit record is active.';
-comment on column fta.org_unit.expiry_date is 'Date on which the organization unit record expires.';
-comment on column fta.org_unit.update_timestamp is 'Timestamp of the last update to the organization unit record.';
-
-
 create table fta.recreation_struct_dimen_code (
     recreation_struct_dimen_code varchar(2) primary key,
     description varchar(120) null,


### PR DESCRIPTION
## Card: https://bcparksdigital.atlassian.net/browse/ORCA-860
## Changes:
### Backend Changes
  - Added `rec_status_code: true` to `baseRecreationResourceSelect`
  - Added `rec_status_code?: string | null` field to `AdminSearchResultRowDto`
  - Updated `mapAdminSearchResultRow` to map `rec_status_code` from database resources
  - Updated all search test cases to include `rec_status_code: null` in mock data

### Frontend Changes
  - Added `rec_status_code?: string | null` to TypeScript interface
  - Added `recStatusCode?: string | null` to `AdminSearchResultRow` interface
  - Updated mapper to include `recStatusCode: row.rec_status_code`
  - Archived status takes precedence and completely replaces status display
  - Added test case to verify `rec_status_code` mapping functionality


## To test
- Run Admin Frontend and Backend
- Got to search page
- Ensure Archived resources appear in search results table,  such that if rec_status_code is AR then it displays Archived otherwise open or closed
<img width="890" height="632" alt="image" src="https://github.com/user-attachments/assets/f14c8dc6-31d8-425f-8bf6-bea385e866fe" />

### Note: This pr is to be merged after https://github.com/bcgov/nr-rec-resources/pull/1628