### PR TITLE
feat: ORCA-932 public access status column

### DIFF
--- a/admin/backend/src/recreation-resources/dtos/admin-search-query.dto.ts
+++ b/admin/backend/src/recreation-resources/dtos/admin-search-query.dto.ts
@@ -36,6 +36,8 @@ export const ADMIN_SEARCH_SORT_VALUES = [
   'district:desc',
   'display_on_public_site:asc',
   'display_on_public_site:desc',
+  'public_access_status:asc',
+  'public_access_status:desc',
 ] as const;
 
 export const ADMIN_SEARCH_PAGE_SIZE_VALUES = [25, 50, 100] as const;
@@ -174,4 +176,15 @@ export class AdminSearchQueryDto {
   @IsOptional()
   @IsIn(['yes', 'no'])
   established?: string;
+
+  @ApiPropertyOptional({
+    description: 'Public access status group labels',
+    type: [String],
+    example: ['Open', 'Closed'],
+  })
+  @Transform(transformStringArrayQueryParam)
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  public_access_status?: string[];
 }

--- a/admin/backend/src/recreation-resources/dtos/admin-search-response.dto.ts
+++ b/admin/backend/src/recreation-resources/dtos/admin-search-response.dto.ts
@@ -99,6 +99,15 @@ export class AdminSearchResultRowDto {
     example: 24,
   })
   campsite_count: number;
+
+  @ApiProperty({
+    description: 'Public access status group label from ACT advisories',
+    example: 'Open',
+    required: false,
+    nullable: true,
+    type: String,
+  })
+  access_status_grouplabel?: string | null;
 }
 
 export class AdminSearchResponseDto {

--- a/admin/backend/src/recreation-resources/queries/recreation-resource-search.queries.ts
+++ b/admin/backend/src/recreation-resources/queries/recreation-resource-search.queries.ts
@@ -5,6 +5,15 @@ import {
 } from '../dtos/admin-search-query.dto';
 import { OPEN_STATUS } from '../recreation-resource.constants';
 
+const ADVISORY_ORDER_SQL = Prisma.sql`
+  af.listing_rank DESC,
+  af.urgency_sequence DESC,
+  af.access_status_precedence ASC,
+  af.updated_date DESC,
+  af.advisory_date DESC,
+  af.event_type_precedence ASC
+`;
+
 export const SORT_FIELD_MAP: Record<
   AdminSearchSort,
   Prisma.recreation_resourceOrderByWithRelationInput
@@ -49,6 +58,8 @@ export const SORT_FIELD_MAP: Record<
   'fee:desc': { name: 'desc' },
   'display_on_public_site:asc': { display_on_public_site: 'asc' },
   'display_on_public_site:desc': { display_on_public_site: 'desc' },
+  'public_access_status:asc': { name: 'asc' },
+  'public_access_status:desc': { name: 'desc' },
 };
 
 // These sorts depend on aggregated related data, so they use the raw SQL path
@@ -64,9 +75,17 @@ export const RAW_SQL_SORTS = new Set<AdminSearchSort>([
   'access:desc',
   'fee:asc',
   'fee:desc',
+  'public_access_status:asc',
+  'public_access_status:desc',
 ]);
 
-type DerivedSortField = 'status' | 'type' | 'activities' | 'access' | 'fee';
+type DerivedSortField =
+  | 'status'
+  | 'type'
+  | 'activities'
+  | 'access'
+  | 'fee'
+  | 'public_access_status';
 
 type DerivedSortQueryParts = {
   joinsSql: Prisma.Sql;
@@ -185,6 +204,20 @@ export function buildSearchWhereSql(query: AdminSearchQueryDto): Prisma.Sql {
     buildDateCondition(query.establishment_date_from, '>='),
     buildDateCondition(query.establishment_date_to, '<='),
     buildEstablishedCondition(query.established),
+    query.public_access_status?.length
+      ? Prisma.sql`
+        COALESCE(
+          (
+            SELECT af.access_status_grouplabel
+            FROM rst.act_advisories_flat af
+            WHERE af.rec_resource_id = rr.rec_resource_id
+            ORDER BY ${ADVISORY_ORDER_SQL}
+            LIMIT 1
+          ),
+          'Open'
+        ) IN (${Prisma.join(query.public_access_status)})
+      `
+      : null,
   ].filter((condition): condition is Prisma.Sql => condition !== null);
 
   if (conditions.length === 0) {
@@ -290,6 +323,24 @@ export function buildDerivedSortQueryParts(
           ) fee_agg ON TRUE
         `,
         orderBySql: Prisma.sql`COALESCE(fee_agg.fee_values, '') ${directionSql}`,
+      };
+    case 'public_access_status':
+      return {
+        joinsSql: Prisma.sql`
+          LEFT JOIN LATERAL (
+            SELECT COALESCE(
+              (
+                SELECT af.access_status_grouplabel
+                FROM rst.act_advisories_flat af
+                WHERE af.rec_resource_id = rr.rec_resource_id
+                ORDER BY ${ADVISORY_ORDER_SQL}
+                LIMIT 1
+              ),
+              'Open'
+            ) AS public_access_status
+          ) advisory_status ON TRUE
+        `,
+        orderBySql: Prisma.sql`advisory_status.public_access_status ${directionSql}`,
       };
   }
 }

--- a/admin/backend/src/recreation-resources/queries/recreation-resource-search.queries.ts
+++ b/admin/backend/src/recreation-resources/queries/recreation-resource-search.queries.ts
@@ -80,6 +80,13 @@ export const RAW_SQL_SORTS = new Set<AdminSearchSort>([
 ]);
 
 type DerivedSortField =
+  | 'name'
+  | 'rec_resource_id'
+  | 'established_date'
+  | 'community'
+  | 'campsites'
+  | 'district'
+  | 'display_on_public_site'
   | 'status'
   | 'type'
   | 'activities'
@@ -237,6 +244,50 @@ export function buildDerivedSortQueryParts(
   const directionSql = direction === 'asc' ? Prisma.sql`ASC` : Prisma.sql`DESC`;
 
   switch (field) {
+    case 'name':
+      return {
+        joinsSql: Prisma.empty,
+        orderBySql: Prisma.sql`rr.name ${directionSql}`,
+      };
+    case 'rec_resource_id':
+      return {
+        joinsSql: Prisma.empty,
+        orderBySql: Prisma.sql`rr.rec_resource_id ${directionSql}`,
+      };
+    case 'established_date':
+      return {
+        joinsSql: Prisma.empty,
+        orderBySql: Prisma.sql`rr.project_established_date ${directionSql}`,
+      };
+    case 'community':
+      return {
+        joinsSql: Prisma.empty,
+        orderBySql: Prisma.sql`rr.closest_community ${directionSql}`,
+      };
+    case 'display_on_public_site':
+      return {
+        joinsSql: Prisma.empty,
+        orderBySql: Prisma.sql`rr.display_on_public_site ${directionSql}`,
+      };
+    case 'campsites':
+      return {
+        joinsSql: Prisma.sql`
+          LEFT JOIN LATERAL (
+            SELECT COUNT(*) AS campsite_count
+            FROM rst.recreation_defined_campsite rdc
+            WHERE rdc.rec_resource_id = rr.rec_resource_id
+          ) campsite_agg ON TRUE
+        `,
+        orderBySql: Prisma.sql`campsite_agg.campsite_count ${directionSql}`,
+      };
+    case 'district':
+      return {
+        joinsSql: Prisma.sql`
+          LEFT JOIN rst.recreation_district_code rdco
+            ON rdco.district_code = rr.district_code
+        `,
+        orderBySql: Prisma.sql`COALESCE(rdco.description, '') ${directionSql}`,
+      };
     case 'status':
       return {
         joinsSql: Prisma.sql`

--- a/admin/backend/src/recreation-resources/recreation-resource.repository.ts
+++ b/admin/backend/src/recreation-resources/recreation-resource.repository.ts
@@ -60,7 +60,7 @@ export class RecreationResourceRepository {
     const pageSize = query.page_size ?? ADMIN_SEARCH_PAGE_SIZE_VALUES[0];
     const sort = query.sort ?? 'name:asc';
 
-    if (RAW_SQL_SORTS.has(sort)) {
+    if (RAW_SQL_SORTS.has(sort) || query.public_access_status?.length) {
       return this.searchResourcesWithDerivedSort(query, page, pageSize, sort);
     }
 
@@ -262,27 +262,6 @@ export class RecreationResourceRepository {
     };
   }
 
-  private buildPublicAccessStatusWhere(
-    publicAccessStatus?: string[],
-  ): Prisma.recreation_resourceWhereInput | null {
-    if (!publicAccessStatus?.length) return null;
-
-    const includesOpen = publicAccessStatus.includes('Open');
-    const conditions: Prisma.recreation_resourceWhereInput[] = [
-      {
-        act_advisories_flat: {
-          some: { access_status_grouplabel: { in: publicAccessStatus } },
-        },
-      },
-    ];
-
-    if (includesOpen) {
-      conditions.push({ act_advisories_flat: { none: {} } });
-    }
-
-    return { OR: conditions };
-  }
-
   private buildEstablishedWhere(
     established?: string,
   ): Prisma.recreation_resourceWhereInput | null {
@@ -349,7 +328,6 @@ export class RecreationResourceRepository {
       this.buildStatusWhere(query.status),
       this.buildEstablishmentDateWhere(query),
       this.buildEstablishedWhere(query.established),
-      this.buildPublicAccessStatusWhere(query.public_access_status),
     ].filter(
       (condition): condition is Prisma.recreation_resourceWhereInput =>
         condition !== null,

--- a/admin/backend/src/recreation-resources/recreation-resource.repository.ts
+++ b/admin/backend/src/recreation-resources/recreation-resource.repository.ts
@@ -262,6 +262,27 @@ export class RecreationResourceRepository {
     };
   }
 
+  private buildPublicAccessStatusWhere(
+    publicAccessStatus?: string[],
+  ): Prisma.recreation_resourceWhereInput | null {
+    if (!publicAccessStatus?.length) return null;
+
+    const includesOpen = publicAccessStatus.includes('Open');
+    const conditions: Prisma.recreation_resourceWhereInput[] = [
+      {
+        act_advisories_flat: {
+          some: { access_status_grouplabel: { in: publicAccessStatus } },
+        },
+      },
+    ];
+
+    if (includesOpen) {
+      conditions.push({ act_advisories_flat: { none: {} } });
+    }
+
+    return { OR: conditions };
+  }
+
   private buildEstablishedWhere(
     established?: string,
   ): Prisma.recreation_resourceWhereInput | null {
@@ -328,6 +349,7 @@ export class RecreationResourceRepository {
       this.buildStatusWhere(query.status),
       this.buildEstablishmentDateWhere(query),
       this.buildEstablishedWhere(query.established),
+      this.buildPublicAccessStatusWhere(query.public_access_status),
     ].filter(
       (condition): condition is Prisma.recreation_resourceWhereInput =>
         condition !== null,

--- a/admin/backend/src/recreation-resources/recreation-resource.select.ts
+++ b/admin/backend/src/recreation-resources/recreation-resource.select.ts
@@ -1,4 +1,13 @@
-const baseRecreationResourceSelect = {
+// Prisma 7 rejects readonly arrays in orderBy, but `as const` makes them readonly.
+// This strips readonly recursively so the selects stay compatible with Prisma query types.
+type DeepWritable<T> =
+  T extends ReadonlyArray<infer U>
+    ? DeepWritable<U>[]
+    : T extends object
+      ? { -readonly [K in keyof T]: DeepWritable<T[K]> }
+      : T;
+
+const _baseRecreationResourceSelect = {
   rec_resource_id: true,
   name: true,
   closest_community: true,
@@ -80,10 +89,13 @@ const baseRecreationResourceSelect = {
   },
 } as const;
 
-export const adminSearchSelect = baseRecreationResourceSelect;
+export const adminSearchSelect =
+  _baseRecreationResourceSelect as unknown as DeepWritable<
+    typeof _baseRecreationResourceSelect
+  >;
 
-export const recreationResourceSelect = {
-  ...baseRecreationResourceSelect,
+const _recreationResourceSelect = {
+  ..._baseRecreationResourceSelect,
   maintenance_standard_code: true,
   right_of_way: true,
   rec_status_code: true,
@@ -157,3 +169,8 @@ export const recreationResourceSelect = {
     },
   },
 } as const;
+
+export const recreationResourceSelect =
+  _recreationResourceSelect as unknown as DeepWritable<
+    typeof _recreationResourceSelect
+  >;

--- a/admin/backend/src/recreation-resources/recreation-resource.select.ts
+++ b/admin/backend/src/recreation-resources/recreation-resource.select.ts
@@ -66,6 +66,18 @@ const baseRecreationResourceSelect = {
       recreation_defined_campsite: true,
     },
   },
+  act_advisories_flat: {
+    orderBy: [
+      { listing_rank: 'desc' },
+      { urgency_sequence: 'desc' },
+      { access_status_precedence: 'asc' },
+      { updated_date: 'desc' },
+      { advisory_date: 'desc' },
+      { event_type_precedence: 'asc' },
+    ],
+    take: 1,
+    select: { access_status_grouplabel: true },
+  },
 } as const;
 
 export const adminSearchSelect = baseRecreationResourceSelect;

--- a/admin/backend/src/recreation-resources/recreation-resource.service.ts
+++ b/admin/backend/src/recreation-resources/recreation-resource.service.ts
@@ -107,6 +107,8 @@ export class RecreationResourceService {
           ? resource.project_established_date.toISOString().slice(0, 10)
           : null,
         campsite_count: resource._count?.recreation_defined_campsite ?? 0,
+        access_status_grouplabel:
+          resource.act_advisories_flat?.[0]?.access_status_grouplabel ?? null,
       }),
     );
 

--- a/admin/backend/test/recreation-resources/dtos/admin-search.dtos.spec.ts
+++ b/admin/backend/test/recreation-resources/dtos/admin-search.dtos.spec.ts
@@ -47,6 +47,54 @@ describe('Admin Search DTOs', () => {
 
       expect(errors.length).toBeGreaterThan(0);
     });
+
+    it('accepts public_access_status:asc and public_access_status:desc as valid sorts', async () => {
+      const dtoAsc = plainToInstance(AdminSearchQueryDto, {
+        sort: 'public_access_status:asc',
+      });
+      const dtoDesc = plainToInstance(AdminSearchQueryDto, {
+        sort: 'public_access_status:desc',
+      });
+
+      expect(await validate(dtoAsc)).toHaveLength(0);
+      expect(await validate(dtoDesc)).toHaveLength(0);
+    });
+
+    it('accepts and transforms public_access_status as an array of strings', async () => {
+      const dto = plainToInstance(AdminSearchQueryDto, {
+        public_access_status: ['Open', 'Closed'],
+      });
+
+      const errors = await validate(dto);
+
+      expect(errors).toHaveLength(0);
+      expect(dto.public_access_status).toEqual(['Open', 'Closed']);
+    });
+
+    it('accepts public_access_status as an underscore-delimited string', async () => {
+      const dto = plainToInstance(AdminSearchQueryDto, {
+        public_access_status: 'Open_Closed',
+      });
+
+      const errors = await validate(dto);
+
+      expect(errors).toHaveLength(0);
+      expect(dto.public_access_status).toEqual(['Open', 'Closed']);
+    });
+
+    it('omits public_access_status when not provided', async () => {
+      const dto = plainToInstance(AdminSearchQueryDto, {});
+
+      const errors = await validate(dto);
+
+      expect(errors).toHaveLength(0);
+      expect(dto.public_access_status).toBeUndefined();
+    });
+
+    it('includes public_access_status:asc and public_access_status:desc in ADMIN_SEARCH_SORT_VALUES', () => {
+      expect(ADMIN_SEARCH_SORT_VALUES).toContain('public_access_status:asc');
+      expect(ADMIN_SEARCH_SORT_VALUES).toContain('public_access_status:desc');
+    });
   });
 
   describe('AdminSearchResponseDto', () => {
@@ -77,6 +125,26 @@ describe('Admin Search DTOs', () => {
       expect(response.total).toBe(137);
       expect(response.page).toBe(1);
       expect(response.page_size).toBe(25);
+    });
+
+    it('assigns access_status_grouplabel on AdminSearchResultRowDto', () => {
+      const row = new AdminSearchResultRowDto();
+      row.access_status_grouplabel = 'Closed';
+
+      expect(row.access_status_grouplabel).toBe('Closed');
+    });
+
+    it('allows access_status_grouplabel to be null', () => {
+      const row = new AdminSearchResultRowDto();
+      row.access_status_grouplabel = null;
+
+      expect(row.access_status_grouplabel).toBeNull();
+    });
+
+    it('allows access_status_grouplabel to be undefined when not set', () => {
+      const row = new AdminSearchResultRowDto();
+
+      expect(row.access_status_grouplabel).toBeUndefined();
     });
   });
 });

