### PR TITLE
feat(search): add established filter to search resources

### DIFF
--- a/admin/backend/src/recreation-resources/dtos/admin-search-query.dto.ts
+++ b/admin/backend/src/recreation-resources/dtos/admin-search-query.dto.ts
@@ -165,4 +165,13 @@ export class AdminSearchQueryDto {
   @IsOptional()
   @IsDateString()
   establishment_date_to?: string;
+
+  @ApiPropertyOptional({
+    description: 'Filter by establishment date presence (yes/no)',
+    enum: ['yes', 'no'],
+    example: 'yes',
+  })
+  @IsOptional()
+  @IsIn(['yes', 'no'])
+  established?: string;
 }

--- a/admin/backend/src/recreation-resources/queries/recreation-resource-search.queries.ts
+++ b/admin/backend/src/recreation-resources/queries/recreation-resource-search.queries.ts
@@ -108,6 +108,22 @@ function buildDateCondition(
   return Prisma.sql`rr.project_established_date ${Prisma.raw(operator)} ${new Date(value)}`;
 }
 
+function buildEstablishedCondition(
+  value: string | undefined,
+): Prisma.Sql | null {
+  if (!value) {
+    return null;
+  }
+
+  if (value === 'yes') {
+    return Prisma.sql`rr.project_established_date IS NOT NULL`;
+  } else if (value === 'no') {
+    return Prisma.sql`rr.project_established_date IS NULL`;
+  }
+
+  return null;
+}
+
 function buildMultiValueExistsCondition({
   values,
   table,
@@ -168,6 +184,7 @@ export function buildSearchWhereSql(query: AdminSearchQueryDto): Prisma.Sql {
       : null,
     buildDateCondition(query.establishment_date_from, '>='),
     buildDateCondition(query.establishment_date_to, '<='),
+    buildEstablishedCondition(query.established),
   ].filter((condition): condition is Prisma.Sql => condition !== null);
 
   if (conditions.length === 0) {

--- a/admin/backend/src/recreation-resources/recreation-resource.repository.ts
+++ b/admin/backend/src/recreation-resources/recreation-resource.repository.ts
@@ -262,6 +262,33 @@ export class RecreationResourceRepository {
     };
   }
 
+  private buildEstablishedWhere(
+    established?: string,
+  ): Prisma.recreation_resourceWhereInput | null {
+    if (!established) {
+      return null;
+    }
+
+    if (established === 'yes') {
+      return {
+        project_established_date: {
+          not: {
+            equals: null,
+          },
+        },
+      };
+    }
+    if (established === 'no') {
+      return {
+        project_established_date: {
+          equals: null,
+        },
+      };
+    }
+
+    return null;
+  }
+
   private buildSearchWhere(
     query: AdminSearchQueryDto,
   ): Prisma.recreation_resourceWhereInput {
@@ -300,6 +327,7 @@ export class RecreationResourceRepository {
       this.buildClosestCommunityWhere(query.closestCommunity),
       this.buildStatusWhere(query.status),
       this.buildEstablishmentDateWhere(query),
+      this.buildEstablishedWhere(query.established),
     ].filter(
       (condition): condition is Prisma.recreation_resourceWhereInput =>
         condition !== null,

--- a/admin/backend/test/recreation-resources/queries/recreation-resource-search.queries.spec.ts
+++ b/admin/backend/test/recreation-resources/queries/recreation-resource-search.queries.spec.ts
@@ -28,6 +28,7 @@ describe('recreation-resource-search.queries', () => {
       status: ['3', 'bad', '4'],
       establishment_date_from: '2020-01-01',
       establishment_date_to: '2024-12-31',
+      established: 'yes',
     });
 
     const normalizedSql = normalizeSql(whereSql);
@@ -41,6 +42,7 @@ describe('recreation-resource-search.queries', () => {
     expect(normalizedSql).toContain('rs.status_code IN (?,?)');
     expect(normalizedSql).toContain('rr.project_established_date >= ?');
     expect(normalizedSql).toContain('rr.project_established_date <= ?');
+    expect(normalizedSql).toContain('rr.project_established_date IS NOT NULL');
     expect(whereSql.values).toEqual([
       '%lake%',
       '%lake%',
@@ -66,6 +68,42 @@ describe('recreation-resource-search.queries', () => {
     const normalizedSql = normalizeSql(whereSql);
 
     expect(normalizedSql).not.toContain('recreation_activity_code IN');
+  });
+
+  it('includes established filter in WHERE clause', () => {
+    const whereYes = buildSearchWhereSql({
+      established: 'yes',
+    });
+    const whereNo = buildSearchWhereSql({
+      established: 'no',
+    });
+
+    expect(normalizeSql(whereYes)).toContain(
+      'rr.project_established_date IS NOT NULL',
+    );
+    expect(normalizeSql(whereNo)).toContain(
+      'rr.project_established_date IS NULL',
+    );
+  });
+
+  it('ignores established filter with invalid value', () => {
+    const whereInvalid = buildSearchWhereSql({
+      established: 'invalid',
+    });
+
+    expect(whereInvalid).toBe(Prisma.empty);
+  });
+
+  it('ignores established filter when undefined or empty', () => {
+    const whereUndefined = buildSearchWhereSql({
+      established: undefined,
+    });
+    const whereEmpty = buildSearchWhereSql({
+      established: '',
+    });
+
+    expect(whereUndefined).toBe(Prisma.empty);
+    expect(whereEmpty).toBe(Prisma.empty);
   });
 
   it('maps raw SQL sorts and derived order clauses correctly', () => {

--- a/admin/backend/test/recreation-resources/recreation-resource.repository.spec.ts
+++ b/admin/backend/test/recreation-resources/recreation-resource.repository.spec.ts
@@ -245,6 +245,134 @@ describe('RecreationResourceRepository', () => {
         data: [],
       });
     });
+
+    it('should filter resources with established=yes (project_established_date is not null)', async () => {
+      (
+        prisma.$transaction as unknown as ReturnType<typeof vi.fn>
+      ).mockResolvedValue([10, []]);
+
+      await repo.searchResources({
+        established: 'yes',
+      });
+
+      expect(prisma.recreation_resource.count).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            AND: expect.arrayContaining([
+              {
+                project_established_date: {
+                  not: {
+                    equals: null,
+                  },
+                },
+              },
+            ]),
+          }),
+        }),
+      );
+    });
+
+    it('should filter resources with established=no (project_established_date is null)', async () => {
+      (
+        prisma.$transaction as unknown as ReturnType<typeof vi.fn>
+      ).mockResolvedValue([5, []]);
+
+      await repo.searchResources({
+        established: 'no',
+      });
+
+      expect(prisma.recreation_resource.count).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            AND: expect.arrayContaining([
+              {
+                project_established_date: {
+                  equals: null,
+                },
+              },
+            ]),
+          }),
+        }),
+      );
+    });
+
+    it('should ignore established filter when value is invalid', async () => {
+      (
+        prisma.$transaction as unknown as ReturnType<typeof vi.fn>
+      ).mockResolvedValue([15, []]);
+
+      await repo.searchResources({
+        established: 'invalid',
+      });
+
+      const countCall = prisma.recreation_resource.count.mock.calls[0];
+      const whereClause = countCall?.[0]?.where;
+
+      // Verify that the invalid established value doesn't add a project_established_date filter
+      if (whereClause?.AND) {
+        const hasEstablishedFilter = whereClause.AND.some(
+          (condition: any) => condition?.project_established_date,
+        );
+        expect(hasEstablishedFilter).toBe(false);
+      }
+    });
+
+    it('should ignore established filter when it is undefined', async () => {
+      (
+        prisma.$transaction as unknown as ReturnType<typeof vi.fn>
+      ).mockResolvedValue([15, []]);
+
+      await repo.searchResources({
+        established: undefined,
+      });
+
+      const countCall = prisma.recreation_resource.count.mock.calls[0];
+      const whereClause = countCall?.[0]?.where;
+
+      // Verify that undefined established value doesn't add a project_established_date filter
+      if (whereClause?.AND) {
+        const hasEstablishedFilter = whereClause.AND.some(
+          (condition: any) => condition?.project_established_date,
+        );
+        expect(hasEstablishedFilter).toBe(false);
+      }
+    });
+
+    it('should combine established filter with other filters', async () => {
+      (
+        prisma.$transaction as unknown as ReturnType<typeof vi.fn>
+      ).mockResolvedValue([3, []]);
+
+      await repo.searchResources({
+        established: 'yes',
+        district: ['ABC'],
+        status: ['1'],
+      });
+
+      expect(prisma.recreation_resource.count).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            AND: expect.arrayContaining([
+              {
+                project_established_date: {
+                  not: {
+                    equals: null,
+                  },
+                },
+              },
+              { district_code: { in: ['ABC'] } },
+              {
+                recreation_status: {
+                  status_code: {
+                    in: [1],
+                  },
+                },
+              },
+            ]),
+          }),
+        }),
+      );
+    });
   });
 
   describe('update', () => {

--- a/admin/frontend/src/components/form/CheckboxDropdownField.tsx
+++ b/admin/frontend/src/components/form/CheckboxDropdownField.tsx
@@ -11,7 +11,7 @@ interface CheckboxDropdownFieldProps {
   className?: string;
   label: ReactNode;
   items: CheckboxDropdownItem[];
-  selectedValues: string[];
+  selectedValues?: string[];
   onToggle: (value: string) => void;
   showSelectedCount?: boolean;
   variant?: string;
@@ -23,7 +23,7 @@ export function CheckboxDropdownField({
   className,
   label,
   items,
-  selectedValues,
+  selectedValues = [],
   onToggle,
   showSelectedCount = false,
   variant,

--- a/admin/frontend/src/pages/search/SearchPage.tsx
+++ b/admin/frontend/src/pages/search/SearchPage.tsx
@@ -30,6 +30,7 @@ export function SearchPage() {
     access: search.access,
     establishment_date_from: search.establishment_date_from,
     establishment_date_to: search.establishment_date_to,
+    established: search.established,
   });
 
   const [communityFilter, setCommunityFilter] = useState<string[]>([]);

--- a/admin/frontend/src/pages/search/components/FilterAccordion.tsx
+++ b/admin/frontend/src/pages/search/components/FilterAccordion.tsx
@@ -24,6 +24,7 @@ type FilterAccordionControllerProps = Pick<
   | 'statusOptions'
   | 'accessOptions'
   | 'closestCommunityOptions'
+  | 'establishedOptions'
   | 'applyFilters'
   | 'resetFilters'
 >;
@@ -48,6 +49,7 @@ const getEditableFilters = (
   closestCommunity: state.closestCommunity,
   establishment_date_from: state.establishment_date_from,
   establishment_date_to: state.establishment_date_to,
+  established: state.established,
 });
 
 const toggleFilterValue = (currentValues: string[], value: string): string[] =>
@@ -71,6 +73,7 @@ export function FilterAccordion({
     statusOptions,
     accessOptions,
     closestCommunityOptions,
+    establishedOptions,
     applyFilters: onApply,
     resetFilters: onReset,
   } = controller;
@@ -80,7 +83,8 @@ export function FilterAccordion({
     activityOptions,
     statusOptions,
     accessOptions,
-    closestCommunityOptions: closestCommunityOptions.map((item) => ({
+    establishedOptions,
+    closestCommunityOptions: (closestCommunityOptions ?? []).map((item) => ({
       ...item,
       label: capitalizeWords(item.label),
     })),
@@ -125,26 +129,63 @@ export function FilterAccordion({
         <div className="filters__panel mb-3">
           <Row className="g-3">
             {ADMIN_SEARCH_MULTISELECT_FILTER_FIELDS.map((field) => {
-              const options = filterOptionsByKey[field.optionsKey] ?? [];
+              const options =
+                filterOptionsByKey[
+                  field.optionsKey as keyof typeof filterOptionsByKey
+                ] ?? [];
+              const typedOptions = options as Array<{
+                id: string;
+                label: string;
+              }>;
+              // Handle established field as a select instead of checkbox dropdown
+              if ('isSelect' in field && field.isSelect) {
+                return (
+                  <Col key={field.key} md={6} xl={3}>
+                    <Form.Group controlId={field.controlId}>
+                      <Form.Label>{field.label}</Form.Label>
+                      <Form.Select
+                        value={draft[field.key as keyof typeof draft] ?? ''}
+                        onChange={(event) =>
+                          updateDraft((current) => ({
+                            ...current,
+                            [field.key]: event.target.value || undefined,
+                          }))
+                        }
+                      >
+                        <option value="">{field.label}</option>
+                        {typedOptions.map((option) => (
+                          <option key={option.id} value={option.id}>
+                            {option.label}
+                          </option>
+                        ))}
+                      </Form.Select>
+                    </Form.Group>
+                  </Col>
+                );
+              }
               return (
                 <Col key={field.key} md={6} xl={3}>
                   <Form.Group controlId={field.controlId}>
                     <Form.Label>{field.label}</Form.Label>
                     <CheckboxDropdownField
                       label={field.label}
-                      items={options.flatMap((option) =>
+                      items={typedOptions.flatMap((option) =>
                         option.id
                           ? [{ value: option.id, label: option.label }]
                           : [],
                       )}
-                      selectedValues={draft[field.key]}
+                      selectedValues={
+                        draft[field.key as keyof typeof draft] as string[]
+                      }
                       toggleStyle="field"
                       showSelectedCount
                       onToggle={(value) =>
                         updateDraft((current) => ({
                           ...current,
                           [field.key]: toggleFilterValue(
-                            current[field.key],
+                            current[
+                              field.key as keyof typeof current
+                            ] as string[],
                             value,
                           ),
                         }))
@@ -216,6 +257,7 @@ export function FilterAccordion({
                     closestCommunity: draft.closestCommunity,
                     establishment_date_from: draft.establishment_date_from,
                     establishment_date_to: draft.establishment_date_to,
+                    established: draft.established,
                   });
                 }}
               >

--- a/admin/frontend/src/pages/search/constants.ts
+++ b/admin/frontend/src/pages/search/constants.ts
@@ -18,6 +18,7 @@ export type EditableAdminSearchFilters = Pick<
   | 'closestCommunity'
   | 'establishment_date_from'
   | 'establishment_date_to'
+  | 'established'
 >;
 
 export const DEFAULT_ADMIN_SEARCH_STATE: AdminSearchRouteState = {
@@ -32,6 +33,7 @@ export const DEFAULT_ADMIN_SEARCH_STATE: AdminSearchRouteState = {
   establishment_date_from: undefined,
   establishment_date_to: undefined,
   access: [],
+  established: undefined,
   closestCommunity: [],
 };
 
@@ -49,15 +51,10 @@ export const EMPTY_ADMIN_SEARCH_FILTERS: EditableAdminSearchFilters = {
   closestCommunity: [],
   establishment_date_from: undefined,
   establishment_date_to: undefined,
+  established: undefined,
 };
 
 export const ADMIN_SEARCH_MULTISELECT_FILTER_FIELDS = [
-  {
-    key: 'type',
-    label: 'Resource type',
-    controlId: 'admin-search-filter-resource-type',
-    optionsKey: 'typeOptions',
-  },
   {
     key: 'district',
     label: 'District',
@@ -65,10 +62,17 @@ export const ADMIN_SEARCH_MULTISELECT_FILTER_FIELDS = [
     optionsKey: 'districtOptions',
   },
   {
-    key: 'activities',
-    label: 'Activities',
-    controlId: 'admin-search-filter-activities',
-    optionsKey: 'activityOptions',
+    key: 'type',
+    label: 'Resource type',
+    controlId: 'admin-search-filter-resource-type',
+    optionsKey: 'typeOptions',
+  },
+  {
+    key: 'established',
+    label: 'Established',
+    controlId: 'admin-search-filter-established',
+    optionsKey: 'establishedOptions',
+    isSelect: true,
   },
   {
     key: 'status',
@@ -76,6 +80,13 @@ export const ADMIN_SEARCH_MULTISELECT_FILTER_FIELDS = [
     controlId: 'admin-search-filter-status',
     optionsKey: 'statusOptions',
   },
+  {
+    key: 'activities',
+    label: 'Activities',
+    controlId: 'admin-search-filter-activities',
+    optionsKey: 'activityOptions',
+  },
+
   {
     key: 'access',
     label: 'Access type',
@@ -88,6 +99,11 @@ export const ADMIN_SEARCH_MULTISELECT_FILTER_FIELDS = [
     controlId: 'admin-search-filter-closest-community',
     optionsKey: 'closestCommunityOptions',
   },
+] as const;
+
+export const ADMIN_SEARCH_ESTABLISHED_OPTIONS = [
+  { id: 'yes', label: 'Yes' },
+  { id: 'no', label: 'No' },
 ] as const;
 
 export const ADMIN_SEARCH_STORAGE_KEYS = {

--- a/admin/frontend/src/pages/search/hooks/useAdminSearchController.ts
+++ b/admin/frontend/src/pages/search/hooks/useAdminSearchController.ts
@@ -23,6 +23,7 @@ import {
   setAdminSearchDistrictFilter,
   setAdminSearchEstablishmentDateFromFilter,
   setAdminSearchEstablishmentDateToFilter,
+  setAdminSearchEstablishedFilter,
   setAdminSearchPage,
   setAdminSearchPageSize,
   setAdminSearchStatusFilter,
@@ -48,7 +49,8 @@ const hasActiveEditableFilters = (search: AdminSearchRouteState) =>
   search.access.length > 0 ||
   search.closestCommunity.length > 0 ||
   Boolean(search.establishment_date_from) ||
-  Boolean(search.establishment_date_to);
+  Boolean(search.establishment_date_to) ||
+  Boolean(search.established);
 
 const hasAppliedSearchState = (search: AdminSearchRouteState) =>
   hasActiveEditableFilters(search) || Boolean(search.q);
@@ -148,6 +150,13 @@ export function useAdminSearchController(search: AdminSearchRouteState) {
     () => sortOptionsByLabel(closestCommunityOptionsByType?.options ?? []),
     [closestCommunityOptionsByType],
   );
+  const establishedOptions = useMemo(
+    () => [
+      { id: 'yes', label: 'Yes' },
+      { id: 'no', label: 'No' },
+    ],
+    [],
+  );
   const updateSearch = (nextSearch: AdminSearchRouteState) =>
     navigate({
       to: ROUTE_PATHS.LANDING,
@@ -229,6 +238,8 @@ export function useAdminSearchController(search: AdminSearchRouteState) {
     updateSearch(setAdminSearchEstablishmentDateFromFilter(search, undefined));
   const clearEstablishmentDateTo = () =>
     updateSearch(setAdminSearchEstablishmentDateToFilter(search, undefined));
+  const clearEstablished = () =>
+    updateSearch(setAdminSearchEstablishedFilter(search, undefined));
   const appliedFilterChips: AdminAppliedFilterChip[] = [];
   appliedFilterChips.push(
     ...search.type.map((type) => ({
@@ -280,6 +291,15 @@ export function useAdminSearchController(search: AdminSearchRouteState) {
       onClear: clearEstablishmentDateTo,
     });
   }
+
+  if (search.established) {
+    const labelMap = { yes: 'Yes', no: 'No' };
+    appliedFilterChips.push({
+      key: `established:${search.established}`,
+      label: `Established: ${labelMap[search.established as keyof typeof labelMap] || search.established}`,
+      onClear: clearEstablished,
+    });
+  }
   const activeFilterStateKey = useMemo(
     () =>
       JSON.stringify({
@@ -291,6 +311,7 @@ export function useAdminSearchController(search: AdminSearchRouteState) {
         closestCommunity: search.closestCommunity,
         establishment_date_from: search.establishment_date_from,
         establishment_date_to: search.establishment_date_to,
+        established: search.established,
       }),
     [
       search.type,
@@ -301,6 +322,7 @@ export function useAdminSearchController(search: AdminSearchRouteState) {
       search.closestCommunity,
       search.establishment_date_from,
       search.establishment_date_to,
+      search.established,
     ],
   );
   const isFilterPanelOpen = hasActiveFilters
@@ -333,6 +355,7 @@ export function useAdminSearchController(search: AdminSearchRouteState) {
     districtOptions,
     accessOptions,
     closestCommunityOptions,
+    establishedOptions,
     appliedFilterChips,
     hasAppliedState: hasAppliedSearchState(search),
     isFilterPanelOpen,
@@ -342,7 +365,6 @@ export function useAdminSearchController(search: AdminSearchRouteState) {
       updateSearch(submitAdminSearchQuery(search, query)),
     setSort: (sort: AdminSearchRouteState['sort']) =>
       updateSearch(setAdminSearchSort(search, sort)),
-    setPage: (page: number) => updateSearch(setAdminSearchPage(search, page)),
     applyFilters: (filters: EditableAdminSearchFilters) =>
       updateSearch({
         ...search,
@@ -366,5 +388,6 @@ export function useAdminSearchController(search: AdminSearchRouteState) {
     clearClosestCommunity,
     clearEstablishmentDateFrom,
     clearEstablishmentDateTo,
+    clearEstablished,
   };
 }

--- a/admin/frontend/src/pages/search/types.ts
+++ b/admin/frontend/src/pages/search/types.ts
@@ -14,6 +14,7 @@ export interface AdminSearchFilters {
   establishment_date_from?: string;
   establishment_date_to?: string;
   access: string[];
+  established?: string;
 }
 
 export interface AdminSearchRouteState extends AdminSearchFilters {

--- a/admin/frontend/src/pages/search/utils/searchSchema.ts
+++ b/admin/frontend/src/pages/search/utils/searchSchema.ts
@@ -122,6 +122,7 @@ export function validateAdminSearch(
     establishment_date_from: getOptionalToken(search.establishment_date_from),
     establishment_date_to: getOptionalToken(search.establishment_date_to),
     access: getSearchFilterTokenList(search.access),
+    established: getOptionalToken(search.established),
     closestCommunity: getSearchFilterTokenList(search.closestCommunity),
   });
 }

--- a/admin/frontend/src/pages/search/utils/urlState.ts
+++ b/admin/frontend/src/pages/search/utils/urlState.ts
@@ -82,6 +82,10 @@ export const serializeAdminSearchRouteState = (
     search.access = serializeListFilter(state.access);
   }
 
+  if (state.established) {
+    search.established = state.established;
+  }
+
   return search;
 };
 
@@ -172,6 +176,14 @@ export const setAdminSearchEstablishmentDateToFilter = (
 ): AdminSearchRouteState =>
   setFilterState(state, {
     establishment_date_to: establishmentDateTo || undefined,
+  });
+
+export const setAdminSearchEstablishedFilter = (
+  state: AdminSearchRouteState,
+  established: AdminSearchRouteState['established'],
+): AdminSearchRouteState =>
+  setFilterState(state, {
+    established: established || undefined,
   });
 
 export const clearAdminSearchState = (

--- a/admin/frontend/src/services/hooks/recreation-resource-admin/searchQueryOptions.ts
+++ b/admin/frontend/src/services/hooks/recreation-resource-admin/searchQueryOptions.ts
@@ -33,6 +33,7 @@ export function buildAdminSearchRequest(
       : undefined,
     establishmentDateFrom: search.establishment_date_from,
     establishmentDateTo: search.establishment_date_to,
+    established: search.established,
   };
 }
 

--- a/admin/frontend/src/services/recreation-resource-admin/apis/RecreationResourcesApi.ts
+++ b/admin/frontend/src/services/recreation-resource-admin/apis/RecreationResourcesApi.ts
@@ -245,6 +245,7 @@ export interface SearchRecreationResourcesRequest {
   status?: Array<string>;
   establishmentDateFrom?: string;
   establishmentDateTo?: string;
+  established?: string;
 }
 
 export interface UpdateActivitiesRequest {
@@ -2269,6 +2270,10 @@ export class RecreationResourcesApi extends runtime.BaseAPI {
     if (requestParameters['establishmentDateTo'] != null) {
       queryParameters['establishment_date_to'] =
         requestParameters['establishmentDateTo'];
+    }
+
+    if (requestParameters['established'] != null) {
+      queryParameters['established'] = requestParameters['established'];
     }
 
     const headerParameters: runtime.HTTPHeaders = {};

--- a/admin/frontend/test/pages/admin-search-page/components/SearchResultsBehavior.test.tsx
+++ b/admin/frontend/test/pages/admin-search-page/components/SearchResultsBehavior.test.tsx
@@ -6,6 +6,11 @@ import { FilterAccordion } from '@/pages/search/components/FilterAccordion';
 import { SearchResultsPagination } from '@/pages/search/components/SearchResultsPagination';
 import { SearchResultsSummary } from '@/pages/search/components/SearchResultsSummary';
 
+const establishedOptions = [
+  { id: 'yes', label: 'Yes' },
+  { id: 'no', label: 'No' },
+];
+
 describe('SearchResultsSummary', () => {
   it('renders loading, query, and total states', () => {
     const { rerender } = render(
@@ -116,6 +121,7 @@ describe('FilterAccordion', () => {
           activityOptions: [{ id: '8', label: 'Camping', is_archived: false }],
           statusOptions: [],
           accessOptions: [{ id: 'W', label: 'Walk-in', is_archived: false }],
+          establishedOptions,
           applyFilters,
           resetFilters: vi.fn(),
         }}
@@ -171,6 +177,7 @@ describe('FilterAccordion', () => {
           activityOptions: [],
           statusOptions: [],
           accessOptions: [],
+          establishedOptions,
           closestCommunityOptions: [],
           applyFilters: vi.fn(),
           resetFilters,
@@ -193,5 +200,175 @@ describe('FilterAccordion', () => {
 
     await user.click(screen.getByRole('button', { name: 'Reset filters' }));
     expect(resetFilters).toHaveBeenCalledTimes(1);
+  });
+
+  it('applies established filter when selected', async () => {
+    const user = userEvent.setup();
+    const applyFilters = vi.fn();
+
+    render(
+      <FilterAccordion
+        search={DEFAULT_ADMIN_SEARCH_STATE}
+        controller={{
+          isFilterPanelOpen: true,
+          closeFilterPanel: vi.fn(),
+          toggleFilterPanel: vi.fn(),
+          typeOptions: [],
+          districtOptions: [],
+          activityOptions: [],
+          statusOptions: [],
+          accessOptions: [],
+          establishedOptions,
+          closestCommunityOptions: [],
+          applyFilters,
+          resetFilters: vi.fn(),
+        }}
+        showTrigger={false}
+        communityFilter={[]}
+      />,
+    );
+
+    const establishedSelect = screen.getByDisplayValue('Established');
+    await user.selectOptions(establishedSelect, 'yes');
+
+    const applyButton = screen.getByRole('button', { name: 'Apply' });
+    expect(applyButton).toBeEnabled();
+
+    await user.click(applyButton);
+
+    expect(applyFilters).toHaveBeenLastCalledWith({
+      type: [],
+      district: [],
+      activities: [],
+      status: [],
+      access: [],
+      closestCommunity: [],
+      establishment_date_from: undefined,
+      establishment_date_to: undefined,
+      established: 'yes',
+    });
+  });
+
+  it('clears established filter when changed back to default', async () => {
+    const user = userEvent.setup();
+    const applyFilters = vi.fn();
+
+    render(
+      <FilterAccordion
+        search={{
+          ...DEFAULT_ADMIN_SEARCH_STATE,
+          established: 'yes',
+        }}
+        controller={{
+          isFilterPanelOpen: true,
+          closeFilterPanel: vi.fn(),
+          toggleFilterPanel: vi.fn(),
+          typeOptions: [],
+          districtOptions: [],
+          activityOptions: [],
+          statusOptions: [],
+          accessOptions: [],
+          establishedOptions,
+          closestCommunityOptions: [],
+          applyFilters,
+          resetFilters: vi.fn(),
+        }}
+        showTrigger={false}
+        communityFilter={[]}
+      />,
+    );
+
+    const establishedSelect = screen.getByDisplayValue('Yes');
+    await user.selectOptions(establishedSelect, '');
+
+    const applyButton = screen.getByRole('button', { name: 'Apply' });
+    expect(applyButton).toBeEnabled();
+
+    await user.click(applyButton);
+
+    expect(applyFilters).toHaveBeenLastCalledWith({
+      type: [],
+      district: [],
+      activities: [],
+      status: [],
+      access: [],
+      closestCommunity: [],
+      establishment_date_from: undefined,
+      establishment_date_to: undefined,
+      established: undefined,
+    });
+  });
+
+  it('preserves established filter when canceling without changes', async () => {
+    const user = userEvent.setup();
+    const closeFilterPanel = vi.fn();
+
+    render(
+      <FilterAccordion
+        search={{
+          ...DEFAULT_ADMIN_SEARCH_STATE,
+          established: 'yes',
+        }}
+        controller={{
+          isFilterPanelOpen: true,
+          closeFilterPanel,
+          toggleFilterPanel: vi.fn(),
+          typeOptions: [],
+          districtOptions: [],
+          activityOptions: [],
+          statusOptions: [],
+          accessOptions: [],
+          establishedOptions,
+          closestCommunityOptions: [],
+          applyFilters: vi.fn(),
+          resetFilters: vi.fn(),
+        }}
+        showTrigger={false}
+        communityFilter={[]}
+      />,
+    );
+
+    const applyButton = screen.getByRole('button', { name: 'Apply' });
+    expect(applyButton).toBeDisabled();
+
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(closeFilterPanel).toHaveBeenCalledTimes(1);
+  });
+
+  it('resets established filter when reset filters is clicked', async () => {
+    const user = userEvent.setup();
+    const resetFilters = vi.fn();
+
+    render(
+      <FilterAccordion
+        search={{
+          ...DEFAULT_ADMIN_SEARCH_STATE,
+          established: 'yes',
+        }}
+        controller={{
+          isFilterPanelOpen: true,
+          closeFilterPanel: vi.fn(),
+          toggleFilterPanel: vi.fn(),
+          typeOptions: [],
+          districtOptions: [],
+          activityOptions: [],
+          statusOptions: [],
+          accessOptions: [],
+          establishedOptions,
+          closestCommunityOptions: [],
+          applyFilters: vi.fn(),
+          resetFilters,
+        }}
+        showTrigger={false}
+        communityFilter={[]}
+      />,
+    );
+
+    expect(screen.getByDisplayValue('Yes')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Reset filters' }));
+
+    expect(resetFilters).toHaveBeenCalledTimes(1);
+    expect(screen.getByDisplayValue('Established')).toBeInTheDocument();
   });
 });

--- a/admin/frontend/test/pages/admin-search-page/hooks/useAdminSearchController.test.tsx
+++ b/admin/frontend/test/pages/admin-search-page/hooks/useAdminSearchController.test.tsx
@@ -211,6 +211,133 @@ describe('useAdminSearchController', () => {
     });
   });
 
+  it('generates filter chip for established=yes and established=no', () => {
+    const searchYes = {
+      ...DEFAULT_ADMIN_SEARCH_STATE,
+      established: 'yes',
+    };
+    const searchNo = {
+      ...DEFAULT_ADMIN_SEARCH_STATE,
+      established: 'no',
+    };
+
+    const { result: resultYes } = renderHook(
+      () => useAdminSearchController(searchYes),
+      { wrapper: createWrapper() },
+    );
+    const { result: resultNo } = renderHook(
+      () => useAdminSearchController(searchNo),
+      { wrapper: createWrapper() },
+    );
+
+    const chipYes = resultYes.current.appliedFilterChips.find(
+      (chip) => chip.key === 'established:yes',
+    );
+    const chipNo = resultNo.current.appliedFilterChips.find(
+      (chip) => chip.key === 'established:no',
+    );
+
+    expect(chipYes?.label).toBe('Established: Yes');
+    expect(chipNo?.label).toBe('Established: No');
+  });
+
+  it('does not generate filter chip when established is undefined', () => {
+    const search = {
+      ...DEFAULT_ADMIN_SEARCH_STATE,
+      established: undefined,
+    };
+    const { result } = renderHook(() => useAdminSearchController(search), {
+      wrapper: createWrapper(),
+    });
+
+    const establishedChip = result.current.appliedFilterChips.find((chip) =>
+      chip.key?.startsWith('established:'),
+    );
+
+    expect(establishedChip).toBeUndefined();
+  });
+
+  it('clears established filter when calling clearEstablished', () => {
+    const search = {
+      ...DEFAULT_ADMIN_SEARCH_STATE,
+      established: 'yes',
+    };
+    const { result } = renderHook(() => useAdminSearchController(search), {
+      wrapper: createWrapper(),
+    });
+
+    act(() => {
+      result.current.clearEstablished();
+    });
+
+    expect(mockNavigate).toHaveBeenCalledWith({
+      to: '/',
+      search: {},
+      resetScroll: false,
+    });
+  });
+
+  it('detects established filter as active filter', () => {
+    const search = {
+      ...DEFAULT_ADMIN_SEARCH_STATE,
+      established: 'yes',
+    };
+    const { result } = renderHook(() => useAdminSearchController(search), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.hasAppliedState).toBe(true);
+  });
+
+  it('applies established filter through applyFilters', () => {
+    const search = DEFAULT_ADMIN_SEARCH_STATE;
+    const { result } = renderHook(() => useAdminSearchController(search), {
+      wrapper: createWrapper(),
+    });
+
+    act(() => {
+      result.current.applyFilters({
+        type: [],
+        district: [],
+        activities: [],
+        status: [],
+        access: [],
+        establishment_date_from: undefined,
+        establishment_date_to: undefined,
+        established: 'yes',
+      });
+    });
+
+    expect(mockNavigate).toHaveBeenCalledWith({
+      to: '/',
+      search: expect.objectContaining({
+        established: 'yes',
+      }),
+      resetScroll: false,
+    });
+  });
+
+  it('resets established filter when calling resetFilters', () => {
+    const search = {
+      ...DEFAULT_ADMIN_SEARCH_STATE,
+      established: 'yes',
+      type: ['RTR'],
+    };
+    const { result } = renderHook(() => useAdminSearchController(search), {
+      wrapper: createWrapper(),
+    });
+
+    act(() => {
+      result.current.resetFilters();
+    });
+
+    expect(mockNavigate).toHaveBeenCalledWith({
+      to: '/',
+      search: {},
+      resetScroll: false,
+    });
+  });
+
   it('persists preferred filter-panel state only when there are no active filters', () => {
     const writeSpy = vi.mocked(storage.writeAdminSearchFilterPanelOpen);
     const { result: noFilters } = renderHook(
@@ -245,5 +372,19 @@ describe('useAdminSearchController', () => {
     });
     expect(withFilters.current.isFilterPanelOpen).toBe(true);
     expect(writeSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('provides establishedOptions with yes and no values', () => {
+    const { result } = renderHook(
+      () => useAdminSearchController(DEFAULT_ADMIN_SEARCH_STATE),
+      {
+        wrapper: createWrapper(),
+      },
+    );
+
+    expect(result.current.establishedOptions).toEqual([
+      { id: 'yes', label: 'Yes' },
+      { id: 'no', label: 'No' },
+    ]);
   });
 });

--- a/admin/frontend/test/pages/admin-search-page/utils/urlState.test.ts
+++ b/admin/frontend/test/pages/admin-search-page/utils/urlState.test.ts
@@ -4,6 +4,7 @@ import {
   setAdminSearchAccessFilter,
   setAdminSearchEstablishmentDateFromFilter,
   setAdminSearchEstablishmentDateToFilter,
+  setAdminSearchEstablishedFilter,
   setAdminSearchPageSize,
   setAdminSearchTypeFilter,
   submitAdminSearchQuery,
@@ -58,6 +59,25 @@ describe('admin search urlState helpers', () => {
     });
   });
 
+  it('sets established filter and resets page', () => {
+    expect(setAdminSearchEstablishedFilter(baseState, 'yes')).toMatchObject({
+      established: 'yes',
+      page: 1,
+    });
+
+    expect(setAdminSearchEstablishedFilter(baseState, 'no')).toMatchObject({
+      established: 'no',
+      page: 1,
+    });
+
+    expect(setAdminSearchEstablishedFilter(baseState, undefined)).toMatchObject(
+      {
+        established: undefined,
+        page: 1,
+      },
+    );
+  });
+
   it('resets page when changing page size', () => {
     expect(setAdminSearchPageSize(baseState, 100)).toMatchObject({
       page: 1,
@@ -95,6 +115,26 @@ describe('admin search urlState helpers', () => {
       page_size: 50,
       district: 'RDCS',
       access: 'W',
+    });
+  });
+
+  it('serializes established filter in search state', () => {
+    expect(
+      serializeAdminSearchRouteState({
+        ...DEFAULT_ADMIN_SEARCH_STATE,
+        established: 'yes',
+      }),
+    ).toEqual({
+      established: 'yes',
+    });
+
+    expect(
+      serializeAdminSearchRouteState({
+        ...DEFAULT_ADMIN_SEARCH_STATE,
+        established: 'no',
+      }),
+    ).toEqual({
+      established: 'no',
     });
   });
 

--- a/admin/frontend/test/pages/search-page/SearchPage.test.tsx
+++ b/admin/frontend/test/pages/search-page/SearchPage.test.tsx
@@ -192,6 +192,10 @@ function buildController() {
       nextPage: vi.fn(),
     },
     setSort: vi.fn(),
+    establishedOptions: [
+      { id: 'yes', label: 'Yes' },
+      { id: 'no', label: 'No' },
+    ],
   };
 }
 


### PR DESCRIPTION
**Card:** https://bcparksdigital.atlassian.net/browse/ORCA-809
Added Established in the filters which works as :- 
Yes - If there is an established date
No - If there isnt any established date

**To test:-**
1. Go to http://localhost:3001
2. Ensure there is a filter for Established 
3. Select Yes or No and apply filters
4. Ensure that the data shown in the table:
     - If YES: shows only those with established date
     - If NO: shows only those without established date

