### PR TITLE
feat: updated archived resource to make it view only

### DIFF
--- a/admin/frontend/src/components/auth/ArchiveGuard.tsx
+++ b/admin/frontend/src/components/auth/ArchiveGuard.tsx
@@ -1,0 +1,17 @@
+import { ReactNode } from 'react';
+
+export interface ArchiveGuardProps {
+  readonly isArchived: boolean;
+  readonly fallback?: ReactNode;
+  readonly children: ReactNode;
+}
+
+export function ArchiveGuard({
+  isArchived,
+  fallback = null,
+  children,
+}: Readonly<ArchiveGuardProps>) {
+  if (isArchived) return <>{fallback}</>;
+
+  return <>{children}</>;
+}

--- a/admin/frontend/src/components/auth/EditableGuard.tsx
+++ b/admin/frontend/src/components/auth/EditableGuard.tsx
@@ -1,0 +1,32 @@
+import { Role } from '@/hooks/useAuthorizations';
+import { ReactNode } from 'react';
+import { ArchiveGuard } from './ArchiveGuard';
+import { RoleGuard } from './RoleGuard';
+
+export interface EditableGuardProps {
+  readonly isArchived?: boolean;
+  readonly requireAll?: readonly Role[];
+  readonly requireAny?: readonly Role[];
+  readonly fallback?: ReactNode;
+  readonly children: ReactNode;
+}
+
+export function EditableGuard({
+  isArchived = false,
+  requireAll,
+  requireAny,
+  fallback = null,
+  children,
+}: Readonly<EditableGuardProps>) {
+  return (
+    <RoleGuard
+      requireAll={requireAll}
+      requireAny={requireAny}
+      fallback={fallback}
+    >
+      <ArchiveGuard isArchived={isArchived} fallback={fallback}>
+        {children}
+      </ArchiveGuard>
+    </RoleGuard>
+  );
+}

--- a/admin/frontend/src/components/auth/index.ts
+++ b/admin/frontend/src/components/auth/index.ts
@@ -1,5 +1,7 @@
 export * from './AuthGuard';
 export * from './AuthLayout';
+export * from './ArchiveGuard';
+export * from './EditableGuard';
 export * from './LoginPanel';
 export * from './RoleGuard';
 export * from './RoleRouteGuard';

--- a/admin/frontend/src/pages/rec-resource-page/RecResourceFilesPage.tsx
+++ b/admin/frontend/src/pages/rec-resource-page/RecResourceFilesPage.tsx
@@ -1,7 +1,8 @@
 import { CustomButton } from '@/components';
-import { RoleGuard } from '@/components/auth';
+import { EditableGuard } from '@/components/auth';
 import { ROLES } from '@/hooks/useAuthorizations';
 import { RecResourceFileSection } from '@/pages/rec-resource-page/components/RecResourceFileSection';