--- a/admin/backend/test/recreation-resources/queries/recreation-resource-search.queries.spec.ts
+++ b/admin/backend/test/recreation-resources/queries/recreation-resource-search.queries.spec.ts
@@ -108,6 +108,8 @@ describe('recreation-resource-search.queries', () => {
 
   it('maps raw SQL sorts and derived order clauses correctly', () => {
     expect(RAW_SQL_SORTS.has('type:asc')).toBe(true);
+    expect(RAW_SQL_SORTS.has('public_access_status:asc')).toBe(true);
+    expect(RAW_SQL_SORTS.has('public_access_status:desc')).toBe(true);
     expect(RAW_SQL_SORTS.has('name:asc' as any)).toBe(false);
     expect(SORT_FIELD_MAP['district:desc']).toEqual({
       recreation_district_code: {
@@ -168,5 +170,95 @@ describe('recreation-resource-search.queries', () => {
     expect(normalizedIdsSql).toContain('OFFSET ?');
     expect(idsQuery.values.at(-2)).toBe(25);
     expect(idsQuery.values.at(-1)).toBe(50);
+  });
+
+  it('builds public_access_status filter using advisory subquery', () => {
+    const whereSql = buildSearchWhereSql({
+      public_access_status: ['Closed', 'Caution'],
+    });
+
+    const normalized = normalizeSql(whereSql);
+
+    expect(normalized).toContain('COALESCE(');
+    expect(normalized).toContain('af.access_status_grouplabel');
+    expect(normalized).toContain('rst.act_advisories_flat af');
+    expect(normalized).toContain('af.rec_resource_id = rr.rec_resource_id');
+    expect(normalized).toContain('LIMIT 1');
+    expect(normalized).toContain("'Open'");
+    expect(normalized).toContain('IN (?,?)');
+    expect(whereSql.values).toContain('Closed');
+    expect(whereSql.values).toContain('Caution');
+  });
+
+  it('omits public_access_status condition when array is empty', () => {
+    const whereSql = buildSearchWhereSql({ public_access_status: [] });
+
+    expect(whereSql).toBe(Prisma.empty);
+  });
+
+  it('omits public_access_status condition when field is absent', () => {
+    const whereSql = buildSearchWhereSql({});
+
+    expect(whereSql).toBe(Prisma.empty);
+  });
+
+  it('builds public_access_status derived sort with lateral join and advisory ordering', () => {
+    const { joinsSql, orderBySql } = buildDerivedSortQueryParts(
+      'public_access_status:asc',
+    );
+
+    const normalizedJoin = normalizeSql(joinsSql);
+    expect(normalizedJoin).toContain('LEFT JOIN LATERAL');
+    expect(normalizedJoin).toContain('rst.act_advisories_flat af');
+    expect(normalizedJoin).toContain('af.rec_resource_id = rr.rec_resource_id');
+    expect(normalizedJoin).toContain('af.listing_rank DESC');
+    expect(normalizedJoin).toContain('LIMIT 1');
+    expect(normalizedJoin).toContain("'Open'");
+    expect(normalizedJoin).toContain('advisory_status ON TRUE');
+
+    expect(normalizeSql(orderBySql)).toContain(
+      'advisory_status.public_access_status ASC',
+    );
+  });
+
+  it('builds public_access_status derived sort descending correctly', () => {
+    const { orderBySql } = buildDerivedSortQueryParts(
+      'public_access_status:desc',
+    );
+
+    expect(normalizeSql(orderBySql)).toContain(
+      'advisory_status.public_access_status DESC',
+    );
+  });
+
+  it('builds ids query for public_access_status sort with lateral join', () => {
+    const whereSql = buildSearchWhereSql({ q: 'park' });
+    const sortParts = buildDerivedSortQueryParts('public_access_status:asc');
+    const idsQuery = buildDerivedSortIdsQuery({
+      whereSql,
+      joinsSql: sortParts.joinsSql,
+      orderBySql: sortParts.orderBySql,
+      pageSize: 25,
+      offset: 0,
+    });
+
+    const normalized = normalizeSql(idsQuery);
+
+    expect(normalized).toContain('LEFT JOIN LATERAL');
+    expect(normalized).toContain('advisory_status ON TRUE');
+    expect(normalized).toContain(
+      'ORDER BY advisory_status.public_access_status ASC, rr.rec_resource_id ASC',
+    );
+    expect(normalized).toContain('LIMIT ?');
+    expect(normalized).toContain('OFFSET ?');
+    expect(idsQuery.values.at(-2)).toBe(25);
+    expect(idsQuery.values.at(-1)).toBe(0);
+  });
+
+  it('SORT_FIELD_MAP has fallback name sort for public_access_status', () => {
+    expect(SORT_FIELD_MAP['public_access_status:asc']).toEqual({ name: 'asc' });
+    expect(SORT_FIELD_MAP['public_access_status:desc']).toEqual({
+      name: 'desc',
+    });
   });
 });

--- a/admin/backend/test/recreation-resources/queries/recreation-resource-search.queries.spec.ts
+++ b/admin/backend/test/recreation-resources/queries/recreation-resource-search.queries.spec.ts
@@ -261,4 +261,52 @@ describe('recreation-resource-search.queries', () => {
       name: 'desc',
     });
   });
+
+  // These column-only sorts reach buildDerivedSortQueryParts only when a
+  // public_access_status filter forces the derived-sort path. They emit no
+  // joins and order directly on a recreation_resource column.
+  it.each([
+    ['name:asc', 'rr.name ASC'],
+    ['name:desc', 'rr.name DESC'],
+    ['rec_resource_id:asc', 'rr.rec_resource_id ASC'],
+    ['established_date:asc', 'rr.project_established_date ASC'],
+    ['community:asc', 'rr.closest_community ASC'],
+    ['display_on_public_site:asc', 'rr.display_on_public_site ASC'],
+  ] as const)(
+    'builds column-only derived sort for %s without joins',
+    (sort, expectedOrderBy) => {
+      const { joinsSql, orderBySql } = buildDerivedSortQueryParts(sort);
+
+      expect(joinsSql).toBe(Prisma.empty);
+      expect(normalizeSql(orderBySql)).toBe(expectedOrderBy);
+    },
+  );
+
+  it('builds campsites derived sort with a campsite count lateral join', () => {
+    const { joinsSql, orderBySql } =
+      buildDerivedSortQueryParts('campsites:asc');
+
+    const normalizedJoin = normalizeSql(joinsSql);
+    expect(normalizedJoin).toContain('LEFT JOIN LATERAL');
+    expect(normalizedJoin).toContain('COUNT(*) AS campsite_count');
+    expect(normalizedJoin).toContain('rst.recreation_defined_campsite rdc');
+    expect(normalizedJoin).toContain(
+      'rdc.rec_resource_id = rr.rec_resource_id',
+    );
+    expect(normalizeSql(orderBySql)).toBe('campsite_agg.campsite_count ASC');
+  });
+
+  it('builds district derived sort with a district code join and COALESCE order', () => {
+    const { joinsSql, orderBySql } =
+      buildDerivedSortQueryParts('district:desc');
+
+    const normalizedJoin = normalizeSql(joinsSql);
+    expect(normalizedJoin).toContain(
+      'LEFT JOIN rst.recreation_district_code rdco',
+    );
+    expect(normalizedJoin).toContain('rdco.district_code = rr.district_code');
+    expect(normalizeSql(orderBySql)).toBe(
+      "COALESCE(rdco.description, '') DESC",
+    );
+  });
 });

--- a/admin/backend/test/recreation-resources/recreation-resource.repository.spec.ts
+++ b/admin/backend/test/recreation-resources/recreation-resource.repository.spec.ts
@@ -230,6 +230,35 @@ describe('RecreationResourceRepository', () => {
       );
     });
 
+    it('should use the derived-sort path when a public_access_status filter is set even for a non-derived sort', async () => {
+      prisma.$queryRaw
+        .mockResolvedValueOnce([{ total: 1n }])
+        .mockResolvedValueOnce([{ rec_resource_id: 'REC001' }]);
+      prisma.recreation_resource.findMany.mockResolvedValue([
+        { rec_resource_id: 'REC001' },
+      ]);
+
+      const result = await repo.searchResources({
+        sort: 'name:asc',
+        public_access_status: ['Closed'],
+      });
+
+      // name:asc is not a RAW_SQL_SORT, so only the filter forces the raw path.
+      expect(prisma.$transaction).not.toHaveBeenCalled();
+      expect(prisma.$queryRaw).toHaveBeenCalledTimes(2);
+
+      const countQuery = prisma.$queryRaw.mock.calls[0]?.[0] as Prisma.Sql;
+      expect(countQuery.sql.replace(/\s+/g, ' ').trim()).toContain(
+        'act_advisories_flat',
+      );
+      expect(countQuery.values).toContain('Closed');
+
+      expect(result).toEqual({
+        total: 1,
+        data: [{ rec_resource_id: 'REC001' }],
+      });
+    });
+
     it('should return an empty data array when the derived-sort ID query returns no rows', async () => {
       prisma.$queryRaw
         .mockResolvedValueOnce([{ total: 0n }])

--- a/admin/backend/test/recreation-resources/recreation-resource.service.spec.ts
+++ b/admin/backend/test/recreation-resources/recreation-resource.service.spec.ts
@@ -171,6 +171,7 @@ describe('RecreationResourceService', () => {
           fee_indicators: ['Reservable', 'Has fees'],
           established_date: '2024-06-10',
           campsite_count: 5,
+          access_status_grouplabel: null,
         },
       ],
       total: 1,
@@ -349,12 +350,131 @@ describe('RecreationResourceService', () => {
           rec_status_code: null,
           established_date: null,
           campsite_count: 0,
+          access_status_grouplabel: null,
         },
       ],
       total: 1,
       page: 1,
       page_size: 25,
     });
