### PR TITLE
chore: fix beta subdomain

### DIFF
--- a/infrastructure/dns/main.tf
+++ b/infrastructure/dns/main.tf
@@ -77,6 +77,18 @@ resource "aws_route53_record" "www" {
     evaluate_target_health = false
   }
 }
+# A record for beta subdomain -> Public CloudFront
+resource "aws_route53_record" "beta" {
+  zone_id = aws_route53_zone.main.zone_id
+  name    = "beta.${var.domain_name}"
+  type    = "A"
+
+  alias {
+    name                   = data.terraform_remote_state.public_frontend.outputs.cloudfront.domain_name
+    zone_id                = local.cloudfront_hosted_zone_id
+    evaluate_target_health = false
+  }
+}
 
 # A record for staff subdomain -> Admin CloudFront
 resource "aws_route53_record" "staff" {

--- a/infrastructure/frontend/cloudfront.tf
+++ b/infrastructure/frontend/cloudfront.tf
@@ -141,6 +141,15 @@ resource "aws_cloudfront_distribution" "s3_distribution" {
       }
     }
 
+    dynamic "function_association" {
+      # Iterate over the list of function ARNs when in prod; otherwise empty
+      for_each = var.app_env == "prod" ? toset(aws_cloudfront_function.beta_to_sites_and_trails[*].arn) : []
+      content {
+        event_type  = "viewer-request"
+        function_arn = function_association.value
+      }
+    }
+
     viewer_protocol_policy = "redirect-to-https"
     min_ttl                = 0
     default_ttl            = 3600

--- a/infrastructure/frontend/cloudfront_function.tf
+++ b/infrastructure/frontend/cloudfront_function.tf
@@ -1,0 +1,10 @@
+// Create a CloudFront Function for beta -> main domain redirect
+resource "aws_cloudfront_function" "beta_to_sites_and_trails" {
+  # Create only in prod
+  count   = var.app_env == "prod" ? 1 : 0
+  name    = "beta-to-sitesandtrails-redirect"
+  runtime = "cloudfront-js-2.0"
+  comment = "Redirect beta.sitesandtrailsbc.ca to sitesandtrailsbc.ca (prod only)"
+  publish = true
+  code    = file("${path.module}/cloudfront_functions/betaToSitesAndTrails.js")
+}

--- a/infrastructure/frontend/cloudfront_functions/betaToSitesAndTrails.js
+++ b/infrastructure/frontend/cloudfront_functions/betaToSitesAndTrails.js
@@ -1,0 +1,19 @@
+/* eslint-disable @typescript-eslint/no-unused-vars -- `handler` is used by the CloudFront runtime */
+function handler(event) {
+  const request = event.request;
+  const host = request.headers.host.value;
+
+  // Check if the request is coming to the beta subdomain
+  if (host === 'beta.sitesandtrailsbc.ca') {
+    return {
+      statusCode: 301,
+      statusDescription: 'Moved Permanently',
+      headers: {
+        location: { value: 'https://sitesandtrailsbc.ca' + request.uri },
+      },
+    };
+  }
+
+  // If it's already the main domain, let it pass through
+  return request;
+}

--- a/terraform/frontend/public-prod/terragrunt.hcl
+++ b/terraform/frontend/public-prod/terragrunt.hcl
@@ -9,7 +9,7 @@ generate "prod_tfvars" {
   disable_signature = true
   contents          = <<-EOF
   target_env = "prod"
-  custom_domains = ["sitesandtrailsbc.ca", "www.sitesandtrailsbc.ca"]
+  custom_domains = ["beta.sitesandtrailsbc.ca","sitesandtrailsbc.ca", "www.sitesandtrailsbc.ca"]
   csp_urls = {
       connect_src = "https://bcparks.api.gov.bc.ca"
       matomo_src = "https://iuqxrr50zl.execute-api.ca-central-1.amazonaws.com https://y09s3hx8j6.execute-api.ca-central-1.amazonaws.com"


### PR DESCRIPTION
Card: https://bcparksdigital.atlassian.net/browse/ORCA-938
PR to add back beta subdomain and cloudfront functions for redirecting beta.sitesandtrailsbc.ca to sitesandtrailsbc.ca

To test
I have added the function directly in cloudfront, https://beta.sitesandtrailsbc.ca/ redirects to https://sitesandtrailsbc.ca/