### PR TITLE
fix: community search

### DIFF
--- a/admin/frontend/src/pages/search/SearchPage.tsx
+++ b/admin/frontend/src/pages/search/SearchPage.tsx
@@ -16,7 +16,6 @@ import { SearchResultsSummary } from '@/pages/search/components/SearchResultsSum
 import { Route } from '@/routes';
 import { resolveAdminSearchRouteState } from '@/pages/search/utils/searchSchema';
 import './SearchPage.scss';
-import { useState } from 'react';
 
 export function SearchPage() {
   const search = resolveAdminSearchRouteState(Route.useSearch());
@@ -28,29 +27,14 @@ export function SearchPage() {
     activities: search.activities,
     status: search.status,
     access: search.access,
+    closestCommunity: search.closestCommunity,
     establishment_date_from: search.establishment_date_from,
     establishment_date_to: search.establishment_date_to,
     established: search.established,
   });
 
-  const [communityFilter, setCommunityFilter] = useState<string[]>([]);
-
-  const clearCommunityFilter = (value: string) => {
-    const communityId = value.split(':')[1];
-    if (communityId) {
-      setCommunityFilter((current) =>
-        current.filter((entry) => entry !== communityId),
-      );
-    }
-  };
-
   const addCommunityFilter = (communityId: string) => {
-    setCommunityFilter((current) => {
-      if (current.includes(communityId)) {
-        return current;
-      }
-      return [...current, communityId];
-    });
+    controller.addClosestCommunity(communityId);
   };
 
   return (
@@ -114,7 +98,6 @@ export function SearchPage() {
               search={search}
               controller={controller}
               showTrigger={false}
-              communityFilter={communityFilter}
             />
 
             <div className="d-flex flex-column flex-lg-row justify-content-between align-items-start gap-3 mb-3">
@@ -126,10 +109,7 @@ export function SearchPage() {
                 />
               </div>
               {controller.hasAppliedState && (
-                <AppliedFilterChips
-                  chips={controller.appliedFilterChips}
-                  onClearCommunity={clearCommunityFilter}
-                />
+                <AppliedFilterChips chips={controller.appliedFilterChips} />
               )}
             </div>
 

--- a/admin/frontend/src/pages/search/components/AppliedFilterChips.tsx
+++ b/admin/frontend/src/pages/search/components/AppliedFilterChips.tsx
@@ -6,12 +6,10 @@ import './AppliedFilterChips.scss';
 
 interface AppliedFilterChipsProps {
   chips: AdminAppliedFilterChip[];
-  onClearCommunity: (communityId: string) => void;
 }
 
 export function AppliedFilterChips({
   chips,
-  onClearCommunity,
 }: Readonly<AppliedFilterChipsProps>) {
   if (chips.length === 0) {
     return null;
@@ -24,10 +22,7 @@ export function AppliedFilterChips({
           key={chip.label}
           type="button"
           className="chip"
-          onClick={() => {
-            chip.onClear();
-            onClearCommunity(chip.key);
-          }}
+          onClick={chip.onClear}
           aria-label={`Clear ${chip.label}`}
         >
           {chip.label}

--- a/admin/frontend/src/pages/search/components/FilterAccordion.tsx
+++ b/admin/frontend/src/pages/search/components/FilterAccordion.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { Button, Col, Form, Row, Stack } from 'react-bootstrap';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faFilter } from '@fortawesome/free-solid-svg-icons';
@@ -33,7 +33,6 @@ interface FilterAccordionProps {
   search: AdminSearchRouteState;
   controller: FilterAccordionControllerProps;
   showTrigger?: boolean;
-  communityFilter: string[];
 }
 
 type FilterDraftState = EditableAdminSearchFilters;
@@ -61,7 +60,6 @@ export function FilterAccordion({
   search,
   controller,
   showTrigger = true,
-  communityFilter,
 }: Readonly<FilterAccordionProps>) {
   const {
     isFilterPanelOpen: isOpen,
@@ -103,21 +101,6 @@ export function FilterAccordion({
   const resetDraft = () => {
     setDraft(EMPTY_ADMIN_SEARCH_FILTERS);
   };
-
-  useEffect(() => {
-    setDraft((current) => ({ ...current, closestCommunity: communityFilter }));
-    onApply({
-      type: draft.type,
-      district: draft.district,
-      activities: draft.activities,
-      status: draft.status,
-      access: draft.access,
-      closestCommunity: communityFilter,
-      establishment_date_from: draft.establishment_date_from,
-      establishment_date_to: draft.establishment_date_to,
-    });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [communityFilter]);
 
   const renderedPanel = (
     <div

--- a/admin/frontend/src/pages/search/hooks/useAdminSearchController.ts
+++ b/admin/frontend/src/pages/search/hooks/useAdminSearchController.ts
@@ -234,6 +234,20 @@ export function useAdminSearchController(search: AdminSearchRouteState) {
         search.closestCommunity.filter((entry) => entry !== value),
       ),
     );
+  const addClosestCommunity = (value: string) => {
+    const nextValue = value.trim();
+
+    if (!nextValue || search.closestCommunity.includes(nextValue)) {
+      return;
+    }
+
+    updateSearch(
+      setAdminSearchClosestCommunityFilter(search, [
+        ...search.closestCommunity,
+        nextValue,
+      ]),
+    );
+  };
   const clearEstablishmentDateFrom = () =>
     updateSearch(setAdminSearchEstablishmentDateFromFilter(search, undefined));
   const clearEstablishmentDateTo = () =>
@@ -385,6 +399,7 @@ export function useAdminSearchController(search: AdminSearchRouteState) {
     clearActivity,
     clearStatus,
     clearAccess,
+    addClosestCommunity,
     clearClosestCommunity,
     clearEstablishmentDateFrom,
     clearEstablishmentDateTo,

--- a/admin/frontend/test/pages/admin-search-page/hooks/useAdminSearchController.test.tsx
+++ b/admin/frontend/test/pages/admin-search-page/hooks/useAdminSearchController.test.tsx
@@ -241,6 +241,22 @@ describe('useAdminSearchController', () => {
     expect(chipNo?.label).toBe('Established: No');
   });
 
+  it('uses raw established value when no known label mapping exists', () => {
+    const search = {
+      ...DEFAULT_ADMIN_SEARCH_STATE,
+      established: 'unknown',
+    };
+    const { result } = renderHook(() => useAdminSearchController(search), {
+      wrapper: createWrapper(),
+    });
+
+    const chip = result.current.appliedFilterChips.find(
+      (entry) => entry.key === 'established:unknown',
+    );
+
+    expect(chip?.label).toBe('Established: unknown');
+  });
+
   it('does not generate filter chip when established is undefined', () => {
     const search = {
       ...DEFAULT_ADMIN_SEARCH_STATE,
@@ -277,6 +293,70 @@ describe('useAdminSearchController', () => {
     });
   });
 
+  it('clears established filter when using the established chip clear action', () => {
+    const search = {
+      ...DEFAULT_ADMIN_SEARCH_STATE,
+      established: 'yes',
+    };
+    const { result } = renderHook(() => useAdminSearchController(search), {
+      wrapper: createWrapper(),
+    });
+
+    const chip = result.current.appliedFilterChips.find(
+      (entry) => entry.key === 'established:yes',
+    );
+
+    act(() => {
+      chip?.onClear();
+    });
+
+    expect(mockNavigate).toHaveBeenCalledWith({
+      to: '/',
+      search: {},
+      resetScroll: false,
+    });
+  });
+
+  it('adds a trimmed closest community when value is new', () => {
+    const search = {
+      ...DEFAULT_ADMIN_SEARCH_STATE,
+      closestCommunity: ['KAMLOOPS'],
+      page: 4,
+    };
+    const { result } = renderHook(() => useAdminSearchController(search), {
+      wrapper: createWrapper(),
+    });
+
+    act(() => {
+      result.current.addClosestCommunity('  WHISTLER  ');
+    });
+
+    expect(mockNavigate).toHaveBeenCalledWith({
+      to: '/',
+      search: {
+        closestCommunity: 'KAMLOOPS_WHISTLER',
+      },
+      resetScroll: false,
+    });
+  });
+
+  it('does not add closest community for empty or duplicate values', () => {
+    const search = {
+      ...DEFAULT_ADMIN_SEARCH_STATE,
+      closestCommunity: ['KAMLOOPS'],
+    };
+    const { result } = renderHook(() => useAdminSearchController(search), {
+      wrapper: createWrapper(),
+    });
+
+    act(() => {
+      result.current.addClosestCommunity('   ');
+      result.current.addClosestCommunity('KAMLOOPS');
+    });
+
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
   it('detects established filter as active filter', () => {
     const search = {
       ...DEFAULT_ADMIN_SEARCH_STATE,
@@ -302,6 +382,7 @@ describe('useAdminSearchController', () => {
         activities: [],
         status: [],
         access: [],
+        closestCommunity: [],
         establishment_date_from: undefined,
         establishment_date_to: undefined,
         established: 'yes',

--- a/admin/frontend/test/pages/search-page/SearchPage.test.tsx
+++ b/admin/frontend/test/pages/search-page/SearchPage.test.tsx
@@ -65,40 +65,16 @@ vi.mock('@/pages/search/components/SearchSubmitBar', () => ({
 }));
 
 vi.mock('@/pages/search/components/FilterAccordion', () => ({
-  FilterAccordion: ({
-    showTrigger,
-    communityFilter,
-  }: {
-    showTrigger: boolean;
-    communityFilter: string[];
-  }) => (
-    <div data-testid="community-filter">
-      {String(showTrigger)}|{communityFilter.join(',')}
-    </div>
+  FilterAccordion: ({ showTrigger }: { showTrigger: boolean }) => (
+    <div data-testid="community-filter">{String(showTrigger)}</div>
   ),
 }));
 
 vi.mock('@/pages/search/components/AppliedFilterChips', () => ({
-  AppliedFilterChips: ({
-    chips,
-    onClearCommunity,
-  }: {
-    chips: Array<{ label: string }>;
-    onClearCommunity: (value: string) => void;
-  }) => (
-    <>
-      <div data-testid="applied-filter-chips">
-        {chips.map((chip) => chip.label).join(',')}
-      </div>
-
-      <button
-        type="button"
-        data-testid="clear-community-button"
-        onClick={() => onClearCommunity('closestCommunity:WHISTLER')}
-      >
-        Clear community
-      </button>
-    </>
+  AppliedFilterChips: ({ chips }: { chips: Array<{ label: string }> }) => (
+    <div data-testid="applied-filter-chips">
+      {chips.map((chip) => chip.label).join(',')}
+    </div>
   ),
 }));
 
@@ -192,6 +168,8 @@ function buildController() {
       nextPage: vi.fn(),
     },
     setSort: vi.fn(),
+    applyFilters: vi.fn(),
+    addClosestCommunity: vi.fn(),
     establishedOptions: [
       { id: 'yes', label: 'Yes' },
       { id: 'no', label: 'No' },
@@ -267,27 +245,16 @@ describe('SearchPage', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('adds community filter', async () => {
+  it('adds community filter through the controller closest-community action', async () => {
     const user = userEvent.setup();
+    const controller = buildController();
+
+    mockController.mockReturnValue(controller);
 
     render(<SearchPage />);
 
     await user.click(screen.getByTestId('add-community-button'));
-    await user.click(screen.getByTestId('add-community-button'));
 
-    expect(screen.getByTestId('community-filter')).toHaveTextContent(
-      'WHISTLER',
-    );
-  });
-
-  it('clears community filter', async () => {
-    const user = userEvent.setup();
-
-    render(<SearchPage />);
-
-    await user.click(screen.getByTestId('add-community-button'));
-    await user.click(screen.getByTestId('clear-community-button'));
-
-    expect(screen.getByTestId('community-filter')).toHaveTextContent('false|');
+    expect(controller.addClosestCommunity).toHaveBeenCalledWith('WHISTLER');
   });
 });


### PR DESCRIPTION
Card: https://bcparksdigital.atlassian.net/browse/ORCA-890
The bug happened because Closest Community had two sources of truth:
- URL/search state (search.closestCommunity) - this is what should persist
- local React state in SearchPage (communityFilter) - this was temporary and resettable

**What went wrong:**
- FilterAccordion had an effect that always did onApply(... closestCommunity: communityFilter ...).
- On mount (or remount), communityFilter was often [] (especially after back nav or when closest was set via filter panel instead of typeahead).
- That effect then wrote [] back into URL state, clearing closestCommunity.
- Editing other filters changed the accordion key/remounted it, so the same effect ran again and wiped closest.
- Back navigation remounted page components, local communityFilter reset, then same wipe happened.
- So the core issue was: a local transient state was overwriting persisted route state.

Changes: 
- Removed that local communityFilter sync path.
- Kept Closest Community fully in controller/URL state.
- Added a controller method (addClosestCommunity) that reuses existing filter helper logic instead of rebuilding full filter objects in SearchPage.