### PR TITLE
chore: added sorting fields

### DIFF
--- a/admin/backend/prisma/schema.prisma
+++ b/admin/backend/prisma/schema.prisma
@@ -1321,6 +1321,10 @@ model act_advisories_flat {
   modified_date               DateTime                 @db.Timestamptz(6)
   published_at                DateTime?                @db.Timestamptz(6)
   sys_period                  Unsupported("tstzrange") @default(dbgenerated("tstzrange(CURRENT_TIMESTAMP, NULL::timestamp with time zone)"))
+  listing_rank                Int                      @default(0)
+  urgency_sequence            Int                      @default(0)
+  access_status_precedence    Int                      @default(0)
+  event_type_precedence       Int                      @default(0)
   recreation_resource         recreation_resource      @relation(fields: [rec_resource_id], references: [rec_resource_id], onDelete: NoAction, onUpdate: NoAction)
 
   @@id([rec_resource_id, advisory_number])

--- a/migrations/rst/sql/V1.1.71__advisories_table_extra_fields.sql
+++ b/migrations/rst/sql/V1.1.71__advisories_table_extra_fields.sql
@@ -1,0 +1,10 @@
+ALTER TABLE rst.act_advisories_flat
+    ADD COLUMN listing_rank integer NOT NULL DEFAULT 0,
+    ADD COLUMN urgency_sequence integer NOT NULL DEFAULT 0,
+    ADD COLUMN access_status_precedence integer NOT NULL DEFAULT 0,
+    ADD COLUMN event_type_precedence integer NOT NULL DEFAULT 0;
+
+comment on column rst.act_advisories_flat.listing_rank is 'Rank for ordering advisories in listings, calculated based on urgency, access status, and event type to ensure the most critical advisories are displayed prominently.';
+comment on column rst.act_advisories_flat.urgency_sequence is 'Sequence number for the urgency level associated with the advisory.';
+comment on column rst.act_advisories_flat.access_status_precedence is 'Precedence level for the access status associated with the advisory.';
+comment on column rst.act_advisories_flat.event_type_precedence is 'Precedence level for the event type associated with the advisory.';

--- a/public/backend/prisma/schema.prisma
+++ b/public/backend/prisma/schema.prisma
@@ -1321,6 +1321,10 @@ model act_advisories_flat {
   modified_date               DateTime                 @db.Timestamptz(6)
   published_at                DateTime?                @db.Timestamptz(6)
   sys_period                  Unsupported("tstzrange") @default(dbgenerated("tstzrange(CURRENT_TIMESTAMP, NULL::timestamp with time zone)"))
+  listing_rank                Int                      @default(0)
+  urgency_sequence            Int                      @default(0)
+  access_status_precedence    Int                      @default(0)
+  event_type_precedence       Int                      @default(0)
   recreation_resource         recreation_resource      @relation(fields: [rec_resource_id], references: [rec_resource_id], onDelete: NoAction, onUpdate: NoAction)
 
   @@id([rec_resource_id, advisory_number])


### PR DESCRIPTION
Added extra fields to comply with this findings:

We got update from team Lynx:
 listingRank can be used for that purpose.
For example, Cape Scott Park has 4 advisories, and "Holberg Road closed due to landslide" has a listingRank of 100: https://alpha-test-cms.bcparks.ca/api/public-advisories?filters[$and][0][protectedAreas][protectedA… 
As a result, that advisory appears first in the advisories section on the Park page: https://alpha-test.bcparks.ca/cape-scott-park/
We also use urgency.sequence, accessStatus.precedence, eventType.precedence, advisoryDate to sort advisories

Thanks @ayeshmcg 