+  });
+
+  it('should map access_status_grouplabel from first advisory when present', async () => {
+    (repo.searchResources as any).mockResolvedValue({
+      total: 1,
+      data: [
+        {
+          rec_resource_id: 'REC300',
+          name: 'Closure Lake',
+          closest_community: 'Hope',
+          project_established_date: null,
+          display_on_public_site: true,
+          rec_status_code: null,
+          recreation_activity: [],
+          recreation_access: [],
+          recreation_fee: [],
+          recreation_resource_reservation_info: null,
+          recreation_resource_type_view_admin: [],
+          recreation_district_code: null,
+          recreation_status: null,
+          _count: { recreation_defined_campsite: 0 },
+          act_advisories_flat: [{ access_status_grouplabel: 'Closed' }],
+        },
+      ],
+    });
+
+    const result = await service.searchResources({});
+
+    expect(result.data[0]?.access_status_grouplabel).toBe('Closed');
+  });
+
+  it('should set access_status_grouplabel to null when act_advisories_flat is empty', async () => {
+    (repo.searchResources as any).mockResolvedValue({
+      total: 1,
+      data: [
+        {
+          rec_resource_id: 'REC301',
+          name: 'Open Lake',
+          closest_community: 'Hope',
+          project_established_date: null,
+          display_on_public_site: true,
+          rec_status_code: null,
+          recreation_activity: [],
+          recreation_access: [],
+          recreation_fee: [],
+          recreation_resource_reservation_info: null,
+          recreation_resource_type_view_admin: [],
+          recreation_district_code: null,
+          recreation_status: null,
+          _count: { recreation_defined_campsite: 0 },
+          act_advisories_flat: [],
+        },
+      ],
+    });
+
+    const result = await service.searchResources({});
+
+    expect(result.data[0]?.access_status_grouplabel).toBeNull();
+  });
+
+  it('should set access_status_grouplabel to null when act_advisories_flat is absent', async () => {
+    (repo.searchResources as any).mockResolvedValue({
+      total: 1,
+      data: [
+        {
+          rec_resource_id: 'REC302',
+          name: 'No Advisory Lake',
+          closest_community: 'Hope',
+          project_established_date: null,
+          display_on_public_site: true,
+          rec_status_code: null,
+          recreation_activity: [],
+          recreation_access: [],
+          recreation_fee: [],
+          recreation_resource_reservation_info: null,
+          recreation_resource_type_view_admin: [],
+          recreation_district_code: null,
+          recreation_status: null,
+          _count: { recreation_defined_campsite: 0 },
+        },
+      ],
+    });
+
+    const result = await service.searchResources({});
+
+    expect(result.data[0]?.access_status_grouplabel).toBeNull();
+  });
+
+  it('should use only the first advisory for access_status_grouplabel', async () => {
+    (repo.searchResources as any).mockResolvedValue({
+      total: 1,
+      data: [
+        {
+          rec_resource_id: 'REC303',
+          name: 'Multi Advisory Lake',
+          closest_community: 'Hope',
+          project_established_date: null,
+          display_on_public_site: true,
+          rec_status_code: null,
+          recreation_activity: [],
+          recreation_access: [],
+          recreation_fee: [],
+          recreation_resource_reservation_info: null,
+          recreation_resource_type_view_admin: [],
+          recreation_district_code: null,
+          recreation_status: null,
+          _count: { recreation_defined_campsite: 0 },
+          act_advisories_flat: [
+            { access_status_grouplabel: 'Caution' },
+            { access_status_grouplabel: 'Closed' },
+          ],
+        },
+      ],
+    });
+
+    const result = await service.searchResources({});
+
+    expect(result.data[0]?.access_status_grouplabel).toBe('Caution');
   });
 });
 

--- a/admin/frontend/src/components/index.ts
+++ b/admin/frontend/src/components/index.ts
@@ -1,4 +1,5 @@
 export * from './admin-status-badge';
+export * from './public-access-status-badge';
 export * from './auth';
 export * from './avatar';
 export * from './buttons';

--- a/admin/frontend/src/components/public-access-status-badge/PublicAccessStatusBadge.tsx
+++ b/admin/frontend/src/components/public-access-status-badge/PublicAccessStatusBadge.tsx
@@ -1,0 +1,56 @@
+import { CustomBadge } from '@/components/custom-badge';
+import {
+  COLOR_BACKGROUND_GREY,
+  COLOR_GOLD_DARK,
+  COLOR_GREEN_DARKER,
+  COLOR_GREEN_LIGHTEST,
+  COLOR_GREY,
+  COLOR_YELLOW_ADVISORY_BG,
+} from '@/styles/colors';
+
+interface PublicAccessStatusBadgeProps {
+  label: string | null;
+}
+
+const OPEN_LABEL = 'Open';
+
+type BadgeColors = { bgColor: string; textColor: string };
+
+const LABEL_COLOR_MAP: Record<string, BadgeColors> = {
+  Closed: { bgColor: COLOR_BACKGROUND_GREY, textColor: COLOR_GREY },
+  Restricted: { bgColor: COLOR_BACKGROUND_GREY, textColor: COLOR_GREY },
+  'Limited access': {
+    bgColor: COLOR_YELLOW_ADVISORY_BG,
+    textColor: COLOR_GOLD_DARK,
+  },
+  'Visit with caution': {
+    bgColor: COLOR_YELLOW_ADVISORY_BG,
+    textColor: COLOR_GOLD_DARK,
+  },
+  Open: { bgColor: COLOR_GREEN_LIGHTEST, textColor: COLOR_GREEN_DARKER },
+  'Seasonal restrictions': {
+    bgColor: COLOR_GREEN_LIGHTEST,
+    textColor: COLOR_GREEN_DARKER,
+  },
+};
+
+const DEFAULT_COLORS: BadgeColors = {
+  bgColor: COLOR_GREEN_LIGHTEST,
+  textColor: COLOR_GREEN_DARKER,
+};
+
+export function PublicAccessStatusBadge({
+  label,
+}: PublicAccessStatusBadgeProps) {
+  const resolvedLabel = label ?? OPEN_LABEL;
+  const { bgColor, textColor } =
+    LABEL_COLOR_MAP[resolvedLabel] ?? DEFAULT_COLORS;
+
+  return (
+    <CustomBadge
+      label={resolvedLabel}
+      bgColor={bgColor}
+      textColor={textColor}
+    />
+  );
+}

--- a/admin/frontend/src/components/public-access-status-badge/index.ts
+++ b/admin/frontend/src/components/public-access-status-badge/index.ts
@@ -1,0 +1,1 @@
+export { PublicAccessStatusBadge } from './PublicAccessStatusBadge';