+import { useRecResource } from '@/pages/rec-resource-page/hooks/useRecResource';
 import { useRecResourceFileTransferState } from '@/pages/rec-resource-page/hooks/useRecResourceFileTransferState';
 import {
   faEllipsisH,
@@ -56,7 +57,7 @@ const ActionButton: FC<ActionButtonProps> = ({
   </CustomButton>
 );
 
-const ActionButtonsSection = () => {
+const ActionButtonsSection = ({ isArchived }: { isArchived: boolean }) => {
   const {
     isDocumentUploadDisabled,
     isImageUploadDisabled,
@@ -72,7 +73,7 @@ const ActionButtonsSection = () => {
     >
       <h2 className="mb-0">Files</h2>
 
-      <RoleGuard requireAll={[ROLES.ADMIN]}>
+      <EditableGuard requireAll={[ROLES.ADMIN]} isArchived={isArchived}>
         <>
           {/* Responsive actions: dropdown on mobile, buttons on desktop */}
           {/* Mobile: show dropdown */}
@@ -132,19 +133,22 @@ const ActionButtonsSection = () => {
             />
           </Stack>
         </>
-      </RoleGuard>
+      </EditableGuard>
     </Stack>
   );
 };
 
 export const RecResourceFilesPage = () => {
+  const { recResource } = useRecResource();
+  const isArchived = recResource?.rec_status_code === 'AR';
+
   return (
     <Stack direction="vertical" gap={4}>
-      <ActionButtonsSection />
-      <RoleGuard requireAll={[ROLES.ADMIN]}>
+      <ActionButtonsSection isArchived={isArchived} />
+      <EditableGuard requireAll={[ROLES.ADMIN]} isArchived={isArchived}>
         <InfoBanner />
-      </RoleGuard>
-      <RecResourceFileSection />
+      </EditableGuard>
+      <RecResourceFileSection isArchived={isArchived} />
     </Stack>
   );
 };

--- a/admin/frontend/src/pages/rec-resource-page/RecResourcePageLayout.tsx
+++ b/admin/frontend/src/pages/rec-resource-page/RecResourcePageLayout.tsx
@@ -56,23 +56,21 @@ export const RecResourcePageLayout = () => {
       aria-label="Recreation resource content"
     >
       <Breadcrumbs />
-      <ResourceHeaderSection recResource={recResource} />
-
       {isArchived && <ArchivedNotice />}
 
-      {!isArchived && (
-        <Row>
-          <Col md={3}>
-            <RecResourceVerticalNav
-              activeTab={activeTab}
-              resourceId={rec_resource_id}
-            />
-          </Col>
-          <Col md={9}>
-            <Outlet />
-          </Col>
-        </Row>
-      )}
+      <ResourceHeaderSection recResource={recResource} />
+
+      <Row>
+        <Col md={3}>
+          <RecResourceVerticalNav
+            activeTab={activeTab}
+            resourceId={rec_resource_id}
+          />
+        </Col>
+        <Col md={9}>
+          <Outlet />
+        </Col>
+      </Row>
     </Stack>
   );
 };

--- a/admin/frontend/src/pages/rec-resource-page/components/RecResourceActivitiesSection/RecResourceActivitiesSection.tsx
+++ b/admin/frontend/src/pages/rec-resource-page/components/RecResourceActivitiesSection/RecResourceActivitiesSection.tsx
@@ -1,6 +1,7 @@
 import { ROUTE_PATHS } from '@/constants/routes';
-import { RoleGuard } from '@/components/auth';
+import { EditableGuard } from '@/components/auth';
 import { ROLES } from '@/hooks/useAuthorizations';
+import { useRecResource } from '@/pages/rec-resource-page/hooks/useRecResource';
 import { RecreationActivityDto } from '@/services/recreation-resource-admin/models';
 import { Link, useParams } from '@tanstack/react-router';
 import { Stack } from 'react-bootstrap';
@@ -14,13 +15,15 @@ export const RecResourceActivitiesSection = ({
   recreationActivities,
 }: RecResourceActivitiesSectionProps) => {
   const { id: rec_resource_id } = useParams({ from: '/rec-resource/$id' });
+  const { recResource } = useRecResource();
+  const isArchived = recResource?.rec_status_code === 'AR';
 
   return (
     <Stack direction="vertical" gap={4}>
       <div className="d-flex justify-content-between align-items-center">
         <h2>Activities</h2>
 
-        <RoleGuard requireAll={[ROLES.ADMIN]}>
+        <EditableGuard requireAll={[ROLES.ADMIN]} isArchived={isArchived}>
           <Link
             to={ROUTE_PATHS.REC_RESOURCE_ACTIVITIES_FEATURES_EDIT.replace(
               '$id',
@@ -30,7 +33,7 @@ export const RecResourceActivitiesSection = ({
           >
             Edit
           </Link>
-        </RoleGuard>
+        </EditableGuard>
       </div>
 
       {!recreationActivities || recreationActivities.length === 0 ? (

--- a/admin/frontend/src/pages/rec-resource-page/components/RecResourceEstablishmentOrderSection/RecResourceEstablishmentOrderSection.tsx
+++ b/admin/frontend/src/pages/rec-resource-page/components/RecResourceEstablishmentOrderSection/RecResourceEstablishmentOrderSection.tsx
@@ -11,14 +11,17 @@ import { DocumentUploadModal } from '@/components/file/DocumentUploadModal';
 
 interface RecResourceEstablishmentOrderSectionProps {
   recResourceId: string;
+  isArchived?: boolean;
 }
 
 const MAX_UPLOADS = 30;
 
 export const RecResourceEstablishmentOrderSection = ({
   recResourceId,
+  isArchived = false,
 }: RecResourceEstablishmentOrderSectionProps) => {
   const { canEdit } = useAuthorizations();
+  const canModifyFiles = canEdit && !isArchived;
   const {
     galleryFiles,
     isLoading,
@@ -35,7 +38,8 @@ export const RecResourceEstablishmentOrderSection = ({
   } = useEstablishmentOrderState(recResourceId);
 
   const reachedMaxUploads = (galleryFiles?.length ?? 0) >= MAX_UPLOADS;
-  const uploadDisabled = !canEdit || isUploadDisabled || reachedMaxUploads;
+  const uploadDisabled =
+    !canModifyFiles || isUploadDisabled || reachedMaxUploads;
 
   return (
     <section>
@@ -54,14 +58,14 @@ export const RecResourceEstablishmentOrderSection = ({
         description="Documents are only accepted in PDF format with a 9.5 MB file size limit. Maximum 30 documents."
         items={galleryFiles}
         uploadLabel="Upload"
-        onFileUploadTileClick={canEdit ? handleUploadClick : undefined}
+        onFileUploadTileClick={canModifyFiles ? handleUploadClick : undefined}
         uploadDisabled={uploadDisabled}
-        showInfoBanner={canEdit}
+        showInfoBanner={canModifyFiles}
         renderItem={(file) => (
           <GalleryFileCard
             file={file}
             getFileActionHandler={handleFileAction}
-            actions={canEdit ? ESTABLISHMENT_ORDER_ACTIONS : []}
+            actions={canModifyFiles ? ESTABLISHMENT_ORDER_ACTIONS : []}
             topContent={
               <FontAwesomeIcon icon={faFilePdf} size="2x" color={COLOR_RED} />
             }

--- a/admin/frontend/src/pages/rec-resource-page/components/RecResourceFeesSection/RecResourceFeesContent.tsx
+++ b/admin/frontend/src/pages/rec-resource-page/components/RecResourceFeesSection/RecResourceFeesContent.tsx
@@ -1,5 +1,5 @@
 import { Stack } from 'react-bootstrap';
-import { RoleGuard } from '@/components/auth';
+import { EditableGuard } from '@/components/auth';
 import { RecResourceFeesTable } from '@/pages/rec-resource-page/components/RecResourceFeesSection/RecResourceFeesTable';
 import { ROUTE_PATHS } from '@/constants/routes';
 import { RecreationFeeUIModel } from '@/services';
@@ -9,16 +9,18 @@ import { Link } from '@tanstack/react-router';
 export const RecResourceFeesContent = ({
   fees,
   recResourceId,
+  isArchived,
 }: {
   fees: RecreationFeeUIModel[];
   recResourceId?: string;
+  isArchived?: boolean;
 }) => {
   return (
     <Stack direction="vertical" gap={4}>
       <div className="d-flex justify-content-between align-items-center">
         <h2>Fees</h2>
         <Stack direction="horizontal" gap={2}>
-          <RoleGuard requireAll={[ROLES.ADMIN]}>
+          <EditableGuard requireAll={[ROLES.ADMIN]} isArchived={isArchived}>
             {recResourceId ? (
               <Link
                 to={ROUTE_PATHS.REC_RESOURCE_FEES_ADD.replace(
@@ -30,12 +32,16 @@ export const RecResourceFeesContent = ({
                 Add Fee
               </Link>
             ) : null}
-          </RoleGuard>
+          </EditableGuard>
         </Stack>
       </div>
       <div className="rounded">
         <div className="fw-bold mb-4">Current Fee Information</div>
-        <RecResourceFeesTable fees={fees} recResourceId={recResourceId} />
+        <RecResourceFeesTable
+          fees={fees}
+          recResourceId={recResourceId}
+          isArchived={isArchived}
+        />
       </div>
     </Stack>
   );

--- a/admin/frontend/src/pages/rec-resource-page/components/RecResourceFeesSection/RecResourceFeesSection.tsx
+++ b/admin/frontend/src/pages/rec-resource-page/components/RecResourceFeesSection/RecResourceFeesSection.tsx
@@ -1,14 +1,23 @@
 import { Route } from '@/routes/rec-resource/$id/fees';
 import { RecResourceFeesContent } from '@/pages/rec-resource-page/components/RecResourceFeesSection/RecResourceFeesContent';
+import { useRecResource } from '@/pages/rec-resource-page/hooks/useRecResource';
 import { useGetFees } from '@/services/hooks/recreation-resource-admin/useGetFees';
 
 export const RecResourceFeesSection = () => {
   const { fees: initialFees } = Route.useLoaderData();
   const params = Route.useParams();
   const recResourceId = params?.id;
+  const { recResource } = useRecResource();
+  const isArchived = recResource?.rec_status_code === 'AR';
   const { data: fees = [] } = useGetFees(recResourceId, {
     initialData: initialFees,
   });
 
-  return <RecResourceFeesContent fees={fees} recResourceId={recResourceId} />;
+  return (
+    <RecResourceFeesContent
+      fees={fees}
+      recResourceId={recResourceId}
+      isArchived={isArchived}
+    />
+  );
 };

--- a/admin/frontend/src/pages/rec-resource-page/components/RecResourceFeesSection/RecResourceFeesTable.tsx
+++ b/admin/frontend/src/pages/rec-resource-page/components/RecResourceFeesSection/RecResourceFeesTable.tsx
@@ -15,11 +15,13 @@ import { addSuccessNotification } from '@/store/notificationStore';
 interface RecResourceFeesTableProps {
   fees: RecreationFeeUIModel[];
   recResourceId?: string;
+  isArchived?: boolean;
 }
 
 export const RecResourceFeesTable = ({
   fees,
   recResourceId,
+  isArchived = false,
 }: RecResourceFeesTableProps) => {
   const { canEdit } = useAuthorizations();
   const deleteFee = useDeleteFee();
@@ -102,7 +104,7 @@ export const RecResourceFeesTable = ({
     {
       header: 'Actions',
       render: (fee: RecreationFeeUIModel) => {
-        if (!canEdit || !recResourceId) return <span>--</span>;
+        if (!canEdit || isArchived || !recResourceId) return <span>--</span>;
         return (
           <div className="d-flex align-items-center gap-3">
             <Link

--- a/admin/frontend/src/pages/rec-resource-page/components/RecResourceFileSection/RecResourceFileSection.tsx
+++ b/admin/frontend/src/pages/rec-resource-page/components/RecResourceFileSection/RecResourceFileSection.tsx
@@ -30,8 +30,13 @@ import { PhotoDetailsModal } from './PhotoDetailsModal';
 import { EditPhotoModal } from './EditPhotoModal';
 import { GalleryAccordion } from '@/components/file/GalleryAccordion';
 
-export const RecResourceFileSection = () => {
+export const RecResourceFileSection = ({
+  isArchived = false,
+}: {
+  isArchived?: boolean;
+}) => {
   const { canEdit } = useAuthorizations();
+  const canModifyFiles = canEdit && !isArchived;
   const {
     getDocumentFileActionHandler,
     getDocumentGeneralActionHandler,
@@ -68,7 +73,7 @@ export const RecResourceFileSection = () => {
       }
       file={doc}
       getFileActionHandler={getDocumentFileActionHandler}
-      actions={canEdit ? undefined : DOCUMENT_VIEWER_CARD_ACTIONS}
+      actions={canModifyFiles ? undefined : DOCUMENT_VIEWER_CARD_ACTIONS}
     />
   );
 
@@ -79,9 +84,9 @@ export const RecResourceFileSection = () => {
       topContent={<img src={image.previewUrl} alt={image.name} />}
       file={image}
       getFileActionHandler={getImageFileActionHandler}
-      actions={canEdit ? IMAGE_CARD_ACTIONS : IMAGE_VIEWER_CARD_ACTIONS}
+      actions={canModifyFiles ? IMAGE_CARD_ACTIONS : IMAGE_VIEWER_CARD_ACTIONS}
       previewActions={
-        canEdit ? IMAGE_PREVIEW_ACTIONS : IMAGE_VIEWER_PREVIEW_ACTIONS
+        canModifyFiles ? IMAGE_PREVIEW_ACTIONS : IMAGE_VIEWER_PREVIEW_ACTIONS
       }
     />
   );
@@ -100,13 +105,15 @@ export const RecResourceFileSection = () => {
         uploadLabel="Upload"
         isLoading={isFetchingImages}
         onFileUploadTileClick={
-          canEdit ? getImageGeneralActionHandler('upload') : undefined
+          canModifyFiles ? getImageGeneralActionHandler('upload') : undefined
         }
         onFileDrop={
-          canEdit ? (file) => processSelectedFile(file, 'image') : undefined
+          canModifyFiles
+            ? (file) => processSelectedFile(file, 'image')
+            : undefined
         }
-        uploadDisabled={!canEdit || isImageUploadDisabled}
-        showInfoBanner={canEdit}
+        uploadDisabled={!canModifyFiles || isImageUploadDisabled}
+        showInfoBanner={canModifyFiles}
         renderItem={renderGalleryImageCard}
       />
       <GalleryAccordion<GalleryDocument>
@@ -121,13 +128,15 @@ export const RecResourceFileSection = () => {
         uploadLabel="Upload"
         isLoading={isFetching}
         onFileUploadTileClick={
-          canEdit ? getDocumentGeneralActionHandler('upload') : undefined
+          canModifyFiles ? getDocumentGeneralActionHandler('upload') : undefined
         }
         onFileDrop={
-          canEdit ? (file) => processSelectedFile(file, 'document') : undefined
+          canModifyFiles
+            ? (file) => processSelectedFile(file, 'document')
+            : undefined
         }
-        uploadDisabled={!canEdit || isDocumentUploadDisabled}
-        showInfoBanner={canEdit}
+        uploadDisabled={!canModifyFiles || isDocumentUploadDisabled}
+        showInfoBanner={canModifyFiles}
         renderItem={renderGalleryDocumentCard}
       />
 

--- a/admin/frontend/src/pages/rec-resource-page/components/RecResourceGeospatialSection/RecResourceGeospatialSection.tsx
+++ b/admin/frontend/src/pages/rec-resource-page/components/RecResourceGeospatialSection/RecResourceGeospatialSection.tsx
@@ -1,5 +1,5 @@
 import { Col, Row, Stack } from 'react-bootstrap';
-import { RoleGuard } from '@/components/auth';
+import { EditableGuard } from '@/components/auth';
 import { CopyButton } from '@shared/components/copy-button';
 import { FieldItem } from '../shared/FieldItem';
 import { RecResourceLocationSection } from '@/pages/rec-resource-page/components/RecResourceLocationSection';
@@ -19,6 +19,7 @@ export function RecResourceGeospatialSection() {
   const params = Route.useParams();
   const recResourceId = params?.id;
   const { recResource } = useRecResource();
+  const isArchived = recResource?.rec_status_code === 'AR';
 
   const { data: geospatialData } =
     useGetRecreationResourceGeospatial(recResourceId);
@@ -93,7 +94,7 @@ export function RecResourceGeospatialSection() {
       <div className="d-flex justify-content-between align-items-center">
         <h2>Geospatial</h2>
 
-        <RoleGuard requireAll={[ROLES.ADMIN]}>
+        <EditableGuard requireAll={[ROLES.ADMIN]} isArchived={isArchived}>
           {hasGeometryData && (
             <Link
               to={ROUTE_PATHS.REC_RESOURCE_GEOSPATIAL_EDIT.replace(
@@ -105,7 +106,7 @@ export function RecResourceGeospatialSection() {
               Edit
             </Link>
           )}
-        </RoleGuard>
+        </EditableGuard>
       </div>
 
       <div className="rec-resource-geospatial-section__body">

--- a/admin/frontend/src/pages/rec-resource-page/components/RecResourceOverviewSection/RecResourceOverviewSection.tsx
+++ b/admin/frontend/src/pages/rec-resource-page/components/RecResourceOverviewSection/RecResourceOverviewSection.tsx
@@ -1,5 +1,5 @@
 import { ROUTE_PATHS } from '@/constants/routes';
-import { RoleGuard } from '@/components/auth';
+import { EditableGuard } from '@/components/auth';
 import { ROLES } from '@/hooks/useAuthorizations';
 import { RecreationResourceDetailUIModel } from '@/services';
 import { Link } from '@tanstack/react-router';
@@ -17,6 +17,7 @@ export const RecResourceOverviewSection = (
   props: RecResourceOverviewSectionProps,
 ) => {
   const { recResource } = props;
+  const isArchived = recResource.rec_status_code === 'AR';
 
   const overviewItems = [
     {
@@ -61,7 +62,7 @@ export const RecResourceOverviewSection = (
       <div className="d-flex justify-content-between align-items-center">
         <h2>Overview</h2>
 
-        <RoleGuard requireAll={[ROLES.ADMIN]}>
+        <EditableGuard requireAll={[ROLES.ADMIN]} isArchived={isArchived}>
           <Link
             to={ROUTE_PATHS.REC_RESOURCE_OVERVIEW_EDIT.replace(
               '$id',
@@ -71,7 +72,7 @@ export const RecResourceOverviewSection = (
           >
             Edit
           </Link>
-        </RoleGuard>
+        </EditableGuard>
       </div>
 
       <Row>
@@ -121,6 +122,7 @@ export const RecResourceOverviewSection = (
 
       <RecResourceEstablishmentOrderSection
         recResourceId={recResource.rec_resource_id}
+        isArchived={isArchived}
       />
 
       {recResource && <RecResourceLocationSection recResource={recResource} />}

--- a/admin/frontend/src/pages/rec-resource-page/components/RecResourceReservationSection/RecResourceReservationSection.tsx
+++ b/admin/frontend/src/pages/rec-resource-page/components/RecResourceReservationSection/RecResourceReservationSection.tsx
@@ -1,6 +1,7 @@
 import { ROUTE_PATHS } from '@/constants/routes';
-import { RoleGuard } from '@/components/auth';
+import { EditableGuard } from '@/components/auth';
 import { RecreationResourceReservationInfoDto } from '@/services';
+import { useRecResource } from '@/pages/rec-resource-page/hooks/useRecResource';
 import { Link } from '@tanstack/react-router';
 import { Col, Row, Stack } from 'react-bootstrap';
 import { Route } from '@/routes/rec-resource/$id/reservation';
@@ -21,6 +22,8 @@ export const RecResourceReservationSection = (
 ) => {
   const params = Route.useParams();
   const recResourceId = params?.id;
+  const { recResource } = useRecResource();
+  const isArchived = recResource?.rec_status_code === 'AR';
   const { reservationInfo } = props;
   const reservationMethodKey = getReservationMethod(reservationInfo);
   const reservationMethod = reservationMethodKey
@@ -60,7 +63,7 @@ export const RecResourceReservationSection = (
       <div className="reservation-section__header d-flex justify-content-between align-items-center">
         <h2 className="mb-0">Reservations</h2>
 
-        <RoleGuard requireAll={[ROLES.ADMIN]}>
+        <EditableGuard requireAll={[ROLES.ADMIN]} isArchived={isArchived}>
           <Link
             to={ROUTE_PATHS.REC_RESOURCE_RESERVATION_EDIT.replace(
               '$id',
@@ -70,7 +73,7 @@ export const RecResourceReservationSection = (
           >
             Edit
           </Link>
-        </RoleGuard>
+        </EditableGuard>
       </div>
 
       <div className="reservation-panel">

--- a/admin/frontend/test/components/auth/ArchiveGuard.test.tsx
+++ b/admin/frontend/test/components/auth/ArchiveGuard.test.tsx
@@ -1,0 +1,36 @@
+import { ArchiveGuard } from '@/components/auth/ArchiveGuard';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+describe('ArchiveGuard', () => {
+  it('renders children when resource is not archived', () => {
+    render(
+      <ArchiveGuard isArchived={false}>
+        <div>Editable content</div>
+      </ArchiveGuard>,
+    );
+
+    expect(screen.getByText('Editable content')).toBeInTheDocument();
+  });
+
+  it('hides children when resource is archived', () => {
+    render(
+      <ArchiveGuard isArchived>
+        <div>Editable content</div>
+      </ArchiveGuard>,
+    );
+
+    expect(screen.queryByText('Editable content')).not.toBeInTheDocument();
+  });
+
+  it('renders fallback when archived', () => {
+    render(
+      <ArchiveGuard isArchived fallback={<div>Read-only</div>}>
+        <div>Editable content</div>
+      </ArchiveGuard>,
+    );
+
+    expect(screen.queryByText('Editable content')).not.toBeInTheDocument();
+    expect(screen.getByText('Read-only')).toBeInTheDocument();
+  });
+});

--- a/admin/frontend/test/components/auth/EditableGuard.test.tsx
+++ b/admin/frontend/test/components/auth/EditableGuard.test.tsx
@@ -1,0 +1,39 @@
+import { EditableGuard } from '@/components/auth/EditableGuard';
+import { render, screen } from '@testing-library/react';
+import { createAuthWrapper } from '@test/routes/helpers/roleGuardTestHelper';
+import { describe, expect, it } from 'vitest';
+
+describe('EditableGuard', () => {
+  it('renders children when user has access and resource is not archived', () => {
+    render(
+      <EditableGuard requireAll={['rst-admin']} isArchived={false}>
+        <div>Edit action</div>
+      </EditableGuard>,
+      { wrapper: createAuthWrapper(['rst-admin']) },
+    );
+
+    expect(screen.getByText('Edit action')).toBeInTheDocument();
+  });
+
+  it('hides children when resource is archived', () => {
+    render(
+      <EditableGuard requireAll={['rst-admin']} isArchived>
+        <div>Edit action</div>
+      </EditableGuard>,
+      { wrapper: createAuthWrapper(['rst-admin']) },
+    );
+
+    expect(screen.queryByText('Edit action')).not.toBeInTheDocument();
+  });
+
+  it('hides children when role check fails', () => {
+    render(
+      <EditableGuard requireAll={['rst-admin']} isArchived={false}>
+        <div>Edit action</div>
+      </EditableGuard>,
+      { wrapper: createAuthWrapper(['rst-viewer']) },
+    );
+
+    expect(screen.queryByText('Edit action')).not.toBeInTheDocument();
+  });
+});

--- a/admin/frontend/test/pages/rec-resource-page/RecResourceFilesPage.test.tsx
+++ b/admin/frontend/test/pages/rec-resource-page/RecResourceFilesPage.test.tsx
@@ -17,6 +17,11 @@ vi.mock('@/hooks/useAuthorizations', () => ({
 const mockUseRecResourceFileTransferState = vi.fn();
 const mockGetImageGeneralActionHandler = vi.fn();
 const mockGetDocumentGeneralActionHandler = vi.fn();
+const mockUseRecResource = vi.fn();
+
+vi.mock('@/pages/rec-resource-page/hooks/useRecResource', () => ({
+  useRecResource: () => mockUseRecResource(),
+}));
 
 // Mock the useRecResourceFileTransferState hook
 vi.mock(
@@ -74,6 +79,11 @@ describe('RecResourceFilesPage', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockUseRecResource.mockReturnValue({
+      recResource: { rec_status_code: 'OP' },
+      isLoading: false,
+      error: null,
+    });
     mockUseAuthorizations.mockReturnValue({
       canView: true,
       canEdit: true,

--- a/admin/frontend/test/pages/rec-resource-page/RecResourcePageLayout.test.tsx
+++ b/admin/frontend/test/pages/rec-resource-page/RecResourcePageLayout.test.tsx
@@ -379,7 +379,7 @@ describe('RecResourcePageLayout', () => {
     );
   });
 
-  it('renders ArchivedNotice and hides nav/outlet when resource is archived', async () => {
+  it('renders ArchivedNotice and keeps nav/outlet visible when resource is archived', async () => {
     const mockResource = {
       name: 'Test Resource',
       rec_resource_id: '123',
@@ -397,9 +397,9 @@ describe('RecResourcePageLayout', () => {
     await waitFor(() => {
       expect(screen.getByTestId('archived-notice')).toBeInTheDocument();
       expect(
-        screen.queryByTestId('rec-resource-vertical-nav'),
-      ).not.toBeInTheDocument();
-      expect(screen.queryByTestId('outlet')).not.toBeInTheDocument();
+        screen.getByTestId('rec-resource-vertical-nav'),
+      ).toBeInTheDocument();
+      expect(screen.getByTestId('outlet')).toBeInTheDocument();
     });
   });
 

--- a/admin/frontend/test/pages/rec-resource-page/components/RecResourceActivitiesSection/RecResourceActivitiesSection.test.tsx
+++ b/admin/frontend/test/pages/rec-resource-page/components/RecResourceActivitiesSection/RecResourceActivitiesSection.test.tsx
@@ -18,9 +18,14 @@ vi.mock('@tanstack/react-router', async (importOriginal) => {
 });
 
 vi.mock('@/components/auth', () => ({
-  RoleGuard: ({ children }: any) => (
+  EditableGuard: ({ children }: any) => (
     <div data-testid="role-guard">{children}</div>
   ),
+}));
+
+const mockUseRecResource = vi.fn();
+vi.mock('@/pages/rec-resource-page/hooks/useRecResource', () => ({
+  useRecResource: () => mockUseRecResource(),
 }));
 
 const mockUseAuthorizations = vi.fn();
@@ -52,6 +57,12 @@ describe('RecResourceActivitiesSection', () => {
     vi.mocked(useParams).mockReturnValue({
       id: 'test-resource-123',
     } as any);
+
+    mockUseRecResource.mockReturnValue({
+      recResource: { rec_status_code: 'OP' },
+      isLoading: false,
+      error: null,
+    });
   });
 
   it('renders section title', () => {

--- a/admin/frontend/test/pages/rec-resource-page/components/RecResourceFeesSection/EditSection/RecResourceFeesEditSection.test.tsx
+++ b/admin/frontend/test/pages/rec-resource-page/components/RecResourceFeesSection/EditSection/RecResourceFeesEditSection.test.tsx
@@ -37,6 +37,7 @@ vi.mock('@/hooks/useAuthorizations', () => ({
 
 vi.mock('@/components/auth', () => ({
   RoleGuard: ({ children }: any) => <>{children}</>,
+  EditableGuard: ({ children }: any) => <>{children}</>,
 }));
 
 const mockFees = [

--- a/admin/frontend/test/pages/rec-resource-page/components/RecResourceFeesSection/RecResourceFeesContent.test.tsx
+++ b/admin/frontend/test/pages/rec-resource-page/components/RecResourceFeesSection/RecResourceFeesContent.test.tsx
@@ -7,7 +7,7 @@ vi.mock('@tanstack/react-router', () => ({
 }));
 
 vi.mock('@/components/auth', () => ({
-  RoleGuard: ({ children }: any) => <>{children}</>,
+  EditableGuard: ({ children }: any) => <>{children}</>,
 }));
 
 const mockUseAuthorizations = vi.fn();

--- a/admin/frontend/test/pages/rec-resource-page/components/RecResourceFeesSection/RecResourceFeesSection.test.tsx
+++ b/admin/frontend/test/pages/rec-resource-page/components/RecResourceFeesSection/RecResourceFeesSection.test.tsx
@@ -42,6 +42,22 @@ vi.mock('@/components/auth', () => ({
 
     return <>{children}</>;
   },
+  EditableGuard: ({ children, requireAll, isArchived }: any) => {
+    const auth = mockUseAuthorizations();
+    const isAdminGuard =
+      Array.isArray(requireAll) && requireAll.includes('rst-admin');
+
+    if ((isAdminGuard && !auth.canEdit) || isArchived) {
+      return null;
+    }
+
+    return <>{children}</>;
+  },
+}));
+
+const mockUseRecResource = vi.fn();
+vi.mock('@/pages/rec-resource-page/hooks/useRecResource', () => ({
+  useRecResource: () => mockUseRecResource(),
 }));
 
 const mockFees = [
@@ -110,6 +126,11 @@ vi.mock('@tanstack/react-router', async () => {
 describe('RecResourceFeesSection', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockUseRecResource.mockReturnValue({
+      recResource: { rec_status_code: 'OP' },
+      isLoading: false,
+      error: null,
+    });
     mockUseAuthorizations.mockReturnValue({
       canView: true,
       canEdit: true,

--- a/admin/frontend/test/pages/rec-resource-page/components/RecResourceGeospatialSection/RecResourceGeospatialSection.test.tsx
+++ b/admin/frontend/test/pages/rec-resource-page/components/RecResourceGeospatialSection/RecResourceGeospatialSection.test.tsx
@@ -33,7 +33,7 @@ vi.mock(
 );
 
 vi.mock('@/components/auth', () => ({
-  RoleGuard: ({ children }: any) => <>{children}</>,
+  EditableGuard: ({ children }: any) => <>{children}</>,
 }));
 
 const mockUseAuthorizations = vi.fn();
@@ -70,7 +70,7 @@ describe('RecResourceGeospatialSection', () => {
 
     mockUseRecResource.mockReturnValue({
       rec_resource_id: 'REC0001',
-      recResource: {},
+      recResource: { rec_status_code: 'OP' },
       isLoading: false,
       error: undefined,
     });

--- a/admin/frontend/test/pages/rec-resource-page/components/RecResourceOverviewSection/RecResourceOverviewSection.test.tsx
+++ b/admin/frontend/test/pages/rec-resource-page/components/RecResourceOverviewSection/RecResourceOverviewSection.test.tsx
@@ -74,6 +74,8 @@ describe('RecResourceOverviewSection', () => {
   });
 
   const recResource = {
+    rec_resource_id: '00000000-0000-0000-0000-000000000000',
+    rec_status_code: 'OP',
     description: '<b>Test Description</b>',
     closest_community: 'Test Community',
     natural_resource_org_unit_name: 'Test Natural Resource District',
@@ -348,6 +350,18 @@ describe('RecResourceOverviewSection', () => {
     expect(
       screen.getByText('RecResourceEstablishmentOrderSection'),
     ).toBeInTheDocument();
+  });
+
+  it('hides Edit action for archived resources', () => {
+    renderWithProvider(
+      <RecResourceOverviewSection
+        recResource={{ ...recResource, rec_status_code: 'AR' }}
+      />,
+    );
+
+    expect(
+      screen.queryByRole('link', { name: 'Edit' }),
+    ).not.toBeInTheDocument();
   });
 
   it('renders the Establishment Order section regardless of flagged-content access', () => {

--- a/admin/frontend/test/pages/rec-resource-page/components/RecResourceReservationSection/RecResourceReservationSection.test.tsx
+++ b/admin/frontend/test/pages/rec-resource-page/components/RecResourceReservationSection/RecResourceReservationSection.test.tsx
@@ -12,7 +12,12 @@ vi.mock('@/routes/rec-resource/$id/reservation', () => ({
 }));
 
 vi.mock('@/components/auth', () => ({
-  RoleGuard: ({ children }: any) => <>{children}</>,
+  EditableGuard: ({ children }: any) => <>{children}</>,
+}));
+
+const mockUseRecResource = vi.fn();
+vi.mock('@/pages/rec-resource-page/hooks/useRecResource', () => ({
+  useRecResource: () => mockUseRecResource(),
 }));
 
 const mockUseAuthorizations = vi.fn();
@@ -57,6 +62,11 @@ describe('RecResourceReservationSection', () => {
       canEditFeatureFlag: true,
     });
     vi.mocked(Route.useParams).mockReturnValue({ id: 'REC123' });
+    mockUseRecResource.mockReturnValue({
+      recResource: { rec_status_code: 'OP' },
+      isLoading: false,
+      error: null,
+    });
   });
 
   it('renders correctly when reservationInfo is null', () => {


### PR DESCRIPTION
**Card :** https://bcparksdigital.atlassian.net/browse/ORCA-914

Introduced ArchivedGuard and combined it with RoleGuard into a new, reusable EditableGuard. Updated all page routes and tests to use this new logic, ensuring archived resources are strictly read-only.

**How to Test**
- Go to http://localhost:3001 and open an Archived resource.
- Verify: You should see the top banner and the archived pill.
- Verify: Ensure all fields are disabled and absolutely nothing is editable.