--- a/admin/frontend/src/pages/search/SearchPage.tsx
+++ b/admin/frontend/src/pages/search/SearchPage.tsx
@@ -31,6 +31,7 @@ export function SearchPage() {
     establishment_date_from: search.establishment_date_from,
     establishment_date_to: search.establishment_date_to,
     established: search.established,
+    publicAccessStatus: search.publicAccessStatus,
   });
 
   const addCommunityFilter = (communityId: string) => {

--- a/admin/frontend/src/pages/search/components/ColumnVisibilityMenu.tsx
+++ b/admin/frontend/src/pages/search/components/ColumnVisibilityMenu.tsx
@@ -4,8 +4,10 @@ import { CheckboxDropdownField } from '@/components/form';
 import { ADMIN_SEARCH_COLUMN_IDS } from '@/pages/search/constants';
 import {
   ADMIN_SEARCH_COLUMN_LABELS,
+  FEATURE_FLAGGED_COLUMN_IDS,
   type AdminSearchColumnId,
 } from '@/pages/search/searchDefinitions';
+import { useAuthorizations } from '@/hooks/useAuthorizations';
 
 interface ColumnVisibilityMenuProps {
   visibleColumns: AdminSearchColumnId[];
@@ -16,8 +18,11 @@ export function ColumnVisibilityMenu({
   visibleColumns,
   onToggle,
 }: Readonly<ColumnVisibilityMenuProps>) {
+  const { canViewFeatureFlag } = useAuthorizations();
   const selectableColumnIds = ADMIN_SEARCH_COLUMN_IDS.filter(
-    (columnId) => columnId !== 'rec_resource_id',
+    (columnId) =>
+      columnId !== 'rec_resource_id' &&
+      (!FEATURE_FLAGGED_COLUMN_IDS.has(columnId) || canViewFeatureFlag),
   );
 
   return (

--- a/admin/frontend/src/pages/search/components/FilterAccordion.tsx
+++ b/admin/frontend/src/pages/search/components/FilterAccordion.tsx
@@ -12,6 +12,7 @@ import { useAdminSearchController } from '@/pages/search/hooks/useAdminSearchCon
 import { AdminSearchRouteState } from '@/pages/search/types';
 import './FilterAccordion.scss';
 import { capitalizeWords } from '@shared/utils/capitalizeWords';
+import { useAuthorizations } from '@/hooks/useAuthorizations';
 
 type FilterAccordionControllerProps = Pick<
   ReturnType<typeof useAdminSearchController>,
@@ -25,6 +26,7 @@ type FilterAccordionControllerProps = Pick<
   | 'accessOptions'
   | 'closestCommunityOptions'
   | 'establishedOptions'
+  | 'publicAccessStatusOptions'
   | 'applyFilters'
   | 'resetFilters'
 >;
@@ -49,6 +51,7 @@ const getEditableFilters = (
   establishment_date_from: state.establishment_date_from,
   establishment_date_to: state.establishment_date_to,
   established: state.established,
+  publicAccessStatus: state.publicAccessStatus,
 });
 
 const toggleFilterValue = (currentValues: string[], value: string): string[] =>
@@ -61,6 +64,7 @@ export function FilterAccordion({
   controller,
   showTrigger = true,
 }: Readonly<FilterAccordionProps>) {
+  const { canViewFeatureFlag } = useAuthorizations();
   const {
     isFilterPanelOpen: isOpen,
     closeFilterPanel: onClose,
@@ -72,6 +76,7 @@ export function FilterAccordion({
     accessOptions,
     closestCommunityOptions,
     establishedOptions,
+    publicAccessStatusOptions,
     applyFilters: onApply,
     resetFilters: onReset,
   } = controller;
@@ -86,6 +91,7 @@ export function FilterAccordion({
       ...item,
       label: capitalizeWords(item.label),
     })),
+    publicAccessStatusOptions,
   };
   const searchFilters = getEditableFilters(search);
   const searchKey = JSON.stringify(searchFilters);
@@ -112,6 +118,13 @@ export function FilterAccordion({
         <div className="filters__panel mb-3">
           <Row className="g-3">
             {ADMIN_SEARCH_MULTISELECT_FILTER_FIELDS.map((field) => {
+              if (
+                'isFeatureFlagged' in field &&
+                field.isFeatureFlagged &&
+                !canViewFeatureFlag
+              ) {
+                return null;
+              }
               const options =
                 filterOptionsByKey[
                   field.optionsKey as keyof typeof filterOptionsByKey
@@ -245,6 +258,7 @@ export function FilterAccordion({
                     establishment_date_from: draft.establishment_date_from,
                     establishment_date_to: draft.establishment_date_to,
                     established: draft.established,
+                    publicAccessStatus: draft.publicAccessStatus,
                   });
                 }}
               >

--- a/admin/frontend/src/pages/search/constants.ts
+++ b/admin/frontend/src/pages/search/constants.ts
@@ -19,6 +19,7 @@ export type EditableAdminSearchFilters = Pick<
   | 'establishment_date_from'
   | 'establishment_date_to'
   | 'established'
+  | 'publicAccessStatus'
 >;
 
 export const DEFAULT_ADMIN_SEARCH_STATE: AdminSearchRouteState = {
@@ -35,6 +36,7 @@ export const DEFAULT_ADMIN_SEARCH_STATE: AdminSearchRouteState = {
   access: [],
   established: undefined,
   closestCommunity: [],
+  publicAccessStatus: [],
 };
 
 export const ADMIN_SEARCH_PAGE_SIZE_OPTIONS = [25, 50, 100] as const;
@@ -52,6 +54,7 @@ export const EMPTY_ADMIN_SEARCH_FILTERS: EditableAdminSearchFilters = {
   establishment_date_from: undefined,
   establishment_date_to: undefined,
   established: undefined,
+  publicAccessStatus: [],
 };
 
 export const ADMIN_SEARCH_MULTISELECT_FILTER_FIELDS = [
@@ -99,11 +102,27 @@ export const ADMIN_SEARCH_MULTISELECT_FILTER_FIELDS = [
     controlId: 'admin-search-filter-closest-community',
     optionsKey: 'closestCommunityOptions',
   },
+  {
+    key: 'publicAccessStatus',
+    label: 'Public access status',
+    controlId: 'admin-search-filter-public-access-status',
+    optionsKey: 'publicAccessStatusOptions',
+    isFeatureFlagged: true,
+  },
 ] as const;
 
 export const ADMIN_SEARCH_ESTABLISHED_OPTIONS = [
   { id: 'yes', label: 'Yes' },
   { id: 'no', label: 'No' },
+] as const;
+
+export const PUBLIC_ACCESS_STATUS_OPTIONS = [
+  { id: 'Open', label: 'Open' },
+  { id: 'Seasonal restrictions', label: 'Seasonal restrictions' },
+  { id: 'Visit with caution', label: 'Visit with caution' },
+  { id: 'Limited access', label: 'Limited access' },
+  { id: 'Restricted', label: 'Restricted' },
+  { id: 'Closed', label: 'Closed' },
 ] as const;
 
 export const ADMIN_SEARCH_STORAGE_KEYS = {

--- a/admin/frontend/src/pages/search/hooks/useAdminSearchController.ts
+++ b/admin/frontend/src/pages/search/hooks/useAdminSearchController.ts
@@ -5,6 +5,7 @@ import {
   ADMIN_SEARCH_PAGE_SIZE_OPTIONS,
   DEFAULT_ADMIN_SEARCH_STATE,
   EMPTY_ADMIN_SEARCH_FILTERS,
+  PUBLIC_ACCESS_STATUS_OPTIONS,
   type EditableAdminSearchFilters,
 } from '@/pages/search/constants';
 import {
@@ -31,6 +32,7 @@ import {
   setAdminSearchTypeFilter,
   submitAdminSearchQuery,
   setAdminSearchClosestCommunityFilter,
+  setAdminSearchPublicAccessStatusFilter,
 } from '@/pages/search/utils/urlState';
 import useGetRecreationResourceSearch from '@/services/hooks/recreation-resource-admin/useGetRecreationResourceSearch';
 import { GetOptionsByTypesTypesEnum } from '@/services/recreation-resource-admin/apis/RecreationResourcesApi';
@@ -48,6 +50,7 @@ const hasActiveEditableFilters = (search: AdminSearchRouteState) =>
   search.status.length > 0 ||
   search.access.length > 0 ||
   search.closestCommunity.length > 0 ||
+  search.publicAccessStatus.length > 0 ||
   Boolean(search.establishment_date_from) ||
   Boolean(search.establishment_date_to) ||
   Boolean(search.established);
@@ -157,6 +160,10 @@ export function useAdminSearchController(search: AdminSearchRouteState) {
     ],
     [],
   );
+  const publicAccessStatusOptions = useMemo(
+    () => [...PUBLIC_ACCESS_STATUS_OPTIONS],
+    [],
+  );
   const updateSearch = (nextSearch: AdminSearchRouteState) =>
     navigate({
       to: ROUTE_PATHS.LANDING,
@@ -254,6 +261,13 @@ export function useAdminSearchController(search: AdminSearchRouteState) {
     updateSearch(setAdminSearchEstablishmentDateToFilter(search, undefined));
   const clearEstablished = () =>
     updateSearch(setAdminSearchEstablishedFilter(search, undefined));
+  const clearPublicAccessStatus = (value: string) =>
+    updateSearch(
+      setAdminSearchPublicAccessStatusFilter(
+        search,
+        search.publicAccessStatus.filter((entry) => entry !== value),
+      ),
+    );
   const appliedFilterChips: AdminAppliedFilterChip[] = [];
   appliedFilterChips.push(
     ...search.type.map((type) => ({
@@ -287,6 +301,11 @@ export function useAdminSearchController(search: AdminSearchRouteState) {
         getOptionLabel(closestCommunity, closestCommunityOptions),
       ),
       onClear: () => clearClosestCommunity(closestCommunity),
+    })),
+    ...search.publicAccessStatus.map((status) => ({
+      key: `publicAccessStatus:${status}`,
+      label: status,
+      onClear: () => clearPublicAccessStatus(status),
     })),
   );
 
@@ -326,6 +345,7 @@ export function useAdminSearchController(search: AdminSearchRouteState) {
         establishment_date_from: search.establishment_date_from,
         establishment_date_to: search.establishment_date_to,
         established: search.established,
+        publicAccessStatus: search.publicAccessStatus,
       }),
     [
       search.type,
@@ -337,6 +357,7 @@ export function useAdminSearchController(search: AdminSearchRouteState) {
       search.establishment_date_from,
       search.establishment_date_to,
       search.established,
+      search.publicAccessStatus,
     ],
   );
   const isFilterPanelOpen = hasActiveFilters
@@ -393,6 +414,7 @@ export function useAdminSearchController(search: AdminSearchRouteState) {
       });
       setFilterPanelOpen(false);
     },
+    publicAccessStatusOptions,
     clearQuery,
     clearType,
     clearDistrict,
@@ -404,5 +426,6 @@ export function useAdminSearchController(search: AdminSearchRouteState) {
     clearEstablishmentDateFrom,
     clearEstablishmentDateTo,
     clearEstablished,
+    clearPublicAccessStatus,
   };
 }

--- a/admin/frontend/src/pages/search/hooks/useSearchResultsTable.tsx
+++ b/admin/frontend/src/pages/search/hooks/useSearchResultsTable.tsx
@@ -8,7 +8,12 @@ import {
 } from '@tanstack/react-table';
 import type { KeyboardEvent } from 'react';
 import { useNavigate } from '@tanstack/react-router';
-import { AdminStatusBadge, CustomBadge, VisibleOnWebsite } from '@/components';
+import {
+  AdminStatusBadge,
+  CustomBadge,
+  PublicAccessStatusBadge,
+  VisibleOnWebsite,
+} from '@/components';
 import { COLOR_RED, COLOR_RED_LIGHT } from '@/styles/colors';
 import { ROUTE_PATHS } from '@/constants/routes';
 import {
@@ -17,11 +22,15 @@ import {
 } from '@/pages/search/constants';
 import { SearchResultsTableSortableHeader } from '@/pages/search/components/SearchResultsTableSortableHeader';
 import type { SearchResultsPaginationModel } from '@/pages/search/hooks/useAdminSearchController';
-import { ADMIN_SEARCH_COLUMN_DEFINITIONS } from '@/pages/search/searchDefinitions';
+import {
+  ADMIN_SEARCH_COLUMN_DEFINITIONS,
+  FEATURE_FLAGGED_COLUMN_IDS,
+} from '@/pages/search/searchDefinitions';
 import type {
   AdminSearchResultRow,
   AdminSearchRouteState,
 } from '@/pages/search/types';
+import { useAuthorizations } from '@/hooks/useAuthorizations';
 
 interface UseSearchResultsTableParams {
   rows: AdminSearchResultRow[];
@@ -34,12 +43,17 @@ interface UseSearchResultsTableParams {
 
 const getSortParts = (sort: AdminSearchRouteState['sort']) => sort.split(':');
 
-const buildColumnVisibility = (visibleColumns: AdminSearchColumnId[]) =>
+const buildColumnVisibility = (
+  visibleColumns: AdminSearchColumnId[],
+  canViewFeatureFlag: boolean,
+) =>
   Object.fromEntries(
-    ADMIN_SEARCH_COLUMN_IDS.map((columnId) => [
-      columnId,
-      visibleColumns.includes(columnId),
-    ]),
+    ADMIN_SEARCH_COLUMN_IDS.map((columnId) => {
+      if (FEATURE_FLAGGED_COLUMN_IDS.has(columnId) && !canViewFeatureFlag) {
+        return [columnId, false];
+      }
+      return [columnId, visibleColumns.includes(columnId)];
+    }),
   ) as Record<AdminSearchColumnId, boolean>;
 
 const buildColumns = (
@@ -90,6 +104,12 @@ const buildColumns = (
       );
     }
 
+    if (id === 'public_access_status') {
+      column.cell = ({ row }: { row: Row<AdminSearchResultRow> }) => (
+        <PublicAccessStatusBadge label={row.original.publicAccessStatus} />
+      );
+    }
+
     return column;
   });
 
@@ -102,6 +122,7 @@ export function useSearchResultsTable({
   onSortChange,
 }: UseSearchResultsTableParams) {
   const navigate = useNavigate();
+  const { canViewFeatureFlag } = useAuthorizations();
   const [sortField, sortDirection] = getSortParts(sort);
 
   const navigateToResource = (recResourceId: string) =>
@@ -128,7 +149,10 @@ export function useSearchResultsTable({
     pageCount: pagination.pageCount,
     rowCount: pagination.rowCount,
     state: {
-      columnVisibility: buildColumnVisibility(visibleColumns),
+      columnVisibility: buildColumnVisibility(
+        visibleColumns,
+        canViewFeatureFlag,
+      ),
       pagination: pagination.state,
     },
     getRowId: (row) => row.recResourceId,

--- a/admin/frontend/src/pages/search/searchDefinitions.ts
+++ b/admin/frontend/src/pages/search/searchDefinitions.ts
@@ -23,6 +23,8 @@ export const ADMIN_SEARCH_SORT_VALUES = [
   'district:desc',
   'display_on_public_site:asc',
   'display_on_public_site:desc',
+  'public_access_status:asc',
+  'public_access_status:desc',
 ] as const;
 
 export type AdminSearchSort = (typeof ADMIN_SEARCH_SORT_VALUES)[number];
@@ -52,6 +54,12 @@ export const ADMIN_SEARCH_COLUMN_DEFINITIONS = [
     label: 'District',
     resultKey: 'district',
     sortKey: 'district',
+  },
+  {
+    id: 'public_access_status',
+    label: 'Public access status',
+    resultKey: 'publicAccessStatus',
+    sortKey: 'public_access_status',
   },
   {
     id: 'closest_community',
@@ -103,6 +111,10 @@ export type AdminSearchColumnId =
 export const ADMIN_SEARCH_COLUMN_IDS = ADMIN_SEARCH_COLUMN_DEFINITIONS.map(
   ({ id }) => id,
 ) as AdminSearchColumnId[];
+
+export const FEATURE_FLAGGED_COLUMN_IDS = new Set<AdminSearchColumnId>([
+  'public_access_status',
+]);
 
 export const ADMIN_SEARCH_COLUMN_LABELS = Object.fromEntries(
   ADMIN_SEARCH_COLUMN_DEFINITIONS.map(({ id, label }) => [id, label]),

--- a/admin/frontend/src/pages/search/searchResultsMapper.ts
+++ b/admin/frontend/src/pages/search/searchResultsMapper.ts
@@ -25,5 +25,6 @@ export function mapAdminSearchResultRow(
     statusCode: row.status_code,
     recStatusCode: row.rec_status_code,
     visible: row.display_on_public_site,
+    publicAccessStatus: row.access_status_grouplabel ?? null,
   };
 }

--- a/admin/frontend/src/pages/search/types.ts
+++ b/admin/frontend/src/pages/search/types.ts
@@ -15,6 +15,7 @@ export interface AdminSearchFilters {
   establishment_date_to?: string;
   access: string[];
   established?: string;
+  publicAccessStatus: string[];
 }
 
 export interface AdminSearchRouteState extends AdminSearchFilters {
@@ -44,4 +45,5 @@ export interface AdminSearchResultRow {
   statusCode: number;
   recStatusCode?: string | null;
   visible: boolean;
+  publicAccessStatus: string | null;
 }

--- a/admin/frontend/src/pages/search/utils/searchSchema.ts
+++ b/admin/frontend/src/pages/search/utils/searchSchema.ts
@@ -124,6 +124,7 @@ export function validateAdminSearch(
     access: getSearchFilterTokenList(search.access),
     established: getOptionalToken(search.established),
     closestCommunity: getSearchFilterTokenList(search.closestCommunity),
+    publicAccessStatus: getSearchFilterTokenList(search.publicAccessStatus),
   });
 }
 
@@ -149,6 +150,7 @@ export function resolveAdminSearchRouteState(
     status: searchFilterTokenList(search.status),
     access: searchFilterTokenList(search.access),
     closestCommunity: searchFilterTokenList(search.closestCommunity),
+    publicAccessStatus: searchFilterTokenList(search.publicAccessStatus),
   };
 }
 

--- a/admin/frontend/src/pages/search/utils/urlState.ts
+++ b/admin/frontend/src/pages/search/utils/urlState.ts
@@ -11,7 +11,8 @@ type SerializedListFilterFields =
   | 'activities'
   | 'status'
   | 'access'
-  | 'closestCommunity';
+  | 'closestCommunity'
+  | 'publicAccessStatus';
 
 export type SerializedAdminSearchRouteState = Partial<
   Omit<AdminSearchRouteState, SerializedListFilterFields | 'sort'> & {
@@ -84,6 +85,10 @@ export const serializeAdminSearchRouteState = (
 
   if (state.established) {
     search.established = state.established;
+  }
+
+  if (state.publicAccessStatus.length > 0) {
+    search.publicAccessStatus = serializeListFilter(state.publicAccessStatus);
   }
 
   return search;
@@ -185,6 +190,11 @@ export const setAdminSearchEstablishedFilter = (
   setFilterState(state, {
     established: established || undefined,
   });
+
+export const setAdminSearchPublicAccessStatusFilter = (
+  state: AdminSearchRouteState,
+  publicAccessStatus: string[],
+): AdminSearchRouteState => setFilterState(state, { publicAccessStatus });
 
 export const clearAdminSearchState = (
   state: AdminSearchRouteState,

--- a/admin/frontend/src/services/hooks/recreation-resource-admin/searchQueryOptions.ts
+++ b/admin/frontend/src/services/hooks/recreation-resource-admin/searchQueryOptions.ts
@@ -34,6 +34,9 @@ export function buildAdminSearchRequest(
     establishmentDateFrom: search.establishment_date_from,
     establishmentDateTo: search.establishment_date_to,
     established: search.established,
+    publicAccessStatus: search.publicAccessStatus.length
+      ? search.publicAccessStatus
+      : undefined,
   };
 }
 

--- a/admin/frontend/src/services/recreation-resource-admin/apis/RecreationResourcesApi.ts
+++ b/admin/frontend/src/services/recreation-resource-admin/apis/RecreationResourcesApi.ts
@@ -281,6 +281,7 @@ export interface SearchRecreationResourcesRequest {
   establishmentDateFrom?: string;
   establishmentDateTo?: string;
   established?: SearchRecreationResourcesEstablishedEnum;
+  publicAccessStatus?: Array<string>;
 }
 
 export interface UpdateActivitiesRequest {
@@ -2657,6 +2658,11 @@ export class RecreationResourcesApi extends runtime.BaseAPI {
       queryParameters['established'] = requestParameters['established'];
     }
 
+    if (requestParameters['publicAccessStatus'] != null) {
+      queryParameters['public_access_status'] =
+        requestParameters['publicAccessStatus'];
+    }
+
     const headerParameters: runtime.HTTPHeaders = {};
 
     if (this.configuration && this.configuration.accessToken) {
@@ -3445,6 +3451,8 @@ export const SearchRecreationResourcesSortEnum = {
   DistrictDesc: 'district:desc',
   DisplayOnPublicSiteAsc: 'display_on_public_site:asc',
   DisplayOnPublicSiteDesc: 'display_on_public_site:desc',
+  PublicAccessStatusAsc: 'public_access_status:asc',
+  PublicAccessStatusDesc: 'public_access_status:desc',
 } as const;
 export type SearchRecreationResourcesSortEnum =
   (typeof SearchRecreationResourcesSortEnum)[keyof typeof SearchRecreationResourcesSortEnum];

--- a/admin/frontend/src/services/recreation-resource-admin/models/AdminSearchResultRowDto.ts
+++ b/admin/frontend/src/services/recreation-resource-admin/models/AdminSearchResultRowDto.ts
@@ -109,6 +109,12 @@ export interface AdminSearchResultRowDto {
    * @memberof AdminSearchResultRowDto
    */
   campsite_count: number;
+  /**
+   * Public access status group label from ACT advisories
+   * @type {string}
+   * @memberof AdminSearchResultRowDto
+   */
+  access_status_grouplabel?: string | null;
 }
 
 /**
@@ -190,6 +196,10 @@ export function AdminSearchResultRowDtoFromJSONTyped(
     established_date:
       json['established_date'] == null ? undefined : json['established_date'],
     campsite_count: json['campsite_count'],
+    access_status_grouplabel:
+      json['access_status_grouplabel'] == null
+        ? undefined
+        : json['access_status_grouplabel'],
   };
 }
 
@@ -223,5 +233,6 @@ export function AdminSearchResultRowDtoToJSONTyped(
     fee_indicators: value['fee_indicators'],
     established_date: value['established_date'],
     campsite_count: value['campsite_count'],
+    access_status_grouplabel: value['access_status_grouplabel'],
   };
 }

--- a/admin/frontend/src/styles/colors.ts
+++ b/admin/frontend/src/styles/colors.ts
@@ -23,3 +23,4 @@ export const COLOR_GREEN = '#4b944d';
 export const COLOR_GREEN_DARKER = '#2e8540';
 export const COLOR_GREEN_LIGHT = '#4f8747';
 export const COLOR_GREEN_LIGHTEST = '#e0eddb';
+export const COLOR_YELLOW_ADVISORY_BG = 'rgba(241, 194, 27, 0.29)';

--- a/admin/frontend/test/components/public-access-status-badge/PublicAccessStatusBadge.test.tsx
+++ b/admin/frontend/test/components/public-access-status-badge/PublicAccessStatusBadge.test.tsx
@@ -1,0 +1,84 @@
+import { PublicAccessStatusBadge } from '@/components/public-access-status-badge/PublicAccessStatusBadge';
+import {
+  COLOR_BACKGROUND_GREY,
+  COLOR_GOLD_DARK,
+  COLOR_GREEN_DARKER,
+  COLOR_GREEN_LIGHTEST,
+  COLOR_GREY,
+  COLOR_YELLOW_ADVISORY_BG,
+} from '@/styles/colors';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+describe('PublicAccessStatusBadge', () => {
+  it('renders the label text', () => {
+    render(<PublicAccessStatusBadge label="Open" />);
+    expect(screen.getByText('Open')).toBeInTheDocument();
+  });
+
+  it('defaults to Open label and green colors when label is null', () => {
+    render(<PublicAccessStatusBadge label={null} />);
+    const badge = screen.getByText('Open');
+    expect(badge).toBeInTheDocument();
+    expect(badge).toHaveStyle({
+      backgroundColor: COLOR_GREEN_LIGHTEST,
+      color: COLOR_GREEN_DARKER,
+    });
+  });
+
+  it('renders Open with green colors', () => {
+    render(<PublicAccessStatusBadge label="Open" />);
+    expect(screen.getByText('Open')).toHaveStyle({
+      backgroundColor: COLOR_GREEN_LIGHTEST,
+      color: COLOR_GREEN_DARKER,
+    });
+  });
+
+  it('renders Seasonal restrictions with green colors', () => {
+    render(<PublicAccessStatusBadge label="Seasonal restrictions" />);
+    expect(screen.getByText('Seasonal restrictions')).toHaveStyle({
+      backgroundColor: COLOR_GREEN_LIGHTEST,
+      color: COLOR_GREEN_DARKER,
+    });
+  });
+
+  it('renders Closed with grey colors', () => {
+    render(<PublicAccessStatusBadge label="Closed" />);
+    expect(screen.getByText('Closed')).toHaveStyle({
+      backgroundColor: COLOR_BACKGROUND_GREY,
+      color: COLOR_GREY,
+    });
+  });
+
+  it('renders Restricted with grey colors', () => {
+    render(<PublicAccessStatusBadge label="Restricted" />);
+    expect(screen.getByText('Restricted')).toHaveStyle({
+      backgroundColor: COLOR_BACKGROUND_GREY,
+      color: COLOR_GREY,
+    });
+  });
+
+  it('renders Limited access with yellow advisory colors', () => {
+    render(<PublicAccessStatusBadge label="Limited access" />);
+    expect(screen.getByText('Limited access')).toHaveStyle({
+      backgroundColor: COLOR_YELLOW_ADVISORY_BG,
+      color: COLOR_GOLD_DARK,
+    });
+  });
+
+  it('renders Visit with caution with yellow advisory colors', () => {
+    render(<PublicAccessStatusBadge label="Visit with caution" />);
+    expect(screen.getByText('Visit with caution')).toHaveStyle({
+      backgroundColor: COLOR_YELLOW_ADVISORY_BG,
+      color: COLOR_GOLD_DARK,
+    });
+  });
+
+  it('falls back to default green colors for unrecognized labels', () => {
+    render(<PublicAccessStatusBadge label="Unknown Status" />);
+    expect(screen.getByText('Unknown Status')).toHaveStyle({
+      backgroundColor: COLOR_GREEN_LIGHTEST,
+      color: COLOR_GREEN_DARKER,
+    });
+  });
+});

--- a/admin/frontend/test/pages/admin-search-page/components/AppliedFilterChips.test.tsx
+++ b/admin/frontend/test/pages/admin-search-page/components/AppliedFilterChips.test.tsx
@@ -7,7 +7,6 @@ describe('AppliedFilterChips', () => {
   it('renders all active chip labels', () => {
     render(
       <AppliedFilterChips
-        onClearCommunity={vi.fn()}
         chips={[
           { key: 'query', label: 'Query: tamihi', onClear: vi.fn() },
           { key: 'type', label: 'Site', onClear: vi.fn() },
@@ -27,7 +26,6 @@ describe('AppliedFilterChips', () => {
 
     render(
       <AppliedFilterChips
-        onClearCommunity={vi.fn()}
         chips={[
           {
             key: 'query',
@@ -46,9 +44,7 @@ describe('AppliedFilterChips', () => {
   });
 
   it('renders nothing when no chips are active', () => {
-    const { container } = render(
-      <AppliedFilterChips chips={[]} onClearCommunity={vi.fn()} />,
-    );
+    const { container } = render(<AppliedFilterChips chips={[]} />);
 
     expect(container).toBeEmptyDOMElement();
   });

--- a/admin/frontend/test/pages/admin-search-page/components/ColumnVisibilityMenu.test.tsx
+++ b/admin/frontend/test/pages/admin-search-page/components/ColumnVisibilityMenu.test.tsx
@@ -1,9 +1,19 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ColumnVisibilityMenu } from '@/pages/search/components/ColumnVisibilityMenu';
 
+const mockUseAuthorizations = vi.fn();
+
+vi.mock('@/hooks/useAuthorizations', () => ({
+  useAuthorizations: () => mockUseAuthorizations(),
+}));
+
 describe('ColumnVisibilityMenu', () => {
+  beforeEach(() => {
+    mockUseAuthorizations.mockReturnValue({ canViewFeatureFlag: false });
+  });
+
   it('stays open while toggling columns and closes on outside click', async () => {
     const user = userEvent.setup();
     const onToggle = vi.fn();
@@ -70,5 +80,40 @@ describe('ColumnVisibilityMenu', () => {
     expect(
       screen.queryByRole('button', { name: /rec #/i }),
     ).not.toBeInTheDocument();
+  });
+
+  it('hides the public access status column when canViewFeatureFlag is false', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <ColumnVisibilityMenu
+        visibleColumns={['rec_resource_id', 'name']}
+        onToggle={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Columns' }));
+
+    expect(
+      screen.queryByRole('button', { name: /public access status/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows the public access status column when canViewFeatureFlag is true', async () => {
+    mockUseAuthorizations.mockReturnValue({ canViewFeatureFlag: true });
+    const user = userEvent.setup();
+
+    render(
+      <ColumnVisibilityMenu
+        visibleColumns={['rec_resource_id', 'name']}
+        onToggle={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Columns' }));
+
+    expect(
+      screen.getByRole('button', { name: /public access status/i }),
+    ).toBeInTheDocument();
   });
 });

--- a/admin/frontend/test/pages/admin-search-page/components/SearchResultsBehavior.test.tsx
+++ b/admin/frontend/test/pages/admin-search-page/components/SearchResultsBehavior.test.tsx
@@ -122,6 +122,7 @@ describe('FilterAccordion', () => {
           statusOptions: [],
           accessOptions: [{ id: 'W', label: 'Walk-in', is_archived: false }],
           establishedOptions,
+          publicAccessStatusOptions: [],
           applyFilters,
           resetFilters: vi.fn(),
         }}
@@ -152,6 +153,8 @@ describe('FilterAccordion', () => {
       closestCommunity: [],
       establishment_date_from: '2020-01-01',
       establishment_date_to: '2021-01-01',
+      established: undefined,
+      publicAccessStatus: [],
     });
   });
 
@@ -177,6 +180,7 @@ describe('FilterAccordion', () => {
           statusOptions: [],
           accessOptions: [],
           establishedOptions,
+          publicAccessStatusOptions: [],
           closestCommunityOptions: [],
           applyFilters: vi.fn(),
           resetFilters,
@@ -232,6 +236,7 @@ describe('FilterAccordion', () => {
           statusOptions: [],
           accessOptions: [],
           establishedOptions,
+          publicAccessStatusOptions: [],
           closestCommunityOptions: [],
           applyFilters: vi.fn(),
           resetFilters: vi.fn(),
@@ -266,6 +271,7 @@ describe('FilterAccordion', () => {
           statusOptions: [],
           accessOptions: [],
           establishedOptions,
+          publicAccessStatusOptions: [],
           closestCommunityOptions: [],
           applyFilters,
           resetFilters: vi.fn(),
@@ -292,6 +298,7 @@ describe('FilterAccordion', () => {
       establishment_date_from: undefined,
       establishment_date_to: undefined,
       established: 'yes',
+      publicAccessStatus: [],
     });
   });
 
@@ -315,6 +322,7 @@ describe('FilterAccordion', () => {
           statusOptions: [],
           accessOptions: [],
           establishedOptions,
+          publicAccessStatusOptions: [],
           closestCommunityOptions: [],
           applyFilters,
           resetFilters: vi.fn(),
@@ -341,6 +349,7 @@ describe('FilterAccordion', () => {
       establishment_date_from: undefined,
       establishment_date_to: undefined,
       established: undefined,
+      publicAccessStatus: [],
     });
   });
 
@@ -364,6 +373,7 @@ describe('FilterAccordion', () => {
           statusOptions: [],
           accessOptions: [],
           establishedOptions,
+          publicAccessStatusOptions: [],
           closestCommunityOptions: [],
           applyFilters: vi.fn(),
           resetFilters: vi.fn(),
@@ -399,6 +409,7 @@ describe('FilterAccordion', () => {
           statusOptions: [],
           accessOptions: [],
           establishedOptions,
+          publicAccessStatusOptions: [],
           closestCommunityOptions: [],
           applyFilters: vi.fn(),
           resetFilters,

--- a/admin/frontend/test/pages/admin-search-page/components/SearchResultsTable.test.tsx
+++ b/admin/frontend/test/pages/admin-search-page/components/SearchResultsTable.test.tsx
@@ -10,6 +10,12 @@ vi.mock('@tanstack/react-router', () => ({
   useNavigate: () => mockNavigate,
 }));
 
+const mockUseAuthorizations = vi.fn();
+
+vi.mock('@/hooks/useAuthorizations', () => ({
+  useAuthorizations: () => mockUseAuthorizations(),
+}));
+
 function createPagination() {
   return {
     state: { pageIndex: 0, pageSize: 25 },
@@ -46,6 +52,62 @@ describe('SearchResultsTable', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    // Default to no feature-flag access, matching production behaviour with no
+    // AuthContext provider. The public access status column stays hidden.
+    mockUseAuthorizations.mockReturnValue({ canViewFeatureFlag: false });
+  });
+
+  it('hides the public access status column without feature-flag access', () => {
+    render(
+      <SearchResultsTable
+        rows={rows}
+        visibleColumns={['rec_resource_id', 'public_access_status']}
+        sort="name:asc"
+        pagination={createPagination()}
+        isLoading={false}
+        onSortChange={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.queryByRole('button', { name: /sort by public access status/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders the public access status as a badge when feature-flag access is granted', () => {
+    mockUseAuthorizations.mockReturnValue({ canViewFeatureFlag: true });
+
+    render(
+      <SearchResultsTable
+        rows={[{ ...rows[0], publicAccessStatus: 'Closed' }]}
+        visibleColumns={['rec_resource_id', 'public_access_status']}
+        sort="name:asc"
+        pagination={createPagination()}
+        isLoading={false}
+        onSortChange={vi.fn()}
+      />,
+    );
+
+    const badge = screen.getByText('Closed');
+    expect(badge.tagName).toBe('SPAN');
+    expect(badge).toHaveClass('custom-badge');
+  });
+
+  it('falls back to an Open badge when the public access status is null', () => {
+    mockUseAuthorizations.mockReturnValue({ canViewFeatureFlag: true });
+
+    render(
+      <SearchResultsTable
+        rows={[{ ...rows[0], publicAccessStatus: null }]}
+        visibleColumns={['rec_resource_id', 'public_access_status']}
+        sort="name:asc"
+        pagination={createPagination()}
+        isLoading={false}
+        onSortChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText('Open')).toBeInTheDocument();
   });
 
   it('renders only the visible columns', () => {

--- a/admin/frontend/test/pages/admin-search-page/components/SearchResultsTable.test.tsx
+++ b/admin/frontend/test/pages/admin-search-page/components/SearchResultsTable.test.tsx
@@ -17,7 +17,9 @@ function createPagination() {
     rowCount: 1,
     canPreviousPage: false,
     canNextPage: false,
+    pageSizeOptions: [25, 50, 100],
     setPageIndex: vi.fn(),
+    setPageSize: vi.fn(),
     previousPage: vi.fn(),
     nextPage: vi.fn(),
   };
@@ -37,6 +39,8 @@ describe('SearchResultsTable', () => {
       closestCommunity: 'Hope',
       status: 'Open',
       statusCode: 1,
+      visible: true,
+      publicAccessStatus: null,
     },
   ];
 

--- a/admin/frontend/test/pages/admin-search-page/hooks/useAdminSearchController.test.tsx
+++ b/admin/frontend/test/pages/admin-search-page/hooks/useAdminSearchController.test.tsx
@@ -386,6 +386,7 @@ describe('useAdminSearchController', () => {
         establishment_date_from: undefined,
         establishment_date_to: undefined,
         established: 'yes',
+        publicAccessStatus: [],
       });
     });
 
@@ -467,5 +468,78 @@ describe('useAdminSearchController', () => {
       { id: 'yes', label: 'Yes' },
       { id: 'no', label: 'No' },
     ]);
+  });
+
+  it('provides publicAccessStatusOptions from constants', () => {
+    const { result } = renderHook(
+      () => useAdminSearchController(DEFAULT_ADMIN_SEARCH_STATE),
+      { wrapper: createWrapper() },
+    );
+
+    expect(result.current.publicAccessStatusOptions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: 'Open', label: 'Open' }),
+        expect.objectContaining({ id: 'Closed', label: 'Closed' }),
+      ]),
+    );
+    expect(result.current.publicAccessStatusOptions.length).toBeGreaterThan(0);
+  });
+
+  it('generates filter chip for publicAccessStatus and clears on chip action', () => {
+    const search = {
+      ...DEFAULT_ADMIN_SEARCH_STATE,
+      publicAccessStatus: ['Closed', 'Restricted'],
+    };
+    const { result } = renderHook(() => useAdminSearchController(search), {
+      wrapper: createWrapper(),
+    });
+
+    const chips = result.current.appliedFilterChips.filter((chip) =>
+      chip.key.startsWith('publicAccessStatus:'),
+    );
+
+    expect(chips.map((chip) => chip.label)).toEqual(['Closed', 'Restricted']);
+
+    act(() => {
+      chips[0].onClear();
+    });
+
+    expect(mockNavigate).toHaveBeenCalledWith({
+      to: '/',
+      search: { publicAccessStatus: 'Restricted' },
+      resetScroll: false,
+    });
+  });
+
+  it('detects publicAccessStatus filter as active filter', () => {
+    const search = {
+      ...DEFAULT_ADMIN_SEARCH_STATE,
+      publicAccessStatus: ['Open'],
+    };
+    const { result } = renderHook(() => useAdminSearchController(search), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.hasAppliedState).toBe(true);
+  });
+
+  it('clears publicAccessStatus filter via clearPublicAccessStatus', () => {
+    const search = {
+      ...DEFAULT_ADMIN_SEARCH_STATE,
+      publicAccessStatus: ['Closed', 'Open'],
+    };
+    const { result } = renderHook(() => useAdminSearchController(search), {
+      wrapper: createWrapper(),
+    });
+
+    act(() => {
+      result.current.clearPublicAccessStatus('Closed');
+    });
+
+    expect(mockNavigate).toHaveBeenCalledWith({
+      to: '/',
+      search: { publicAccessStatus: 'Open' },
+      resetScroll: false,
+    });
   });
 });

--- a/admin/frontend/test/pages/admin-search-page/hooks/useSearchResultsTable.test.tsx
+++ b/admin/frontend/test/pages/admin-search-page/hooks/useSearchResultsTable.test.tsx
@@ -17,7 +17,9 @@ function createPagination(pageIndex = 0) {
     rowCount: 55,
     canPreviousPage: pageIndex > 0,
     canNextPage: pageIndex < 2,
+    pageSizeOptions: [25, 50, 100],
     setPageIndex: vi.fn(),
+    setPageSize: vi.fn(),
     previousPage: vi.fn(),
     nextPage: vi.fn(),
   };
@@ -34,6 +36,10 @@ const rows: AdminSearchResultRow[] = [
     feeType: 'Reservable, Has fees',
     definedCampsites: '3',
     closestCommunity: 'Hope',
+    status: 'Open',
+    statusCode: 1,
+    visible: true,
+    publicAccessStatus: null,
   },
 ];
 
@@ -123,7 +129,7 @@ describe('useSearchResultsTable', () => {
     interactionProps.onKeyDown({
       key: 'Enter',
       preventDefault,
-    } as KeyboardEvent<HTMLTableRowElement>);
+    } as unknown as KeyboardEvent<HTMLTableRowElement>);
 
     expect(preventDefault).toHaveBeenCalledTimes(1);
     expect(mockNavigate).toHaveBeenCalledTimes(2);

--- a/admin/frontend/test/pages/admin-search-page/searchResultsMapper.test.ts
+++ b/admin/frontend/test/pages/admin-search-page/searchResultsMapper.test.ts
@@ -64,4 +64,32 @@ describe('mapAdminSearchResultRow', () => {
       recStatusCode: 'AR',
     });
   });
+
+  it('maps publicAccessStatus from access_status_grouplabel', () => {
+    expect(
+      mapAdminSearchResultRow({
+        ...baseRow,
+        access_status_grouplabel: 'Closed',
+      }),
+    ).toMatchObject({
+      publicAccessStatus: 'Closed',
+    });
+  });
+
+  it('maps publicAccessStatus to null when access_status_grouplabel is null', () => {
+    expect(
+      mapAdminSearchResultRow({
+        ...baseRow,
+        access_status_grouplabel: null,
+      }),
+    ).toMatchObject({
+      publicAccessStatus: null,
+    });
+  });
+
+  it('maps publicAccessStatus to null when access_status_grouplabel is absent', () => {
+    expect(mapAdminSearchResultRow(baseRow)).toMatchObject({
+      publicAccessStatus: null,
+    });
+  });
 });

--- a/admin/frontend/test/pages/admin-search-page/utils/searchSchema.test.ts
+++ b/admin/frontend/test/pages/admin-search-page/utils/searchSchema.test.ts
@@ -77,4 +77,43 @@ describe('validateAdminSearch', () => {
       ),
     ).toEqual(['rec_resource_id', 'name', 'recreation_resource_type']);
   });
+
+  it('parses publicAccessStatus token list in validateAdminSearch', () => {
+    expect(
+      validateAdminSearch({
+        publicAccessStatus: 'Open_Closed',
+      }),
+    ).toEqual({
+      publicAccessStatus: 'Open_Closed',
+    });
+  });
+
+  it('omits publicAccessStatus from validated state when absent', () => {
+    expect(validateAdminSearch({})).toEqual({});
+  });
+
+  it('resolves publicAccessStatus token list in resolveAdminSearchRouteState', () => {
+    expect(
+      resolveAdminSearchRouteState({
+        publicAccessStatus: 'Open_Closed',
+      }),
+    ).toMatchObject({
+      publicAccessStatus: ['Open', 'Closed'],
+    });
+  });
+
+  it('resolves empty publicAccessStatus when not present in route state', () => {
+    expect(resolveAdminSearchRouteState({})).toMatchObject({
+      publicAccessStatus: [],
+    });
+  });
+
+  it('accepts public_access_status:asc and public_access_status:desc sort values', () => {
+    expect(validateAdminSearch({ sort: 'public_access_status:asc' })).toEqual({
+      sort: 'public_access_status_asc',
+    });
+    expect(validateAdminSearch({ sort: 'public_access_status:desc' })).toEqual({
+      sort: 'public_access_status_desc',
+    });
+  });
 });

--- a/admin/frontend/test/pages/admin-search-page/utils/urlState.test.ts
+++ b/admin/frontend/test/pages/admin-search-page/utils/urlState.test.ts
@@ -6,6 +6,7 @@ import {
   setAdminSearchEstablishmentDateToFilter,
   setAdminSearchEstablishedFilter,
   setAdminSearchPageSize,
+  setAdminSearchPublicAccessStatusFilter,
   setAdminSearchTypeFilter,
   submitAdminSearchQuery,
 } from '@/pages/search/utils/urlState';
@@ -165,6 +166,38 @@ describe('admin search urlState helpers', () => {
       }),
     ).toEqual({
       sort: 'rec_resource_id_desc',
+    });
+  });
+
+  it('serializes publicAccessStatus filter with underscore delimiter', () => {
+    expect(
+      serializeAdminSearchRouteState({
+        ...DEFAULT_ADMIN_SEARCH_STATE,
+        publicAccessStatus: ['Open', 'Closed'],
+      }),
+    ).toEqual({
+      publicAccessStatus: 'Open_Closed',
+    });
+  });
+
+  it('omits publicAccessStatus from serialized state when empty', () => {
+    expect(
+      serializeAdminSearchRouteState({
+        ...DEFAULT_ADMIN_SEARCH_STATE,
+        publicAccessStatus: [],
+      }),
+    ).toEqual({});
+  });
+
+  it('sets publicAccessStatus filter and resets page', () => {
+    expect(
+      setAdminSearchPublicAccessStatusFilter(baseState, [
+        'Closed',
+        'Restricted',
+      ]),
+    ).toMatchObject({
+      publicAccessStatus: ['Closed', 'Restricted'],
+      page: 1,
     });
   });
 

--- a/admin/frontend/test/services/hooks/recreation-resource-admin/searchQueryOptions.test.ts
+++ b/admin/frontend/test/services/hooks/recreation-resource-admin/searchQueryOptions.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+import { buildAdminSearchRequest } from '@/services/hooks/recreation-resource-admin/searchQueryOptions';
+import { DEFAULT_ADMIN_SEARCH_STATE } from '@/pages/search/constants';
+
+describe('buildAdminSearchRequest', () => {
+  it('maps default state with empty arrays to undefined filter fields', () => {
+    const result = buildAdminSearchRequest(DEFAULT_ADMIN_SEARCH_STATE);
+
+    expect(result.type).toBeUndefined();
+    expect(result.district).toBeUndefined();
+    expect(result.activities).toBeUndefined();
+    expect(result.status).toBeUndefined();
+    expect(result.access).toBeUndefined();
+    expect(result.closestCommunity).toBeUndefined();
+    expect(result.publicAccessStatus).toBeUndefined();
+  });
+
+  it('passes publicAccessStatus array when non-empty', () => {
+    const result = buildAdminSearchRequest({
+      ...DEFAULT_ADMIN_SEARCH_STATE,
+      publicAccessStatus: ['Closed', 'Restricted'],
+    });
+
+    expect(result.publicAccessStatus).toEqual(['Closed', 'Restricted']);
+  });
+
+  it('omits publicAccessStatus when empty array', () => {
+    const result = buildAdminSearchRequest({
+      ...DEFAULT_ADMIN_SEARCH_STATE,
+      publicAccessStatus: [],
+    });
+
+    expect(result.publicAccessStatus).toBeUndefined();
+  });
+
+  it('maps q, sort, page, pageSize from search state', () => {
+    const result = buildAdminSearchRequest({
+      ...DEFAULT_ADMIN_SEARCH_STATE,
+      q: 'lake',
+      sort: 'name:desc',
+      page: 3,
+      page_size: 50,
+    });
+
+    expect(result.q).toBe('lake');
+    expect(result.sort).toBe('name:desc');
+    expect(result.page).toBe(3);
+    expect(result.pageSize).toBe(50);
+  });
+
+  it('sets q to undefined when empty string', () => {
+    const result = buildAdminSearchRequest({
+      ...DEFAULT_ADMIN_SEARCH_STATE,
+      q: '',
+    });
+
+    expect(result.q).toBeUndefined();
+  });
+
+  it('passes non-empty type, district, activities, status, access, closestCommunity', () => {
+    const result = buildAdminSearchRequest({
+      ...DEFAULT_ADMIN_SEARCH_STATE,
+      type: ['RTR'],
+      district: ['D1'],
+      activities: ['8'],
+      status: ['1'],
+      access: ['W'],
+      closestCommunity: ['WHISTLER'],
+    });
+
+    expect(result.type).toEqual(['RTR']);
+    expect(result.district).toEqual(['D1']);
+    expect(result.activities).toEqual(['8']);
+    expect(result.status).toEqual(['1']);
+    expect(result.access).toEqual(['W']);
+    expect(result.closestCommunity).toEqual(['WHISTLER']);
+  });
+
+  it('passes established and date range as-is', () => {
+    const result = buildAdminSearchRequest({
+      ...DEFAULT_ADMIN_SEARCH_STATE,
+      established: 'yes',
+      establishment_date_from: '2020-01-01',
+      establishment_date_to: '2021-12-31',
+    });
+
+    expect(result.established).toBe('yes');
+    expect(result.establishmentDateFrom).toBe('2020-01-01');
+    expect(result.establishmentDateTo).toBe('2021-12-31');
+  });
+});

--- a/migrations/fixtures/sql/V1.1.21__advisories_data.sql
+++ b/migrations/fixtures/sql/V1.1.21__advisories_data.sql
@@ -7,110 +7,110 @@ INSERT INTO rst.act_advisories_flat (
     expiry_date, updated_date, published_at,
     listing_rank, urgency_sequence, access_status_precedence, event_type_precedence
 ) VALUES
--- 1. Ecological Reserve Access Restriction (permit required, High urgency, Restricted access)
-('REC204117', 1067, 'A permit is required to access this ecological reserve', '<div>Permits are available for research and educational activities only.</div>', 'Sarah Mitchell',
+-- 1. Season permit required — top advisory on REC204117 (precedence 40, Restricted)
+('REC204117', 1067, 'Season fee permit required for trail access', '<div>Trail fee permits must be purchased and displayed on vehicles. Managed in partnership with the Coquihalla Summit Snowmobile Club during the fee collection period.</div>', 'Sarah Mitchell',
  'Restricted: permit required', 'Restricted', 'A permit is required to enter this park - typically for ecological reserves only',
  'Access restricted', 'High', 'Published', false,
  false, false, false, false,
  '2021-07-12 06:30:41+00', '2021-07-12 06:30:41+00', NULL,
- NULL, '2021-07-12 06:30:41+00', '2025-01-08 19:28:11+00',
+ '2026-11-01 00:00:00+00', '2021-07-12 06:30:41+00', '2025-01-08 19:28:11+00',
  0, 3, 40, 172),
 
--- 2. Trail Closure (High urgency, Closed access)
+-- 2. Full trail closure — top advisory on REC1222 (precedence 10, Closed) ← CLOSED resource 1
 ('REC1222', 1068, 'Main trail closed due to severe washout and debris', '<div>Flooding has compromised the lower bridge. Structural engineering assessment pending.</div>', 'James Okafor',
  'Full closure', 'Closed', 'The entire park or specific trails are completely closed to all public access.',
  'Trail closure', 'High', 'Published', false,
  true, true, false, true,
  '2026-05-15 08:00:00+00', '2026-05-15 08:00:00+00', NULL,
- NULL, '2026-05-16 14:22:10+00', '2026-05-16 14:25:00+00',
+ '2026-09-01 00:00:00+00', '2026-05-16 14:22:10+00', '2026-05-16 14:25:00+00',
  0, 3, 10, 180),
 
--- 3. Wildlife Migration Notice (Low urgency, Open access)
-('REC160773', 1069, 'Seasonal wildlife migration activity in area', '<div>Expect heavy elk presence along the northern boundary roads. Please drive with caution.</div>', 'Priya Sandhu',
- 'Open', 'Open', 'Park facilities are running under normal conditions.',
- 'Wildlife', 'Low', 'Published', false,
- false, true, false, false,
- '2026-05-20 12:00:00+00', '2026-05-22 00:00:00+00', NULL,
- NULL, '2026-05-20 12:00:00+00', '2026-05-20 12:05:00+00',
- 0, 1, 999, 75),
+-- 3. Wildfire evacuation order — top advisory on REC203239 (precedence 20, Closed) ← CLOSED resource 2
+('REC203239', 1069, 'EVACUATION ORDER: Active wildfire within park boundary', '<div>An active wildfire is burning within 2 km of the parking lot. All visitors must leave immediately. Firefighting crews are on site.</div>', 'Priya Sandhu',
+ 'Under evacuation order', 'Closed', 'Immediate threat to human safety requires emergency park clearing.',
+ 'Wildfire', 'High', 'Published', true,
+ true, true, false, true,
+ '2026-05-20 12:00:00+00', '2026-05-20 12:00:00+00', NULL,
+ '2026-07-15 00:00:00+00', '2026-05-20 14:30:00+00', '2026-05-20 14:31:00+00',
+ 0, 3, 20, 65),
 
--- 4. Service Disruption with Reservation Impact (Medium urgency, Open access)
-('REC204117', 1070, 'Campground power grid upgrade delays reservation window', '<div>Electrical maintenance has been extended. Affected reservation holders will be contacted.</div>', 'Sarah Mitchell',
- 'Open', 'Open', 'Park facilities are running under normal conditions.',
- 'Service disruption', 'Medium', 'Published', true,
- true, true, true, true,
- '2026-05-25 09:15:00+00', '2026-06-01 00:00:00+00', '2026-06-15 18:00:00+00',
- '2026-06-16 00:00:00+00', '2026-05-25 10:00:00+00', '2026-05-25 10:02:00+00',
- 0, 2, 999, 120),
-
--- 5. Bear Safety Warning (High urgency, Visit with caution) — secondary advisory on REC1222, beaten by Closed
-('REC1222', 1071, 'Aggressive bear encounter reported near lakeside cache', '<div>A defensive black bear was reported near campsite 4. Ensure all attractants are locked up.</div>', 'James Okafor',
- 'Warning', 'Visit with caution', 'A public-safety-related incident has occurred that may affect access to the park',
- 'Public safety', 'High', 'Published', false,
- true, true, false, false,
- '2026-05-28 17:30:00+00', '2026-05-28 17:30:00+00', NULL,
- NULL, '2026-05-28 17:45:00+00', '2026-05-28 17:46:00+00',
- 0, 3, 92, 70),
-
--- 6. Seasonal Restrictions — top advisory on REC160773 (urgency_sequence=2 beats the Open advisories at 1)
-('REC160773', 1072, 'Seasonal facility closures — some day use amenities unavailable', '<div>Seasonal road closures are in effect for specific access routes. Check posted notices before visiting.</div>', 'Priya Sandhu',
+-- 4. Seasonal cabin access restrictions — top advisory on REC160773 (precedence 120, Seasonal restrictions)
+('REC160773', 1070, 'Seasonal facility closures — cabin restricted to emergency use only', '<div>Winter seasonal access restrictions are in effect. The 10K cabin is for emergency use only during avalanche season. Check local conditions before visiting.</div>', 'Priya Sandhu',
  'Seasonal restrictions', 'Seasonal restrictions', 'Seasonal access restrictions are in effect.',
  'Seasonal closure', 'Medium', 'Published', false,
  true, true, true, false,
  '2026-05-30 11:00:00+00', '2026-06-10 07:00:00+00', NULL,
- NULL, '2026-05-30 11:00:00+00', '2026-05-30 11:35:00+00',
+ '2026-10-01 00:00:00+00', '2026-05-30 11:00:00+00', '2026-05-30 11:35:00+00',
  0, 2, 120, 65),
 
--- 7. Archived Construction Notice (Low urgency, Open access, fully closed out with removal date)
-('REC204117', 1073, 'Temporary construction noise near day use beach area', '<div>Heavy excavation equipment will be operating near the boat launch.</div>', 'Tom Belanger',
- 'Open', 'Open', 'Park facilities are running under normal conditions.',
- 'Construction', 'Low', 'Scheduled', false,
- true, true, true, true,
- '2026-09-01 08:00:00+00', '2026-09-05 08:00:00+00', '2026-09-10 17:00:00+00',
- '2026-09-11 00:00:00+00', '2026-04-10 17:05:00+00', '2026-04-01 08:30:00+00',
- 0, 1, 999, 280),
-
--- 8. Flash Flood Closure (High urgency, Closed — top advisory on REC1222 by updated_date tiebreak over 1068)
-('REC1222', 1074, 'EVACUATION ORDER: Extreme flash flood risk', '<div>Leave the riverbank corridors immediately. Park rangers are supervising staging areas.</div>', 'James Okafor',
- 'Under evacuation order', 'Closed', 'Immediate threat to human safety requires emergency park clearing.',
- 'Natural Hazard', 'High', 'Published', true,
- true, true, false, false,
- '2026-05-31 22:10:00+00', '2026-05-31 22:10:00+00', NULL,
- NULL, '2026-05-31 22:15:00+00', '2026-05-31 22:15:12+00',
- 0, 3, 20, 120),
-
--- 9. Boil Water Advisory (Medium urgency, Open access)
-('REC160773', 1075, 'Boil water advisory active for campground taps', '<div>Routine testing showed elevated bacterial counts. Water treatment infrastructure is being flushed.</div>', 'Tom Belanger',
- 'Open', 'Open', 'Park facilities are running under normal conditions.',
- 'Boil water advisory', 'Medium', 'Published', false,
- true, true, false, true,
- '2026-05-29 06:00:00+00', '2026-05-29 06:00:00+00', NULL,
- NULL, '2026-05-31 09:00:00+00', '2026-05-29 06:45:00+00',
- 0, 1, 999, 180),
-
--- 10. Campfire Ban (High urgency, Visit with caution) — secondary advisory on REC204117, beaten by Restricted (precedence 40 < 92)
-('REC204117', 1076, 'Category 1 open campfire ban instituted immediately', '<div>Due to climbing unseasonable indices, campfires are strictly prohibited across all backcountry sites.</div>', 'Sarah Mitchell',
- 'Warning', 'Visit with caution', 'Regional prohibitions or regulations have been modified.',
- 'Campfires', 'High', 'Published', false,
- true, true, false, false,
- '2026-06-01 12:00:00+00', '2026-06-01 12:00:00+00', NULL,
- NULL, '2026-06-01 12:00:00+00', '2026-06-01 12:01:15+00',
- 0, 3, 92, 65),
-
--- 11. Visit with caution — sole advisory on REC0108 (top advisory = Visit with caution)
-('REC0108', 1077, 'Bear activity warning near the day use area', '<div>A bear has been sighted frequenting the day use picnic area. Store food securely and supervise children.</div>', 'Tom Belanger',
+-- 5. Bear activity warning — top advisory on REC0108 (precedence 92, Visit with caution)
+('REC0108', 1071, 'Bear activity warning near the day use area', '<div>A bear has been sighted frequenting the day use picnic area. Store food securely and supervise children at all times.</div>', 'Tom Belanger',
  'Warning', 'Visit with caution', 'A public-safety-related incident has occurred that may affect access to the park',
  'Public safety', 'High', 'Published', false,
  true, true, false, true,
  '2026-06-02 09:00:00+00', '2026-06-02 09:00:00+00', NULL,
- NULL, '2026-06-02 09:15:00+00', '2026-06-02 09:16:00+00',
+ '2026-08-02 00:00:00+00', '2026-06-02 09:15:00+00', '2026-06-02 09:16:00+00',
  0, 3, 92, 70),
 
--- 12. Limited access — sole advisory on REC0180 (top advisory = Limited access)
-('REC0180', 1078, 'North access road partially closed for bridge repairs', '<div>Bridge structural repairs are underway on the north access road. Single-lane alternating traffic in effect.</div>', 'James Okafor',
+-- 6. Partial road closure — top advisory on REC0180 (precedence 50, Limited access)
+('REC0180', 1072, 'North access road partially closed for bridge repairs', '<div>Bridge structural repairs are underway on the north access road. Single-lane alternating traffic in effect.</div>', 'James Okafor',
  'Partial closure', 'Limited access', 'There is a legal order that prohibits entry to a portion of this park.',
  'Trail closure', 'High', 'Published', false,
  true, true, false, true,
  '2026-06-03 08:00:00+00', '2026-06-03 08:00:00+00', NULL,
- NULL, '2026-06-03 08:30:00+00', '2026-06-03 08:31:00+00',
- 0, 3, 50, 180);
+ '2026-09-03 00:00:00+00', '2026-06-03 08:30:00+00', '2026-06-03 08:31:00+00',
+ 0, 3, 50, 180),
+
+-- 7. Trail signage update — sole advisory on REC6866 (precedence 999, Open)
+('REC6866', 1073, 'Historic trail route markers refreshed for the summer season', '<div>New waymarkers and interpretive signage have been installed along the 1861 Goldrush Pack Trail. Trail is fully open and in excellent condition.</div>', 'Sarah Mitchell',
+ 'Open', 'Open', 'Park facilities are running under normal conditions.',
+ 'Construction', 'Low', 'Published', false,
+ true, true, true, true,
+ '2026-05-01 08:00:00+00', '2026-05-05 08:00:00+00', '2026-05-15 17:00:00+00',
+ '2026-05-16 00:00:00+00', '2026-05-01 17:05:00+00', '2026-05-01 08:30:00+00',
+ 0, 1, 999, 280),
+
+-- 8. Elevated water levels notice — sole advisory on REC203900 (precedence 999, Open)
+('REC203900', 1074, 'Seasonal water levels affecting shoreline access at 18 Mile', '<div>Water levels on Revelstoke Lake are elevated this season due to power generation cycles. Shoreline campsites remain accessible but may be wet near the water line.</div>', 'James Okafor',
+ 'Open', 'Open', 'Park facilities are running under normal conditions.',
+ 'Flooding', 'Low', 'Published', false,
+ false, true, false, false,
+ '2026-05-18 09:00:00+00', '2026-05-18 09:00:00+00', NULL,
+ '2026-09-30 00:00:00+00', '2026-05-18 09:30:00+00', '2026-05-18 09:31:00+00',
+ 0, 1, 999, 120),
+
+-- 9. Wildlife migration notice — sole advisory on REC2094 (precedence 999, Open)
+('REC2094', 1075, 'Seasonal wildlife migration activity near Bull River confluence', '<div>Expect elk and deer presence along the river corridor. Please observe wildlife from a distance and store food securely at all times.</div>', 'Tom Belanger',
+ 'Open', 'Open', 'Park facilities are running under normal conditions.',
+ 'Wildlife', 'Low', 'Published', false,
+ false, true, false, false,
+ '2026-05-22 12:00:00+00', '2026-05-24 00:00:00+00', NULL,
+ '2026-07-22 00:00:00+00', '2026-05-22 12:00:00+00', '2026-05-22 12:05:00+00',
+ 0, 1, 999, 75),
+
+-- 10. Campfire ban — secondary advisory on REC204117 (precedence 92, beaten by Restricted at 40)
+('REC204117', 1076, 'Category 1 open campfire ban instituted immediately', '<div>Due to elevated fire risk in the Merritt area, campfires are strictly prohibited across all backcountry sites.</div>', 'Sarah Mitchell',
+ 'Warning', 'Visit with caution', 'Regional prohibitions or regulations have been modified.',
+ 'Campfires', 'High', 'Published', false,
+ true, true, false, false,
+ '2026-06-01 12:00:00+00', '2026-06-01 12:00:00+00', NULL,
+ '2026-09-30 00:00:00+00', '2026-06-01 12:00:00+00', '2026-06-01 12:01:15+00',
+ 0, 3, 92, 65),
+
+-- 11. Aggressive bear near campsite — secondary advisory on REC1222 (precedence 92, beaten by Full closure at 10)
+('REC1222', 1077, 'Aggressive bear encounter reported near lakeside cache', '<div>A defensive black bear was reported near campsite 4. Ensure all attractants are locked up.</div>', 'James Okafor',
+ 'Warning', 'Visit with caution', 'A public-safety-related incident has occurred that may affect access to the park',
+ 'Public safety', 'High', 'Published', false,
+ true, true, false, false,
+ '2026-05-28 17:30:00+00', '2026-05-28 17:30:00+00', NULL,
+ '2026-07-28 00:00:00+00', '2026-05-28 17:45:00+00', '2026-05-28 17:46:00+00',
+ 0, 3, 92, 70),
+
+-- 12. Boil water advisory — secondary advisory on REC160773 (precedence 999, beaten by Seasonal restrictions at 120)
+('REC160773', 1078, 'Boil water advisory active for cabin water supply', '<div>Routine testing showed elevated bacterial counts in the emergency cabin water supply. Use treated or bottled water only until further notice.</div>', 'Tom Belanger',
+ 'Open', 'Open', 'Park facilities are running under normal conditions.',
+ 'Boil water advisory', 'Medium', 'Published', false,
+ true, true, false, true,
+ '2026-05-29 06:00:00+00', '2026-05-29 06:00:00+00', NULL,
+ '2026-07-01 00:00:00+00', '2026-05-31 09:00:00+00', '2026-05-29 06:45:00+00',
+ 0, 1, 999, 180);

--- a/migrations/fixtures/sql/V1.1.21__advisories_data.sql
+++ b/migrations/fixtures/sql/V1.1.21__advisories_data.sql
@@ -18,21 +18,21 @@ INSERT INTO rst.act_advisories_flat (
 
 -- 2. Trail Closure (High urgency, Closed access)
 ('REC1222', 1068, 'Main trail closed due to severe washout and debris', '<div>Flooding has compromised the lower bridge. Structural engineering assessment pending.</div>', 'James Okafor',
- 'Closed', 'Closed', 'The entire park or specific trails are completely closed to all public access.',
+ 'Full closure', 'Closed', 'The entire park or specific trails are completely closed to all public access.',
  'Trail closure', 'High', 'Published', false,
  true, true, false, true,
  '2026-05-15 08:00:00+00', '2026-05-15 08:00:00+00', NULL,
  NULL, '2026-05-16 14:22:10+00', '2026-05-16 14:25:00+00',
- 1, 3, 50, 180),
+ 0, 3, 10, 180),
 
--- 3. Wildlife Migration Notice (Low urgency, Open access — low urgency advisories use Open status)
+-- 3. Wildlife Migration Notice (Low urgency, Open access)
 ('REC160773', 1069, 'Seasonal wildlife migration activity in area', '<div>Expect heavy elk presence along the northern boundary roads. Please drive with caution.</div>', 'Priya Sandhu',
  'Open', 'Open', 'Park facilities are running under normal conditions.',
  'Wildlife', 'Low', 'Published', false,
  false, true, false, false,
  '2026-05-20 12:00:00+00', '2026-05-22 00:00:00+00', NULL,
  NULL, '2026-05-20 12:00:00+00', '2026-05-20 12:05:00+00',
- 5, 1, 20, 100),
+ 0, 1, 999, 75),
 
 -- 4. Service Disruption with Reservation Impact (Medium urgency, Open access)
 ('REC204117', 1070, 'Campground power grid upgrade delays reservation window', '<div>Electrical maintenance has been extended. Affected reservation holders will be contacted.</div>', 'Sarah Mitchell',
@@ -41,58 +41,76 @@ INSERT INTO rst.act_advisories_flat (
  true, true, true, true,
  '2026-05-25 09:15:00+00', '2026-06-01 00:00:00+00', '2026-06-15 18:00:00+00',
  '2026-06-16 00:00:00+00', '2026-05-25 10:00:00+00', '2026-05-25 10:02:00+00',
- 2, 2, 10, 120),
+ 0, 2, 999, 120),
 
--- 5. Bear Safety Advisory (High urgency, Caution: Wildlife activity)
+-- 5. Bear Safety Warning (High urgency, Visit with caution) — secondary advisory on REC1222, beaten by Closed
 ('REC1222', 1071, 'Aggressive bear encounter reported near lakeside cache', '<div>A defensive black bear was reported near campsite 4. Ensure all attractants are locked up.</div>', 'James Okafor',
- 'Caution: Wildlife activity', 'Caution', NULL,
+ 'Warning', 'Visit with caution', 'A public-safety-related incident has occurred that may affect access to the park',
  'Public safety', 'High', 'Published', false,
  true, true, false, false,
  '2026-05-28 17:30:00+00', '2026-05-28 17:30:00+00', NULL,
  NULL, '2026-05-28 17:45:00+00', '2026-05-28 17:46:00+00',
- 0, 3, 30, 190),
+ 0, 3, 92, 70),
 
--- 6. Prescribed Burn Preparation — Draft, not yet published
-('REC160773', 1072, 'Scheduled preventative prescribed burn preparation', '<div>Crews will be staging equipment along the fire access roads. Draft review required before launch.</div>', 'Priya Sandhu',
- 'Information', 'Information', 'General park notice or update.',
- 'Fire Management', 'Low', 'Draft', false,
- false, false, false, false,
+-- 6. Seasonal Restrictions — top advisory on REC160773 (urgency_sequence=2 beats the Open advisories at 1)
+('REC160773', 1072, 'Seasonal facility closures — some day use amenities unavailable', '<div>Seasonal road closures are in effect for specific access routes. Check posted notices before visiting.</div>', 'Priya Sandhu',
+ 'Seasonal restrictions', 'Seasonal restrictions', 'Seasonal access restrictions are in effect.',
+ 'Seasonal closure', 'Medium', 'Published', false,
+ true, true, true, false,
  '2026-05-30 11:00:00+00', '2026-06-10 07:00:00+00', NULL,
- NULL, '2026-05-30 11:00:00+00', NULL,
- 10, 1, 10, 105),
+ NULL, '2026-05-30 11:00:00+00', '2026-05-30 11:35:00+00',
+ 0, 2, 120, 65),
 
 -- 7. Archived Construction Notice (Low urgency, Open access, fully closed out with removal date)
 ('REC204117', 1073, 'Temporary construction noise near day use beach area', '<div>Heavy excavation equipment will be operating near the boat launch.</div>', 'Tom Belanger',
  'Open', 'Open', 'Park facilities are running under normal conditions.',
  'Construction', 'Low', 'Scheduled', false,
  true, true, true, true,
- '2026-04-01 08:00:00+00', '2026-04-05 08:00:00+00', '2026-04-10 17:00:00+00',
- '2026-04-11 00:00:00+00', '2026-04-10 17:05:00+00', '2026-04-01 08:30:00+00',
- 99, 1, 0, 80),
+ '2026-09-01 08:00:00+00', '2026-09-05 08:00:00+00', '2026-09-10 17:00:00+00',
+ '2026-09-11 00:00:00+00', '2026-04-10 17:05:00+00', '2026-04-01 08:30:00+00',
+ 0, 1, 999, 280),
 
--- 8. Flash Flood Closure (High urgency, Closed — no Extreme urgency level in the real system)
+-- 8. Flash Flood Closure (High urgency, Closed — top advisory on REC1222 by updated_date tiebreak over 1068)
 ('REC1222', 1074, 'EVACUATION ORDER: Extreme flash flood risk', '<div>Leave the riverbank corridors immediately. Park rangers are supervising staging areas.</div>', 'James Okafor',
- 'Closed', 'Closed', 'Immediate threat to human safety requires emergency park clearing.',
+ 'Under evacuation order', 'Closed', 'Immediate threat to human safety requires emergency park clearing.',
  'Natural Hazard', 'High', 'Published', true,
  true, true, false, false,
  '2026-05-31 22:10:00+00', '2026-05-31 22:10:00+00', NULL,
  NULL, '2026-05-31 22:15:00+00', '2026-05-31 22:15:12+00',
- 0, 4, 100, 250),
+ 0, 3, 20, 120),
 
--- 9. Boil Water Advisory (Medium urgency, Open access — real boil water advisories use Open status)
+-- 9. Boil Water Advisory (Medium urgency, Open access)
 ('REC160773', 1075, 'Boil water advisory active for campground taps', '<div>Routine testing showed elevated bacterial counts. Water treatment infrastructure is being flushed.</div>', 'Tom Belanger',
  'Open', 'Open', 'Park facilities are running under normal conditions.',
  'Boil water advisory', 'Medium', 'Published', false,
  true, true, false, true,
  '2026-05-29 06:00:00+00', '2026-05-29 06:00:00+00', NULL,
  NULL, '2026-05-31 09:00:00+00', '2026-05-29 06:45:00+00',
- 3, 2, 35, 140),
+ 0, 1, 999, 180),
 
--- 10. Campfire Ban (High urgency, Caution)
+-- 10. Campfire Ban (High urgency, Visit with caution) — secondary advisory on REC204117, beaten by Restricted (precedence 40 < 92)
 ('REC204117', 1076, 'Category 1 open campfire ban instituted immediately', '<div>Due to climbing unseasonable indices, campfires are strictly prohibited across all backcountry sites.</div>', 'Sarah Mitchell',
- 'Caution', 'Caution', 'Regional prohibitions or regulations have been modified.',
+ 'Warning', 'Visit with caution', 'Regional prohibitions or regulations have been modified.',
  'Campfires', 'High', 'Published', false,
  true, true, false, false,
  '2026-06-01 12:00:00+00', '2026-06-01 12:00:00+00', NULL,
  NULL, '2026-06-01 12:00:00+00', '2026-06-01 12:01:15+00',
- 0, 3, 30, 200);
+ 0, 3, 92, 65),
+
+-- 11. Visit with caution — sole advisory on REC0108 (top advisory = Visit with caution)
+('REC0108', 1077, 'Bear activity warning near the day use area', '<div>A bear has been sighted frequenting the day use picnic area. Store food securely and supervise children.</div>', 'Tom Belanger',
+ 'Warning', 'Visit with caution', 'A public-safety-related incident has occurred that may affect access to the park',
+ 'Public safety', 'High', 'Published', false,
+ true, true, false, true,
+ '2026-06-02 09:00:00+00', '2026-06-02 09:00:00+00', NULL,
+ NULL, '2026-06-02 09:15:00+00', '2026-06-02 09:16:00+00',
+ 0, 3, 92, 70),
+
+-- 12. Limited access — sole advisory on REC0180 (top advisory = Limited access)
+('REC0180', 1078, 'North access road partially closed for bridge repairs', '<div>Bridge structural repairs are underway on the north access road. Single-lane alternating traffic in effect.</div>', 'James Okafor',
+ 'Partial closure', 'Limited access', 'There is a legal order that prohibits entry to a portion of this park.',
+ 'Trail closure', 'High', 'Published', false,
+ true, true, false, true,
+ '2026-06-03 08:00:00+00', '2026-06-03 08:00:00+00', NULL,
+ NULL, '2026-06-03 08:30:00+00', '2026-06-03 08:31:00+00',
+ 0, 3, 50, 180);


### PR DESCRIPTION
Don't merge until https://github.com/bcgov/nr-rec-resources/pull/1687 has been merged.

## Backend changes
- Added `public_access_status` as a filter param to the search endpoint. The filter matches resources based on their top ranked advisory only (using the same sort order provided by team Lynx), same order used elsewhere in the app. Resources with no advisories default to "Open".
- The search result row now includes `access_status_grouplabel`, pulled from `act_advisories_flat` using the same ranking with take: 1 (so the displayed value is always the top-ranked advisory).

## Frontend changes
- Added a "Public access status" column to the search results table (feature-flagged). It displays a colour coded badge using the access_status_grouplabel value from the API. The colour mapping is: grey for Closed/Restricted, yellow/gold for Visit with caution/Limited access, and green for Open/Seasonal restrictions. If the field is null (no advisories), it defaults to showing "Open" with the green badge.
- Added a "Public access status" filter to the filter panel (also feature-flagged). The filter options are hardcoded to the known group label values (Open, Seasonal restrictions, Visit with caution, Limited access, Restricted, Closed).
