### PR TITLE
feat: added super admin role

### DIFF
--- a/admin/backend/src/auth/auth.constants.ts
+++ b/admin/backend/src/auth/auth.constants.ts
@@ -7,6 +7,7 @@ export const AUTH_ROLES_KEY = 'roles';
 export enum RecreationResourceAuthRole {
   RST_ADMIN = 'rst-admin',
   RST_VIEWER = 'rst-viewer',
+  RST_SUPER_ADMIN = 'rst-super-admin',
 }
 
 // Role validation modes

--- a/admin/backend/src/auth/index.ts
+++ b/admin/backend/src/auth/index.ts
@@ -4,3 +4,5 @@ export * from './auth.types';
 export * from './auth-roles.guard';
 export * from './auth-roles.decorator';
 export * from './auth-papssport-keycloak-strategy.service';
+export * from './is-super-admin.decorator';
+export * from './super-admin.guard';

--- a/admin/backend/src/auth/is-super-admin.decorator.ts
+++ b/admin/backend/src/auth/is-super-admin.decorator.ts
@@ -1,0 +1,30 @@
+import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+import { RecreationResourceAuthRole } from './auth.constants';
+import { KeycloakUserToken } from './auth.types';
+
+/**
+ * Parameter decorator that resolves to `true` when the authenticated user
+ * has the `rst-super-admin` role, and `false` otherwise.
+ *
+ * Use this when a handler needs to branch on super-admin status without
+ * blocking the request entirely.
+ *
+ * @example
+ * ```ts
+ * async search(@IsSuperAdmin() isSuperAdmin: boolean) {
+ *   return this.service.search({ includeArchived: isSuperAdmin });
+ * }
+ * ```
+ */
+export const IsSuperAdmin = createParamDecorator(
+  (_data: unknown, ctx: ExecutionContext): boolean => {
+    const request = ctx
+      .switchToHttp()
+      .getRequest<{ user: KeycloakUserToken }>();
+    return (
+      request.user?.client_roles?.includes(
+        RecreationResourceAuthRole.RST_SUPER_ADMIN,
+      ) ?? false
+    );
+  },
+);

--- a/admin/backend/src/auth/super-admin.guard.ts
+++ b/admin/backend/src/auth/super-admin.guard.ts
@@ -1,0 +1,48 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  ForbiddenException,
+  Injectable,
+} from '@nestjs/common';
+import { RecreationResourceAuthRole } from './auth.constants';
+import { KeycloakUserToken } from './auth.types';
+
+/**
+ * Guard that restricts an entire endpoint (or controller) to users with the
+ * `rst-super-admin` role.  Apply it alongside the existing `AuthRolesGuard`
+ * when a feature should be completely hidden from regular admins.
+ *
+ * @example — protect a single endpoint:
+ * ```ts
+ * @UseGuards(SuperAdminGuard)
+ * @Delete(':id')
+ * async delete(@Param('id') id: string) { ... }
+ * ```
+ *
+ * @example — protect an entire controller:
+ * ```ts
+ * @UseGuards(AuthGuard('keycloak'), AuthRolesGuard, SuperAdminGuard)
+ * @Controller('admin/super-only')
+ * export class SuperOnlyController { ... }
+ * ```
+ */
+@Injectable()
+export class SuperAdminGuard implements CanActivate {
+  canActivate(context: ExecutionContext): boolean {
+    const request = context
+      .switchToHttp()
+      .getRequest<{ user: KeycloakUserToken }>();
+    const isSuperAdmin =
+      request.user?.client_roles?.includes(
+        RecreationResourceAuthRole.RST_SUPER_ADMIN,
+      ) ?? false;
+
+    if (!isSuperAdmin) {
+      throw new ForbiddenException(
+        'This action requires the rst-super-admin role.',
+      );
+    }
+
+    return true;
+  }
+}

--- a/admin/backend/src/recreation-resources/queries/recreation-resource-search.queries.ts
+++ b/admin/backend/src/recreation-resources/queries/recreation-resource-search.queries.ts
@@ -175,7 +175,10 @@ function buildMultiValueExistsCondition({
   `;
 }
 
-export function buildSearchWhereSql(query: AdminSearchQueryDto): Prisma.Sql {
+export function buildSearchWhereSql(
+  query: AdminSearchQueryDto,
+  includeArchived = false,
+): Prisma.Sql {
   const conditions = [
     buildSearchTextCondition(query.q),
     buildMultiValueExistsCondition({
@@ -224,6 +227,10 @@ export function buildSearchWhereSql(query: AdminSearchQueryDto): Prisma.Sql {
           'Open'
         ) IN (${Prisma.join(query.public_access_status)})
       `
+      : null,
+    // Exclude archived resources unless the caller explicitly includes them (super-admin)
+    !includeArchived
+      ? Prisma.sql`(rr.rec_status_code IS DISTINCT FROM 'AR')`
       : null,
   ].filter((condition): condition is Prisma.Sql => condition !== null);
 

--- a/admin/backend/src/recreation-resources/recreation-resource.controller.ts
+++ b/admin/backend/src/recreation-resources/recreation-resource.controller.ts
@@ -67,7 +67,7 @@ export class RecreationResourceController {
    * When a text query is active, only super-admins see archived resources.
    *
    * @param query - Search / filter parameters
-   * @param isSuperAdmin - Resolved by @IsSuperAdmin() from the JWT token
+   * @param req - The HTTP request (used to resolve super-admin status from JWT roles)
    */
   @AuthRoles(
     [
@@ -107,7 +107,7 @@ export class RecreationResourceController {
    * Archived resources are only suggested to super-admins.
    *
    * @param query - Contains the search_term
-   * @param isSuperAdmin - Resolved by @IsSuperAdmin() from the JWT token
+   * @param req - The HTTP request (used to resolve super-admin status from JWT roles)
    */
   @AuthRoles(
     [
@@ -196,7 +196,7 @@ export class RecreationResourceController {
    *
    * @param rec_resource_id - The ID of the recreation resource
    * @param updateData - The data to update
-   * @param isSuperAdmin - Resolved by @IsSuperAdmin() from the JWT token
+   * @param isSuperAdmin
    * @returns The updated recreation resource detail DTO
    * @throws ForbiddenException if a non-super-admin tries to edit an archived resource
    * @throws NotFoundException if resource not found

--- a/admin/backend/src/recreation-resources/recreation-resource.controller.ts
+++ b/admin/backend/src/recreation-resources/recreation-resource.controller.ts
@@ -2,6 +2,7 @@ import {
   AUTH_STRATEGY,
   AuthRoles,
   AuthRolesGuard,
+  IsSuperAdmin,
   RecreationResourceAuthRole,
   ROLE_MODE,
 } from '@/auth';
@@ -9,6 +10,7 @@ import { BadRequestResponseDto } from '@/common/dtos/bad-request-response.dto';
 import {
   Body,
   Controller,
+  ForbiddenException,
   Get,
   HttpException,
   Param,
@@ -34,6 +36,7 @@ import { SuggestionsQueryDto } from './dtos/suggestions-query.dto';
 import { SuggestionsResponseDto } from './dtos/suggestions-response.dto';
 import { UpdateRecreationResourceDto } from './dtos/update-recreation-resource.dto';
 import { RecreationResourceService } from './recreation-resource.service';
+import { RecreationResourceRepository } from './recreation-resource.repository';
 
 /**
  * Controller for recreation resource endpoints.
@@ -43,25 +46,34 @@ import { RecreationResourceService } from './recreation-resource.service';
 @ApiTags('recreation-resources')
 @ApiBearerAuth(AUTH_STRATEGY.KEYCLOAK)
 @UseGuards(AuthGuard(AUTH_STRATEGY.KEYCLOAK), AuthRolesGuard)
-@AuthRoles([RecreationResourceAuthRole.RST_ADMIN], ROLE_MODE.ALL)
+@AuthRoles(
+  [
+    RecreationResourceAuthRole.RST_ADMIN,
+    RecreationResourceAuthRole.RST_SUPER_ADMIN,
+  ],
+  ROLE_MODE.ANY,
+)
 export class RecreationResourceController {
   constructor(
     private readonly recreationResourceService: RecreationResourceService,
+    private readonly recreationResourceRepository: RecreationResourceRepository,
   ) {}
 
   /**
-   * GET /recreation-resource/suggestions
+   * GET /recreation-resources/search
    *
-   * Returns recreation resource suggestions based on a search term.
-   * Only accessible to users with the 'rst-viewer' role.
+   * Returns paginated search results.
+   * Archived resources are always visible when browsing (no text query).
+   * When a text query is active, only super-admins see archived resources.
    *
-   * @param query - Query parameters containing the searchTerm
-   * @returns SuggestionsResponseDto containing total and data array
+   * @param query - Search / filter parameters
+   * @param isSuperAdmin - Resolved by @IsSuperAdmin() from the JWT token
    */
   @AuthRoles(
     [
       RecreationResourceAuthRole.RST_VIEWER,
       RecreationResourceAuthRole.RST_ADMIN,
+      RecreationResourceAuthRole.RST_SUPER_ADMIN,
     ],
     ROLE_MODE.ANY,
   )
@@ -76,14 +88,32 @@ export class RecreationResourceController {
   })
   async searchResources(
     @Query() query: AdminSearchQueryDto,
+    @IsSuperAdmin() isSuperAdmin: boolean,
   ): Promise<AdminSearchResponseDto> {
-    return await this.recreationResourceService.searchResources(query);
+    // Show archived resources when browsing the table (no text query) so all
+    // admin users can see them.  When an active text search is applied, only
+    // super-admins see archived results.
+    const isTextSearch = Boolean(query.q?.trim());
+    const includeArchived = !isTextSearch || isSuperAdmin;
+    return await this.recreationResourceService.searchResources(query, {
+      includeArchived,
+    });
   }
 
+  /**
+   * GET /recreation-resources/suggestions
+   *
+   * Returns typeahead suggestions.
+   * Archived resources are only suggested to super-admins.
+   *
+   * @param query - Contains the search_term
+   * @param isSuperAdmin - Resolved by @IsSuperAdmin() from the JWT token
+   */
   @AuthRoles(
     [
       RecreationResourceAuthRole.RST_VIEWER,
       RecreationResourceAuthRole.RST_ADMIN,
+      RecreationResourceAuthRole.RST_SUPER_ADMIN,
     ],
     ROLE_MODE.ANY,
   )
@@ -103,14 +133,16 @@ export class RecreationResourceController {
   })
   async getSuggestions(
     @Query() query: SuggestionsQueryDto,
+    @IsSuperAdmin() isSuperAdmin: boolean,
   ): Promise<SuggestionsResponseDto> {
     return await this.recreationResourceService.getSuggestions(
       query.search_term,
+      { includeArchived: isSuperAdmin },
     );
   }
 
   /**
-   * GET /recreation-resource/:id
+   * GET /recreation-resources/:rec_resource_id
    *
    * Returns a recreation resource by its ID.
    *
@@ -121,6 +153,7 @@ export class RecreationResourceController {
     [
       RecreationResourceAuthRole.RST_VIEWER,
       RecreationResourceAuthRole.RST_ADMIN,
+      RecreationResourceAuthRole.RST_SUPER_ADMIN,
     ],
     ROLE_MODE.ANY,
   )
@@ -156,14 +189,16 @@ export class RecreationResourceController {
   }
 
   /**
-   * PUT /recreation-resource/:id
+   * PUT /recreation-resources/:rec_resource_id
    *
-   * Updates a recreation resource by its ID. Intelligently handles both
-   * direct table fields and related table fields based on request content.
+   * Updates a recreation resource by its ID.
+   * Mirrors the frontend EditableGuard: only super-admins may edit archived resources.
    *
    * @param rec_resource_id - The ID of the recreation resource
    * @param updateData - The data to update
+   * @param isSuperAdmin - Resolved by @IsSuperAdmin() from the JWT token
    * @returns The updated recreation resource detail DTO
+   * @throws ForbiddenException if a non-super-admin tries to edit an archived resource
    * @throws NotFoundException if resource not found
    * @throws BadRequestException if update data is invalid
    */
@@ -197,7 +232,17 @@ export class RecreationResourceController {
   async update(
     @Param('rec_resource_id') rec_resource_id: string,
     @Body() updateData: UpdateRecreationResourceDto,
+    @IsSuperAdmin() isSuperAdmin: boolean,
   ): Promise<RecreationResourceDetailDto> {
+    if (!isSuperAdmin) {
+      const resource =
+        await this.recreationResourceRepository.findOneById(rec_resource_id);
+      if (resource?.rec_status_code === 'AR') {
+        throw new ForbiddenException(
+          'Only super-admins can edit archived resources.',
+        );
+      }
+    }
     // Service layer will throw appropriate exceptions (NotFoundException, BadRequestException)
     // Controller just passes through - let NestJS exception filters handle HTTP responses
     return await this.recreationResourceService.update(

--- a/admin/backend/src/recreation-resources/recreation-resource.repository.ts
+++ b/admin/backend/src/recreation-resources/recreation-resource.repository.ts
@@ -52,19 +52,29 @@ export class RecreationResourceRepository {
     return { total: data.length, data };
   }
 
-  async searchResources(query: AdminSearchQueryDto): Promise<{
+  async searchResources(
+    query: AdminSearchQueryDto,
+    options?: { includeArchived?: boolean },
+  ): Promise<{
     total: number;
     data: AdminSearchRecreationResourceGetPayload[];
   }> {
     const page = query.page ?? 1;
     const pageSize = query.page_size ?? ADMIN_SEARCH_PAGE_SIZE_VALUES[0];
     const sort = query.sort ?? 'name:asc';
+    const includeArchived = options?.includeArchived ?? false;
 
     if (RAW_SQL_SORTS.has(sort) || query.public_access_status?.length) {
-      return this.searchResourcesWithDerivedSort(query, page, pageSize, sort);
+      return this.searchResourcesWithDerivedSort(
+        query,
+        page,
+        pageSize,
+        sort,
+        includeArchived,
+      );
     }
 
-    const where = this.buildSearchWhere(query);
+    const where = this.buildSearchWhere(query, includeArchived);
 
     const [total, data] = await this.prisma.$transaction([
       this.prisma.recreation_resource.count({ where }),
@@ -85,11 +95,12 @@ export class RecreationResourceRepository {
     page: number,
     pageSize: number,
     sort: AdminSearchSort,
+    includeArchived = false,
   ): Promise<{
     total: number;
     data: AdminSearchRecreationResourceGetPayload[];
   }> {
-    const whereSql = buildSearchWhereSql(query);
+    const whereSql = buildSearchWhereSql(query, includeArchived);
     const { joinsSql, orderBySql } = buildDerivedSortQueryParts(sort);
     const offset = (page - 1) * pageSize;
 
@@ -291,6 +302,7 @@ export class RecreationResourceRepository {
 
   private buildSearchWhere(
     query: AdminSearchQueryDto,
+    includeArchived = false,
   ): Prisma.recreation_resourceWhereInput {
     const and = [
       this.buildSearchTextWhere(query.q),
@@ -328,6 +340,12 @@ export class RecreationResourceRepository {
       this.buildStatusWhere(query.status),
       this.buildEstablishmentDateWhere(query),
       this.buildEstablishedWhere(query.established),
+      // Exclude archived resources unless super-admin explicitly includes them
+      !includeArchived
+        ? {
+            OR: [{ rec_status_code: null }, { rec_status_code: { not: 'AR' } }],
+          }
+        : null,
     ].filter(
       (condition): condition is Prisma.recreation_resourceWhereInput =>
         condition !== null,

--- a/admin/backend/src/recreation-resources/recreation-resource.service.ts
+++ b/admin/backend/src/recreation-resources/recreation-resource.service.ts
@@ -33,34 +33,46 @@ export class RecreationResourceService {
   /**
    * Retrieves recreation resource suggestions based on a search term.
    * @param searchTerm - Alphanumeric search term (min 3 characters)
+   * @param options - Optional flags (e.g. includeArchived for super-admins)
    * @returns SuggestionsResponseDto with total and data array
    */
-  async getSuggestions(searchTerm: string): Promise<SuggestionsResponseDto> {
+  async getSuggestions(
+    searchTerm: string,
+    options?: { includeArchived?: boolean },
+  ): Promise<SuggestionsResponseDto> {
     const normalizedSearchTerm = searchTerm.trim().toLowerCase();
-    const { total, data } =
+    const { data } =
       await this.recreationResourceRepository.findSuggestions(
         normalizedSearchTerm,
       );
 
+    const includeArchived = options?.includeArchived ?? false;
+    const filteredData = includeArchived
+      ? data
+      : data.filter((item) => item.rec_status_code !== 'AR');
+
+    const validSuggestions = filteredData.filter(this.isValidSuggestion).map(
+      (item): SuggestionDto => ({
+        name: item.name,
+        rec_resource_id: item.rec_resource_id,
+        recreation_resource_type: item.recreation_resource_type,
+        recreation_resource_type_code: item.recreation_resource_type_code,
+        district_description: item.district_description,
+        display_on_public_site: item.display_on_public_site,
+        closest_community: item.closest_community,
+        rec_status_code: item.rec_status_code,
+      }),
+    );
+
     return {
-      total,
-      suggestions: data.filter(this.isValidSuggestion).map(
-        (item): SuggestionDto => ({
-          name: item.name,
-          rec_resource_id: item.rec_resource_id,
-          recreation_resource_type: item.recreation_resource_type,
-          recreation_resource_type_code: item.recreation_resource_type_code,
-          district_description: item.district_description,
-          display_on_public_site: item.display_on_public_site,
-          closest_community: item.closest_community,
-          rec_status_code: item.rec_status_code,
-        }),
-      ),
+      total: validSuggestions.length,
+      suggestions: validSuggestions,
     };
   }
 
   async searchResources(
     query: AdminSearchQueryDto,
+    options?: { includeArchived?: boolean },
   ): Promise<AdminSearchResponseDto> {
     const defaultPageSize = ADMIN_SEARCH_PAGE_SIZE_VALUES[0];
     const normalizedQuery = {
@@ -70,7 +82,10 @@ export class RecreationResourceService {
       sort: query.sort ?? 'name:asc',
     };
     const { total, data } =
-      await this.recreationResourceRepository.searchResources(normalizedQuery);
+      await this.recreationResourceRepository.searchResources(
+        normalizedQuery,
+        options,
+      );
 
     const mappedRows = data.map(
       (resource): AdminSearchResultRowDto => ({

--- a/admin/backend/test/auth/is-super-admin.decorator.spec.ts
+++ b/admin/backend/test/auth/is-super-admin.decorator.spec.ts
@@ -1,0 +1,79 @@
+import { ExecutionContext } from '@nestjs/common';
+import { describe, expect, it, vi } from 'vitest';
+import { RecreationResourceAuthRole } from '../../src/auth/auth.constants';
+import { createMockExecutionContext } from '../test-utils/mock-execution-context';
+import { IsSuperAdmin } from '../../src/auth/is-super-admin.decorator';
+
+const state = vi.hoisted(() => ({
+  factory: null as ((_data: unknown, ctx: ExecutionContext) => boolean) | null,
+}));
+
+vi.mock('@nestjs/common', async () => ({
+  ...(await vi.importActual('@nestjs/common')),
+  createParamDecorator: vi
+    .fn()
+    .mockImplementation(
+      (factory: (_data: unknown, ctx: ExecutionContext) => boolean) => {
+        state.factory = factory;
+        return vi.fn();
+      },
+    ),
+}));
+
+describe('IsSuperAdmin Decorator', () => {
+  it('should export the IsSuperAdmin decorator', () => {
+    expect(IsSuperAdmin).toBeDefined();
+  });
+
+  it('should register a factory via createParamDecorator', () => {
+    expect(state.factory).not.toBeNull();
+  });
+
+  it('should return true when user has the rst-super-admin role', () => {
+    const mockContext = createMockExecutionContext({
+      user: { client_roles: [RecreationResourceAuthRole.RST_SUPER_ADMIN] },
+    });
+    expect(state.factory!(undefined, mockContext as ExecutionContext)).toBe(
+      true,
+    );
+  });
+
+  it('should return true when user has rst-super-admin among other roles', () => {
+    const mockContext = createMockExecutionContext({
+      user: {
+        client_roles: [
+          'rst-admin',
+          RecreationResourceAuthRole.RST_SUPER_ADMIN,
+          'rst-viewer',
+        ],
+      },
+    });
+    expect(state.factory!(undefined, mockContext as ExecutionContext)).toBe(
+      true,
+    );
+  });
+
+  it.each([
+    {
+      description: 'missing the rst-super-admin role',
+      user: { client_roles: ['rst-admin', 'rst-viewer'] },
+    },
+    {
+      description: 'with an empty client_roles array',
+      user: { client_roles: [] },
+    },
+    {
+      description: 'without client_roles property',
+      user: {},
+    },
+    {
+      description: 'without a user object',
+      user: undefined,
+    },
+  ])('should return false when user is $description', ({ user }) => {
+    const mockContext = createMockExecutionContext({ user });
+    expect(state.factory!(undefined, mockContext as ExecutionContext)).toBe(
+      false,
+    );
+  });
+});

--- a/admin/backend/test/auth/super-admin.guard.spec.ts
+++ b/admin/backend/test/auth/super-admin.guard.spec.ts
@@ -1,0 +1,71 @@
+import { ExecutionContext, ForbiddenException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { SuperAdminGuard } from '../../src/auth/super-admin.guard';
+import { createMockExecutionContext } from '../test-utils/mock-execution-context';
+
+describe('SuperAdminGuard', () => {
+  let guard: SuperAdminGuard;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [SuperAdminGuard],
+    }).compile();
+
+    guard = module.get<SuperAdminGuard>(SuperAdminGuard);
+  });
+
+  it('should be defined', () => {
+    expect(guard).toBeDefined();
+  });
+
+  it('should return true when user has the rst-super-admin role', () => {
+    const mockContext = createMockExecutionContext({
+      user: { client_roles: ['rst-super-admin'] },
+    });
+    expect(guard.canActivate(mockContext as ExecutionContext)).toBe(true);
+  });
+
+  it('should return true when user has rst-super-admin role among other roles', () => {
+    const mockContext = createMockExecutionContext({
+      user: { client_roles: ['rst-admin', 'rst-super-admin', 'rst-viewer'] },
+    });
+    expect(guard.canActivate(mockContext as ExecutionContext)).toBe(true);
+  });
+
+  it.each([
+    {
+      description: 'missing the rst-super-admin role',
+      user: { client_roles: ['rst-admin', 'rst-viewer'] },
+    },
+    {
+      description: 'with an empty client_roles array',
+      user: { client_roles: [] },
+    },
+    {
+      description: 'without client_roles property',
+      user: {},
+    },
+    {
+      description: 'without a user object',
+      user: undefined,
+    },
+  ])(
+    'should throw ForbiddenException when user is $description',
+    ({ user }) => {
+      const mockContext = createMockExecutionContext({ user });
+      expect(() => guard.canActivate(mockContext as ExecutionContext)).toThrow(
+        ForbiddenException,
+      );
+    },
+  );
+
+  it('should throw ForbiddenException with the correct message', () => {
+    const mockContext = createMockExecutionContext({
+      user: { client_roles: ['rst-admin'] },
+    });
+    expect(() => guard.canActivate(mockContext as ExecutionContext)).toThrow(
+      'This action requires the rst-super-admin role.',
+    );
+  });
+});

--- a/admin/backend/test/recreation-resources/queries/recreation-resource-search.queries.spec.ts
+++ b/admin/backend/test/recreation-resources/queries/recreation-resource-search.queries.spec.ts
@@ -12,10 +12,14 @@ import { describe, expect, it } from 'vitest';
 const normalizeSql = (sql: Prisma.Sql) => sql.sql.replace(/\s+/g, ' ').trim();
 
 describe('recreation-resource-search.queries', () => {
-  it('returns Prisma.empty when no search filters are provided', () => {
+  it('returns only the archived exclusion filter when no other search filters are provided', () => {
     const whereSql = buildSearchWhereSql({});
 
-    expect(whereSql).toBe(Prisma.empty);
+    const normalizedSql = normalizeSql(whereSql);
+    expect(normalizedSql).toContain("rr.rec_status_code IS DISTINCT FROM 'AR'");
+    // No other conditions should be present
+    expect(normalizedSql).not.toContain('ILIKE');
+    expect(normalizedSql).not.toContain('project_established_date');
   });
 
   it('builds SQL conditions for all supported filters and sanitizes activities', () => {
@@ -91,7 +95,11 @@ describe('recreation-resource-search.queries', () => {
       established: 'invalid',
     });
 
-    expect(whereInvalid).toBe(Prisma.empty);
+    const normalizedSql = normalizeSql(whereInvalid);
+    // Invalid established value is ignored — no date condition
+    expect(normalizedSql).not.toContain('project_established_date');
+    // But the default archived exclusion filter is still applied
+    expect(normalizedSql).toContain("rr.rec_status_code IS DISTINCT FROM 'AR'");
   });
 
   it('ignores established filter when undefined or empty', () => {
@@ -102,8 +110,18 @@ describe('recreation-resource-search.queries', () => {
       established: '',
     });
 
-    expect(whereUndefined).toBe(Prisma.empty);
-    expect(whereEmpty).toBe(Prisma.empty);
+    // No date condition added for undefined/empty established
+    expect(normalizeSql(whereUndefined)).not.toContain(
+      'project_established_date',
+    );
+    expect(normalizeSql(whereEmpty)).not.toContain('project_established_date');
+    // Default archived exclusion filter is still applied
+    expect(normalizeSql(whereUndefined)).toContain(
+      "rr.rec_status_code IS DISTINCT FROM 'AR'",
+    );
+    expect(normalizeSql(whereEmpty)).toContain(
+      "rr.rec_status_code IS DISTINCT FROM 'AR'",
+    );
   });
 
   it('maps raw SQL sorts and derived order clauses correctly', () => {
@@ -193,13 +211,21 @@ describe('recreation-resource-search.queries', () => {
   it('omits public_access_status condition when array is empty', () => {
     const whereSql = buildSearchWhereSql({ public_access_status: [] });
 
-    expect(whereSql).toBe(Prisma.empty);
+    const normalized = normalizeSql(whereSql);
+    expect(normalized).not.toContain('access_status_grouplabel');
+    expect(normalized).not.toContain('act_advisories_flat');
+    // The archived exclusion filter is still present
+    expect(normalized).toContain("rr.rec_status_code IS DISTINCT FROM 'AR'");
   });
 
   it('omits public_access_status condition when field is absent', () => {
     const whereSql = buildSearchWhereSql({});
 
-    expect(whereSql).toBe(Prisma.empty);
+    const normalized = normalizeSql(whereSql);
+    expect(normalized).not.toContain('access_status_grouplabel');
+    expect(normalized).not.toContain('act_advisories_flat');
+    // The archived exclusion filter is still present
+    expect(normalized).toContain("rr.rec_status_code IS DISTINCT FROM 'AR'");
   });
 
   it('builds public_access_status derived sort with lateral join and advisory ordering', () => {

--- a/admin/backend/test/recreation-resources/recreation-resource.controller.spec.ts
+++ b/admin/backend/test/recreation-resources/recreation-resource.controller.spec.ts
@@ -9,13 +9,6 @@ import { ForbiddenException } from '@nestjs/common';
 import { Test } from '@nestjs/testing';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-// Helper to build a mock request with optional roles
-const mockReq = (roles: string[] = []) =>
-  ({ user: { client_roles: roles } }) as any;
-
-const SUPER_ADMIN_ROLES = ['rst-super-admin'];
-const ADMIN_ROLES = ['rst-admin'];
-
 describe('RecreationResourceController', () => {
   let controller: RecreationResourceController;
   let service: RecreationResourceService;
@@ -76,7 +69,7 @@ describe('RecreationResourceController', () => {
       const query: AdminSearchQueryDto = { page: 1, page_size: 25 };
       (service.searchResources as any).mockResolvedValue(mockResponse);
 
-      await controller.searchResources(query, mockReq(ADMIN_ROLES));
+      await controller.searchResources(query, false);
 
       expect(service.searchResources).toHaveBeenCalledWith(query, {
         includeArchived: true,
@@ -87,7 +80,7 @@ describe('RecreationResourceController', () => {
       const query: AdminSearchQueryDto = { q: '   ', page: 1, page_size: 25 };
       (service.searchResources as any).mockResolvedValue(mockResponse);
 
-      await controller.searchResources(query, mockReq(ADMIN_ROLES));
+      await controller.searchResources(query, false);
       expect(service.searchResources).toHaveBeenCalledWith(query, {
         includeArchived: true,
       });
@@ -102,10 +95,7 @@ describe('RecreationResourceController', () => {
       };
       (service.searchResources as any).mockResolvedValue(mockResponse);
 
-      const result = await controller.searchResources(
-        query,
-        mockReq(ADMIN_ROLES),
-      );
+      const result = await controller.searchResources(query, false);
 
       expect(service.searchResources).toHaveBeenCalledWith(query, {
         includeArchived: false,
@@ -122,7 +112,7 @@ describe('RecreationResourceController', () => {
       };
       (service.searchResources as any).mockResolvedValue(mockResponse);
 
-      await controller.searchResources(query, mockReq(SUPER_ADMIN_ROLES));
+      await controller.searchResources(query, true);
 
       expect(service.searchResources).toHaveBeenCalledWith(query, {
         includeArchived: true,
@@ -150,10 +140,7 @@ describe('RecreationResourceController', () => {
       (service.getSuggestions as any).mockResolvedValue(mockResponse);
 
       const query: SuggestionsQueryDto = { search_term: 'Test' };
-      const result = await controller.getSuggestions(
-        query,
-        mockReq(ADMIN_ROLES),
-      );
+      const result = await controller.getSuggestions(query, false);
 
       expect(service.getSuggestions).toHaveBeenCalledWith('Test', {
         includeArchived: false,
@@ -165,7 +152,7 @@ describe('RecreationResourceController', () => {
       (service.getSuggestions as any).mockResolvedValue(mockResponse);
 
       const query: SuggestionsQueryDto = { search_term: 'Test' };
-      await controller.getSuggestions(query, mockReq(SUPER_ADMIN_ROLES));
+      await controller.getSuggestions(query, true);
 
       expect(service.getSuggestions).toHaveBeenCalledWith('Test', {
         includeArchived: true,
@@ -240,11 +227,7 @@ describe('RecreationResourceController', () => {
       });
       (service.update as any).mockResolvedValue(mockUpdatedResource);
 
-      const result = await controller.update(
-        'REC123',
-        updateData,
-        mockReq(ADMIN_ROLES),
-      );
+      const result = await controller.update('REC123', updateData, false);
 
       expect(service.update).toHaveBeenCalledWith('REC123', updateData);
       expect(result).toEqual(mockUpdatedResource);
@@ -256,11 +239,7 @@ describe('RecreationResourceController', () => {
       });
       (service.update as any).mockResolvedValue(mockUpdatedResource);
 
-      const result = await controller.update(
-        'REC123',
-        updateData,
-        mockReq(SUPER_ADMIN_ROLES),
-      );
+      const result = await controller.update('REC123', updateData, true);
 
       // findOneById is NOT called for super-admin (fast path)
       expect(repo.findOneById).not.toHaveBeenCalled();
@@ -274,7 +253,7 @@ describe('RecreationResourceController', () => {
       });
 
       await expect(
-        controller.update('REC123', updateData, mockReq(ADMIN_ROLES)),
+        controller.update('REC123', updateData, false),
       ).rejects.toThrow(ForbiddenException);
 
       expect(service.update).not.toHaveBeenCalled();
@@ -289,7 +268,7 @@ describe('RecreationResourceController', () => {
       (service.update as any).mockRejectedValue(error);
 
       await expect(
-        controller.update('NOT_FOUND', updateData, mockReq(ADMIN_ROLES)),
+        controller.update('NOT_FOUND', updateData, false),
       ).rejects.toThrow("Recreation resource with ID 'NOT_FOUND' not found");
     });
 
@@ -302,11 +281,7 @@ describe('RecreationResourceController', () => {
       (service.update as any).mockRejectedValue(error);
 
       await expect(
-        controller.update(
-          'REC123',
-          { control_access_code: 'INVALID' },
-          mockReq(ADMIN_ROLES),
-        ),
+        controller.update('REC123', { control_access_code: 'INVALID' }, false),
       ).rejects.toThrow(
         'Invalid reference: control_access_code does not exist',
       );

--- a/admin/backend/test/recreation-resources/recreation-resource.controller.spec.ts
+++ b/admin/backend/test/recreation-resources/recreation-resource.controller.spec.ts
@@ -3,13 +3,23 @@ import { AdminSearchQueryDto } from '@/recreation-resources/dtos/admin-search-qu
 import { SuggestionsResponseDto } from '@/recreation-resources/dtos/suggestions-response.dto';
 import { UpdateRecreationResourceDto } from '@/recreation-resources/dtos/update-recreation-resource.dto';
 import { RecreationResourceController } from '@/recreation-resources/recreation-resource.controller';
+import { RecreationResourceRepository } from '@/recreation-resources/recreation-resource.repository';
 import { RecreationResourceService } from '@/recreation-resources/recreation-resource.service';
+import { ForbiddenException } from '@nestjs/common';
 import { Test } from '@nestjs/testing';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Helper to build a mock request with optional roles
+const mockReq = (roles: string[] = []) =>
+  ({ user: { client_roles: roles } }) as any;
+
+const SUPER_ADMIN_ROLES = ['rst-super-admin'];
+const ADMIN_ROLES = ['rst-admin'];
 
 describe('RecreationResourceController', () => {
   let controller: RecreationResourceController;
   let service: RecreationResourceService;
+  let repo: RecreationResourceRepository;
 
   beforeEach(async () => {
     const moduleRef = await Test.createTestingModule({
@@ -24,24 +34,25 @@ describe('RecreationResourceController', () => {
             update: vi.fn(),
           },
         },
+        {
+          provide: RecreationResourceRepository,
+          useValue: {
+            findOneById: vi.fn(),
+          },
+        },
       ],
     }).compile();
 
     controller = moduleRef.get(RecreationResourceController);
     service = moduleRef.get(RecreationResourceService);
+    repo = moduleRef.get(RecreationResourceRepository);
   });
 
   it('should be defined', () => {
     expect(controller).toBeDefined();
   });
 
-  it('should call service.searchResources and return its result', async () => {
-    const query: AdminSearchQueryDto = {
-      q: 'Test',
-      page: 2,
-      page_size: 50,
-      sort: 'name:desc',
-    };
+  describe('searchResources', () => {
     const mockResponse = {
       data: [
         {
@@ -61,15 +72,65 @@ describe('RecreationResourceController', () => {
       page_size: 50,
     };
 
-    (service.searchResources as any).mockResolvedValue(mockResponse);
+    it('should include archived for all users when there is no text search query', async () => {
+      const query: AdminSearchQueryDto = { page: 1, page_size: 25 };
+      (service.searchResources as any).mockResolvedValue(mockResponse);
 
-    const result = await controller.searchResources(query);
+      await controller.searchResources(query, mockReq(ADMIN_ROLES));
 
-    expect(service.searchResources).toHaveBeenCalledWith(query);
-    expect(result).toEqual(mockResponse);
+      expect(service.searchResources).toHaveBeenCalledWith(query, {
+        includeArchived: true,
+      });
+    });
+
+    it('should include archived for all users when text search query is empty string', async () => {
+      const query: AdminSearchQueryDto = { q: '   ', page: 1, page_size: 25 };
+      (service.searchResources as any).mockResolvedValue(mockResponse);
+
+      await controller.searchResources(query, mockReq(ADMIN_ROLES));
+      expect(service.searchResources).toHaveBeenCalledWith(query, {
+        includeArchived: true,
+      });
+    });
+
+    it('should exclude archived for non-super-admin when text search query is active', async () => {
+      const query: AdminSearchQueryDto = {
+        q: 'Test',
+        page: 2,
+        page_size: 50,
+        sort: 'name:desc',
+      };
+      (service.searchResources as any).mockResolvedValue(mockResponse);
+
+      const result = await controller.searchResources(
+        query,
+        mockReq(ADMIN_ROLES),
+      );
+
+      expect(service.searchResources).toHaveBeenCalledWith(query, {
+        includeArchived: false,
+      });
+      expect(result).toEqual(mockResponse);
+    });
+
+    it('should include archived for super-admin when text search query is active', async () => {
+      const query: AdminSearchQueryDto = {
+        q: 'Test',
+        page: 2,
+        page_size: 50,
+        sort: 'name:desc',
+      };
+      (service.searchResources as any).mockResolvedValue(mockResponse);
+
+      await controller.searchResources(query, mockReq(SUPER_ADMIN_ROLES));
+
+      expect(service.searchResources).toHaveBeenCalledWith(query, {
+        includeArchived: true,
+      });
+    });
   });
 
-  it('should call service.getSuggestions and return its result', async () => {
+  describe('getSuggestions', () => {
     const mockResponse: SuggestionsResponseDto = {
       total: 1,
       suggestions: [
@@ -80,15 +141,36 @@ describe('RecreationResourceController', () => {
           recreation_resource_type_code: 'RR',
           district_description: 'Test District',
           display_on_public_site: true,
+          closest_community: 'Hope',
         },
       ],
     };
-    (service.getSuggestions as any).mockResolvedValue(mockResponse);
 
-    const query: SuggestionsQueryDto = { search_term: 'Test' };
-    const result = await controller.getSuggestions(query);
-    expect(service.getSuggestions).toHaveBeenCalledWith('Test');
-    expect(result).toEqual(mockResponse);
+    it('should exclude archived suggestions for non-super-admin', async () => {
+      (service.getSuggestions as any).mockResolvedValue(mockResponse);
+
+      const query: SuggestionsQueryDto = { search_term: 'Test' };
+      const result = await controller.getSuggestions(
+        query,
+        mockReq(ADMIN_ROLES),
+      );
+
+      expect(service.getSuggestions).toHaveBeenCalledWith('Test', {
+        includeArchived: false,
+      });
+      expect(result).toEqual(mockResponse);
+    });
+
+    it('should include archived suggestions for super-admin', async () => {
+      (service.getSuggestions as any).mockResolvedValue(mockResponse);
+
+      const query: SuggestionsQueryDto = { search_term: 'Test' };
+      await controller.getSuggestions(query, mockReq(SUPER_ADMIN_ROLES));
+
+      expect(service.getSuggestions).toHaveBeenCalledWith('Test', {
+        includeArchived: true,
+      });
+    });
   });
 
   it('should call service.findOne and return its result', async () => {
@@ -121,74 +203,111 @@ describe('RecreationResourceController', () => {
   });
 
   describe('update', () => {
-    it('should call service.update and return updated resource', async () => {
-      const updateData: UpdateRecreationResourceDto = {
+    const updateData: UpdateRecreationResourceDto = {
+      maintenance_standard_code: '1',
+      status_code: 1,
+    };
+    const mockUpdatedResource = {
+      rec_resource_id: 'REC123',
+      name: 'Test Resource',
+      closest_community: '',
+      description: undefined,
+      driving_directions: undefined,
+      maintenance_standard: {
         maintenance_standard_code: '1',
-        status_code: 1,
-      };
-      const mockUpdatedResource = {
-        rec_resource_id: 'REC123',
-        name: 'Test Resource',
-        closest_community: '',
-        description: undefined,
-        driving_directions: undefined,
-        maintenance_standard: {
-          maintenance_standard_code: '1',
-          description: 'Standard 1',
-        },
-        rec_resource_type: '',
-        access_codes: [],
-        recreation_activity: [],
-        recreation_status: { description: 'Open', comment: '', status_code: 1 },
-        campsite_count: 0,
-        recreation_structure: { has_toilet: false, has_table: false },
-        recreation_district: undefined,
-        spatial_feature_geometry: undefined,
-        site_point_geometry: undefined,
-        established_date: undefined,
-        recreation_control_access_code: {
-          recreation_control_access_code: '',
-          description: '',
-        },
-        risk_rating: undefined,
-      };
+        description: 'Standard 1',
+      },
+      rec_resource_type: '',
+      access_codes: [],
+      recreation_activity: [],
+      recreation_status: { description: 'Open', comment: '', status_code: 1 },
+      campsite_count: 0,
+      recreation_structure: { has_toilet: false, has_table: false },
+      recreation_district: undefined,
+      spatial_feature_geometry: undefined,
+      site_point_geometry: undefined,
+      established_date: undefined,
+      recreation_control_access_code: {
+        recreation_control_access_code: '',
+        description: '',
+      },
+      risk_rating: undefined,
+    };
 
+    it('should call service.update and return updated resource for non-archived resource', async () => {
+      (repo.findOneById as any).mockResolvedValue({
+        rec_status_code: null,
+      });
       (service.update as any).mockResolvedValue(mockUpdatedResource);
 
-      const result = await controller.update('REC123', updateData);
+      const result = await controller.update(
+        'REC123',
+        updateData,
+        mockReq(ADMIN_ROLES),
+      );
 
       expect(service.update).toHaveBeenCalledWith('REC123', updateData);
       expect(result).toEqual(mockUpdatedResource);
     });
 
-    it('should propagate NotFoundException from service', async () => {
-      const updateData: UpdateRecreationResourceDto = {
-        maintenance_standard_code: '1',
-      };
+    it('should allow super-admin to update an archived resource', async () => {
+      (repo.findOneById as any).mockResolvedValue({
+        rec_status_code: 'AR',
+      });
+      (service.update as any).mockResolvedValue(mockUpdatedResource);
 
+      const result = await controller.update(
+        'REC123',
+        updateData,
+        mockReq(SUPER_ADMIN_ROLES),
+      );
+
+      // findOneById is NOT called for super-admin (fast path)
+      expect(repo.findOneById).not.toHaveBeenCalled();
+      expect(service.update).toHaveBeenCalledWith('REC123', updateData);
+      expect(result).toEqual(mockUpdatedResource);
+    });
+
+    it('should throw ForbiddenException when non-super-admin tries to update an archived resource', async () => {
+      (repo.findOneById as any).mockResolvedValue({
+        rec_status_code: 'AR',
+      });
+
+      await expect(
+        controller.update('REC123', updateData, mockReq(ADMIN_ROLES)),
+      ).rejects.toThrow(ForbiddenException);
+
+      expect(service.update).not.toHaveBeenCalled();
+    });
+
+    it('should propagate NotFoundException from service', async () => {
+      (repo.findOneById as any).mockResolvedValue({ rec_status_code: null });
       const error = new Error(
         "Recreation resource with ID 'NOT_FOUND' not found",
       );
       error.name = 'NotFoundException';
       (service.update as any).mockRejectedValue(error);
 
-      await expect(controller.update('NOT_FOUND', updateData)).rejects.toThrow(
-        "Recreation resource with ID 'NOT_FOUND' not found",
-      );
+      await expect(
+        controller.update('NOT_FOUND', updateData, mockReq(ADMIN_ROLES)),
+      ).rejects.toThrow("Recreation resource with ID 'NOT_FOUND' not found");
     });
 
     it('should propagate BadRequestException from service', async () => {
-      const updateData: UpdateRecreationResourceDto = {
-        control_access_code: 'INVALID',
-      };
-
+      (repo.findOneById as any).mockResolvedValue({ rec_status_code: null });
       const error = new Error(
         'Invalid reference: control_access_code does not exist',
       );
       error.name = 'BadRequestException';
       (service.update as any).mockRejectedValue(error);
 
-      await expect(controller.update('REC123', updateData)).rejects.toThrow(
+      await expect(
+        controller.update(
+          'REC123',
+          { control_access_code: 'INVALID' },
+          mockReq(ADMIN_ROLES),
+        ),
+      ).rejects.toThrow(
         'Invalid reference: control_access_code does not exist',
       );
     });

--- a/admin/backend/test/recreation-resources/recreation-resource.service.spec.ts
+++ b/admin/backend/test/recreation-resources/recreation-resource.service.spec.ts
@@ -81,6 +81,69 @@ describe('RecreationResourceService', () => {
     expect(result.suggestions.length).toBe(0);
   });
 
+  it('should filter out archived suggestions when includeArchived is false (default)', async () => {
+    const mockData = [
+      {
+        name: 'Active Resource',
+        rec_resource_id: 'REC125',
+        recreation_resource_type: 'RR',
+        recreation_resource_type_code: 'RR',
+        district_description: 'District',
+        rec_status_code: null,
+      },
+      {
+        name: 'Archived Resource',
+        rec_resource_id: 'REC126',
+        recreation_resource_type: 'RR',
+        recreation_resource_type_code: 'RR',
+        district_description: 'District',
+        rec_status_code: 'AR',
+      },
+    ];
+    (repo.findSuggestions as any).mockResolvedValue({
+      total: 2,
+      data: mockData,
+    });
+
+    const result = await service.getSuggestions('Test');
+    expect(result.total).toBe(1);
+    expect(result.suggestions.length).toBe(1);
+    expect(result.suggestions[0]?.rec_resource_id).toBe('REC125');
+  });
+
+  it('should include archived suggestions when includeArchived is true (super admin)', async () => {
+    const mockData = [
+      {
+        name: 'Active Resource',
+        rec_resource_id: 'REC125',
+        recreation_resource_type: 'RR',
+        recreation_resource_type_code: 'RR',
+        district_description: 'District',
+        rec_status_code: null,
+      },
+      {
+        name: 'Archived Resource',
+        rec_resource_id: 'REC126',
+        recreation_resource_type: 'RR',
+        recreation_resource_type_code: 'RR',
+        district_description: 'District',
+        rec_status_code: 'AR',
+      },
+    ];
+    (repo.findSuggestions as any).mockResolvedValue({
+      total: 2,
+      data: mockData,
+    });
+
+    const result = await service.getSuggestions('Test', {
+      includeArchived: true,
+    });
+    expect(result.total).toBe(2);
+    expect(result.suggestions.length).toBe(2);
+    expect(result.suggestions[0]?.rec_resource_id).toBe('REC125');
+    expect(result.suggestions[1]?.rec_resource_id).toBe('REC126');
+  });
+
   it('should map admin search results into response DTO shape', async () => {
     const query: AdminSearchQueryDto = {
       q: 'lake',

--- a/admin/backend/test/recreation-resources/recreation-resource.service.spec.ts
+++ b/admin/backend/test/recreation-resources/recreation-resource.service.spec.ts
@@ -210,12 +210,15 @@ describe('RecreationResourceService', () => {
 
     const result = await service.searchResources(query);
 
-    expect(repo.searchResources).toHaveBeenCalledWith({
-      ...query,
-      page: 1,
-      page_size: 50,
-      sort: 'name:asc',
-    });
+    expect(repo.searchResources).toHaveBeenCalledWith(
+      {
+        ...query,
+        page: 1,
+        page_size: 50,
+        sort: 'name:asc',
+      },
+      undefined,
+    );
     expect(result).toEqual({
       data: [
         {
@@ -390,11 +393,14 @@ describe('RecreationResourceService', () => {
 
     const result = await service.searchResources({});
 
-    expect(repo.searchResources).toHaveBeenCalledWith({
-      page: 1,
-      page_size: 25,
-      sort: 'name:asc',
-    });
+    expect(repo.searchResources).toHaveBeenCalledWith(
+      {
+        page: 1,
+        page_size: 25,
+        sort: 'name:asc',
+      },
+      undefined,
+    );
     expect(result).toEqual({
       data: [
         {

--- a/admin/docs/auth/auth.md
+++ b/admin/docs/auth/auth.md
@@ -89,21 +89,28 @@ validates it; invalid or expired tokens get 401.
 
 ## Role Combinations
 
-RecSpace uses three roles:
+RecSpace uses four roles:
 
 - `rst-viewer`
 - `rst-admin`
+- `rst-super-admin`
 - `rst-developer`
 
 `rst-developer` does not grant access on its own. Instead, it unlocks the
-feature flags when paired with either `rst-viewer` or `rst-admin`.
+feature flags when paired with either `rst-viewer`, `rst-admin`, or
+`rst-super-admin`.
 
-| Role combination               | Access level | Typical use                                                      |
-| ------------------------------ | ------------ | ---------------------------------------------------------------- |
-| `rst-viewer`                   | View only    | Can read/view content and use read-only routes. No edit actions. |
-| `rst-admin`                    | View + edit  | Can view content and use edit/update actions.                    |
-| `rst-viewer` + `rst-developer` | View only    | Can view content including feature flags                         |
-| `rst-admin` + `rst-developer`  | View + edit  | Can view and use edit/update actions including feature flags     |
+`rst-super-admin` is a distinct elevated role that extends `rst-admin`
+privileges with the ability to edit and view **Archived** resources.
+
+| Role combination                    | Access level      | Typical use                                                                     |
+| ----------------------------------- | ----------------- | ------------------------------------------------------------------------------- |
+| `rst-viewer`                        | View only         | Can read/view content and use read-only routes. No edit actions.                |
+| `rst-admin`                         | View + edit       | Can view content and use edit/update actions. Archived resources are read-only. |
+| `rst-super-admin`                   | View + edit (all) | Elevated admin; can view, search, and edit resources including Archived status. |
+| `rst-viewer` + `rst-developer`      | View only         | Can view content including feature flags                                        |
+| `rst-admin` + `rst-developer`       | View + edit       | Can view and use edit/update actions including feature flags                    |
+| `rst-super-admin` + `rst-developer` | View + edit (all) | Full elevated access including feature flags and Archived resource editing      |
 
 ## Environment
 

--- a/admin/frontend/src/components/auth/ArchiveGuard.tsx
+++ b/admin/frontend/src/components/auth/ArchiveGuard.tsx
@@ -2,16 +2,19 @@ import { ReactNode } from 'react';
 
 export interface ArchiveGuardProps {
   readonly isArchived: boolean;
+  /** When true, bypasses the archived restriction (e.g. for rst-super-admin) */
+  readonly bypass?: boolean;
   readonly fallback?: ReactNode;
   readonly children: ReactNode;
 }
 
 export function ArchiveGuard({
   isArchived,
+  bypass = false,
   fallback = null,
   children,
 }: Readonly<ArchiveGuardProps>) {
-  if (isArchived) return <>{fallback}</>;
+  if (isArchived && !bypass) return <>{fallback}</>;
 
   return <>{children}</>;
 }

--- a/admin/frontend/src/components/auth/EditableGuard.tsx
+++ b/admin/frontend/src/components/auth/EditableGuard.tsx
@@ -1,32 +1,29 @@
-import { Role } from '@/hooks/useAuthorizations';
+import { useAuthorizations } from '@/hooks/useAuthorizations';
 import { ReactNode } from 'react';
-import { ArchiveGuard } from './ArchiveGuard';
-import { RoleGuard } from './RoleGuard';
 
 export interface EditableGuardProps {
   readonly isArchived?: boolean;
-  readonly requireAll?: readonly Role[];
-  readonly requireAny?: readonly Role[];
   readonly fallback?: ReactNode;
   readonly children: ReactNode;
 }
 
+/**
+ * Guards edit actions behind role and archive status checks.
+ *
+ * - `rst-admin`: can edit non-archived resources only.
+ * - `rst-super-admin`: can edit all resources, including archived ones.
+ * - All other roles: editing is always hidden.
+ */
 export function EditableGuard({
   isArchived = false,
-  requireAll,
-  requireAny,
   fallback = null,
   children,
 }: Readonly<EditableGuardProps>) {
-  return (
-    <RoleGuard
-      requireAll={requireAll}
-      requireAny={requireAny}
-      fallback={fallback}
-    >
-      <ArchiveGuard isArchived={isArchived} fallback={fallback}>
-        {children}
-      </ArchiveGuard>
-    </RoleGuard>
-  );
+  const { canEdit, canEditArchived } = useAuthorizations();
+
+  const hasAccess = canEdit && (!isArchived || canEditArchived);
+
+  if (!hasAccess) return <>{fallback}</>;
+
+  return <>{children}</>;
 }

--- a/admin/frontend/src/hooks/useAuthorizations.ts
+++ b/admin/frontend/src/hooks/useAuthorizations.ts
@@ -4,6 +4,7 @@ import { AuthContext } from '@/contexts/AuthContext';
 export const ROLES = {
   VIEWER: 'rst-viewer',
   ADMIN: 'rst-admin',
+  SUPER_ADMIN: 'rst-super-admin',
   DEVELOPER: 'rst-developer',
 } as const;
 
@@ -29,6 +30,7 @@ export const useUserRoles = () => {
 export type AuthorizationKey =
   | 'canView'
   | 'canEdit'
+  | 'canEditArchived'
   | 'canViewFeatureFlag'
   | 'canEditFeatureFlag';
 
@@ -37,13 +39,19 @@ export const useAuthorizations = () => {
 
   return useMemo(() => {
     const roles = getUserRoles(context);
-    const canView = hasAnyRole(roles, [ROLES.VIEWER, ROLES.ADMIN]);
-    const canEdit = hasAnyRole(roles, [ROLES.ADMIN]);
+    const canView = hasAnyRole(roles, [
+      ROLES.VIEWER,
+      ROLES.ADMIN,
+      ROLES.SUPER_ADMIN,
+    ]);
+    const canEdit = hasAnyRole(roles, [ROLES.ADMIN, ROLES.SUPER_ADMIN]);
+    const canEditArchived = hasAnyRole(roles, [ROLES.SUPER_ADMIN]);
     const hasDeveloperAccess = hasAnyRole(roles, [ROLES.DEVELOPER]);
 
     return {
       canView,
       canEdit,
+      canEditArchived,
       canViewFeatureFlag: hasDeveloperAccess && canView,
       canEditFeatureFlag: hasDeveloperAccess && canEdit,
     };

--- a/admin/frontend/src/pages/rec-resource-page/RecResourceFilesPage.tsx
+++ b/admin/frontend/src/pages/rec-resource-page/RecResourceFilesPage.tsx
@@ -1,6 +1,5 @@
 import { CustomButton } from '@/components';
 import { EditableGuard } from '@/components/auth';
-import { ROLES } from '@/hooks/useAuthorizations';
 import { RecResourceFileSection } from '@/pages/rec-resource-page/components/RecResourceFileSection';
 import { useRecResource } from '@/pages/rec-resource-page/hooks/useRecResource';
 import { useRecResourceFileTransferState } from '@/pages/rec-resource-page/hooks/useRecResourceFileTransferState';
@@ -73,7 +72,7 @@ const ActionButtonsSection = ({ isArchived }: { isArchived: boolean }) => {
     >
       <h2 className="mb-0">Files</h2>
 
-      <EditableGuard requireAll={[ROLES.ADMIN]} isArchived={isArchived}>
+      <EditableGuard isArchived={isArchived}>
         <>
           {/* Responsive actions: dropdown on mobile, buttons on desktop */}
           {/* Mobile: show dropdown */}
@@ -145,7 +144,7 @@ export const RecResourceFilesPage = () => {
   return (
     <Stack direction="vertical" gap={4}>
       <ActionButtonsSection isArchived={isArchived} />
-      <EditableGuard requireAll={[ROLES.ADMIN]} isArchived={isArchived}>
+      <EditableGuard isArchived={isArchived}>
         <InfoBanner />
       </EditableGuard>
       <RecResourceFileSection isArchived={isArchived} />

--- a/admin/frontend/src/pages/rec-resource-page/components/RecResourceActivitiesSection/RecResourceActivitiesSection.tsx
+++ b/admin/frontend/src/pages/rec-resource-page/components/RecResourceActivitiesSection/RecResourceActivitiesSection.tsx
@@ -1,6 +1,5 @@
 import { ROUTE_PATHS } from '@/constants/routes';
 import { EditableGuard } from '@/components/auth';
-import { ROLES } from '@/hooks/useAuthorizations';
 import { useRecResource } from '@/pages/rec-resource-page/hooks/useRecResource';
 import { RecreationActivityDto } from '@/services/recreation-resource-admin/models';
 import { Link, useParams } from '@tanstack/react-router';
@@ -23,7 +22,7 @@ export const RecResourceActivitiesSection = ({
       <div className="d-flex justify-content-between align-items-center">
         <h2>Activities</h2>
 
-        <EditableGuard requireAll={[ROLES.ADMIN]} isArchived={isArchived}>
+        <EditableGuard isArchived={isArchived}>
           <Link
             to={ROUTE_PATHS.REC_RESOURCE_ACTIVITIES_FEATURES_EDIT.replace(
               '$id',

--- a/admin/frontend/src/pages/rec-resource-page/components/RecResourceEstablishmentOrderSection/RecResourceEstablishmentOrderSection.tsx
+++ b/admin/frontend/src/pages/rec-resource-page/components/RecResourceEstablishmentOrderSection/RecResourceEstablishmentOrderSection.tsx
@@ -20,8 +20,8 @@ export const RecResourceEstablishmentOrderSection = ({
   recResourceId,
   isArchived = false,
 }: RecResourceEstablishmentOrderSectionProps) => {
-  const { canEdit } = useAuthorizations();
-  const canModifyFiles = canEdit && !isArchived;
+  const { canEdit, canEditArchived } = useAuthorizations();
+  const canModifyFiles = canEdit && (!isArchived || canEditArchived);
   const {
     galleryFiles,
     isLoading,

--- a/admin/frontend/src/pages/rec-resource-page/components/RecResourceFeesSection/RecResourceFeesContent.tsx
+++ b/admin/frontend/src/pages/rec-resource-page/components/RecResourceFeesSection/RecResourceFeesContent.tsx
@@ -3,7 +3,6 @@ import { EditableGuard } from '@/components/auth';
 import { RecResourceFeesTable } from '@/pages/rec-resource-page/components/RecResourceFeesSection/RecResourceFeesTable';
 import { ROUTE_PATHS } from '@/constants/routes';
 import { RecreationFeeUIModel } from '@/services';
-import { ROLES } from '@/hooks/useAuthorizations';
 import { Link } from '@tanstack/react-router';
 
 export const RecResourceFeesContent = ({
@@ -20,7 +19,7 @@ export const RecResourceFeesContent = ({
       <div className="d-flex justify-content-between align-items-center">
         <h2>Fees</h2>
         <Stack direction="horizontal" gap={2}>
-          <EditableGuard requireAll={[ROLES.ADMIN]} isArchived={isArchived}>
+          <EditableGuard isArchived={isArchived}>
             {recResourceId ? (
               <Link
                 to={ROUTE_PATHS.REC_RESOURCE_FEES_ADD.replace(

--- a/admin/frontend/src/pages/rec-resource-page/components/RecResourceFeesSection/RecResourceFeesTable.tsx
+++ b/admin/frontend/src/pages/rec-resource-page/components/RecResourceFeesSection/RecResourceFeesTable.tsx
@@ -23,7 +23,7 @@ export const RecResourceFeesTable = ({
   recResourceId,
   isArchived = false,
 }: RecResourceFeesTableProps) => {
-  const { canEdit } = useAuthorizations();
+  const { canEdit, canEditArchived } = useAuthorizations();
   const deleteFee = useDeleteFee();
   const [selectedFee, setSelectedFee] = useState<RecreationFeeUIModel>();
 
@@ -104,7 +104,8 @@ export const RecResourceFeesTable = ({
     {
       header: 'Actions',
       render: (fee: RecreationFeeUIModel) => {
-        if (!canEdit || isArchived || !recResourceId) return <span>--</span>;
+        if (!canEdit || (isArchived && !canEditArchived) || !recResourceId)
+          return <span>--</span>;
         return (
           <div className="d-flex align-items-center gap-3">
             <Link

--- a/admin/frontend/src/pages/rec-resource-page/components/RecResourceFileSection/RecResourceFileSection.tsx
+++ b/admin/frontend/src/pages/rec-resource-page/components/RecResourceFileSection/RecResourceFileSection.tsx
@@ -35,8 +35,8 @@ export const RecResourceFileSection = ({
 }: {
   isArchived?: boolean;
 }) => {
-  const { canEdit } = useAuthorizations();
-  const canModifyFiles = canEdit && !isArchived;
+  const { canEdit, canEditArchived } = useAuthorizations();
+  const canModifyFiles = canEdit && (!isArchived || canEditArchived);
   const {
     getDocumentFileActionHandler,
     getDocumentGeneralActionHandler,

--- a/admin/frontend/src/pages/rec-resource-page/components/RecResourceGeospatialSection/RecResourceGeospatialSection.tsx
+++ b/admin/frontend/src/pages/rec-resource-page/components/RecResourceGeospatialSection/RecResourceGeospatialSection.tsx
@@ -7,7 +7,6 @@ import { Route } from '@/routes/rec-resource/$id/geospatial';
 import { ROUTE_PATHS } from '@/constants/routes';
 import { useRecResource } from '@/pages/rec-resource-page/hooks/useRecResource';
 import { useGetRecreationResourceGeospatial } from '@/services/hooks/recreation-resource-admin/useGetRecreationResourceGeospatial';
-import { ROLES } from '@/hooks/useAuthorizations';
 import { Link } from '@tanstack/react-router';
 
 const geometryNumberFormat: Intl.NumberFormatOptions = {
@@ -94,7 +93,7 @@ export function RecResourceGeospatialSection() {
       <div className="d-flex justify-content-between align-items-center">
         <h2>Geospatial</h2>
 
-        <EditableGuard requireAll={[ROLES.ADMIN]} isArchived={isArchived}>
+        <EditableGuard isArchived={isArchived}>
           {hasGeometryData && (
             <Link
               to={ROUTE_PATHS.REC_RESOURCE_GEOSPATIAL_EDIT.replace(

--- a/admin/frontend/src/pages/rec-resource-page/components/RecResourceOverviewSection/RecResourceOverviewSection.tsx
+++ b/admin/frontend/src/pages/rec-resource-page/components/RecResourceOverviewSection/RecResourceOverviewSection.tsx
@@ -1,6 +1,5 @@
 import { ROUTE_PATHS } from '@/constants/routes';
 import { EditableGuard } from '@/components/auth';
-import { ROLES } from '@/hooks/useAuthorizations';
 import { RecreationResourceDetailUIModel } from '@/services';
 import { Link } from '@tanstack/react-router';
 import { Col, Row, Stack } from 'react-bootstrap';
@@ -62,7 +61,7 @@ export const RecResourceOverviewSection = (
       <div className="d-flex justify-content-between align-items-center">
         <h2>Overview</h2>
 
-        <EditableGuard requireAll={[ROLES.ADMIN]} isArchived={isArchived}>
+        <EditableGuard isArchived={isArchived}>
           <Link
             to={ROUTE_PATHS.REC_RESOURCE_OVERVIEW_EDIT.replace(
               '$id',

--- a/admin/frontend/src/pages/rec-resource-page/components/RecResourceReservationSection/RecResourceReservationSection.tsx
+++ b/admin/frontend/src/pages/rec-resource-page/components/RecResourceReservationSection/RecResourceReservationSection.tsx
@@ -11,7 +11,6 @@ import {
   getReservationMethod,
 } from '@/pages/rec-resource-page/components/RecResourceReservationSection/helpers';
 import './RecResourceReservationSection.scss';
-import { ROLES } from '@/hooks/useAuthorizations';
 
 type RecResourceReservationSectionProps = {
   reservationInfo: RecreationResourceReservationInfoDto | null;
@@ -63,7 +62,7 @@ export const RecResourceReservationSection = (
       <div className="reservation-section__header d-flex justify-content-between align-items-center">
         <h2 className="mb-0">Reservations</h2>
 
-        <EditableGuard requireAll={[ROLES.ADMIN]} isArchived={isArchived}>
+        <EditableGuard isArchived={isArchived}>
           <Link
             to={ROUTE_PATHS.REC_RESOURCE_RESERVATION_EDIT.replace(
               '$id',

--- a/admin/frontend/src/services/auth/AuthService.ts
+++ b/admin/frontend/src/services/auth/AuthService.ts
@@ -167,10 +167,10 @@ export class AuthService {
 
   /**
    * Check if the user is authorized to access the application
-   * Requires at least 'rst-viewer' or 'rst-admin' role
+   * Requires at least 'rst-viewer', 'rst-admin', or 'rst-super-admin' role
    */
   isAuthorized(): boolean {
-    return this.hasRequiredRole(['rst-viewer', 'rst-admin']);
+    return this.hasRequiredRole(['rst-viewer', 'rst-admin', 'rst-super-admin']);
   }
 
   /**

--- a/admin/frontend/test/components/auth/ArchiveGuard.test.tsx
+++ b/admin/frontend/test/components/auth/ArchiveGuard.test.tsx
@@ -33,4 +33,14 @@ describe('ArchiveGuard', () => {
     expect(screen.queryByText('Editable content')).not.toBeInTheDocument();
     expect(screen.getByText('Read-only')).toBeInTheDocument();
   });
+
+  it('renders children when archived but bypass is true (super-admin)', () => {
+    render(
+      <ArchiveGuard isArchived bypass>
+        <div>Editable content</div>
+      </ArchiveGuard>,
+    );
+
+    expect(screen.getByText('Editable content')).toBeInTheDocument();
+  });
 });

--- a/admin/frontend/test/components/auth/EditableGuard.test.tsx
+++ b/admin/frontend/test/components/auth/EditableGuard.test.tsx
@@ -4,9 +4,9 @@ import { createAuthWrapper } from '@test/routes/helpers/roleGuardTestHelper';
 import { describe, expect, it } from 'vitest';
 
 describe('EditableGuard', () => {
-  it('renders children when user has access and resource is not archived', () => {
+  it('renders children when admin has access and resource is not archived', () => {
     render(
-      <EditableGuard requireAll={['rst-admin']} isArchived={false}>
+      <EditableGuard isArchived={false}>
         <div>Edit action</div>
       </EditableGuard>,
       { wrapper: createAuthWrapper(['rst-admin']) },
@@ -15,9 +15,9 @@ describe('EditableGuard', () => {
     expect(screen.getByText('Edit action')).toBeInTheDocument();
   });
 
-  it('hides children when resource is archived', () => {
+  it('hides children for admin when resource is archived', () => {
     render(
-      <EditableGuard requireAll={['rst-admin']} isArchived>
+      <EditableGuard isArchived>
         <div>Edit action</div>
       </EditableGuard>,
       { wrapper: createAuthWrapper(['rst-admin']) },
@@ -26,14 +26,48 @@ describe('EditableGuard', () => {
     expect(screen.queryByText('Edit action')).not.toBeInTheDocument();
   });
 
-  it('hides children when role check fails', () => {
+  it('hides children when viewer tries to edit a non-archived resource', () => {
     render(
-      <EditableGuard requireAll={['rst-admin']} isArchived={false}>
+      <EditableGuard isArchived={false}>
         <div>Edit action</div>
       </EditableGuard>,
       { wrapper: createAuthWrapper(['rst-viewer']) },
     );
 
     expect(screen.queryByText('Edit action')).not.toBeInTheDocument();
+  });
+
+  it('renders children for super-admin when resource is archived', () => {
+    render(
+      <EditableGuard isArchived>
+        <div>Edit action</div>
+      </EditableGuard>,
+      { wrapper: createAuthWrapper(['rst-super-admin']) },
+    );
+
+    expect(screen.getByText('Edit action')).toBeInTheDocument();
+  });
+
+  it('renders children for super-admin when resource is not archived', () => {
+    render(
+      <EditableGuard isArchived={false}>
+        <div>Edit action</div>
+      </EditableGuard>,
+      { wrapper: createAuthWrapper(['rst-super-admin']) },
+    );
+
+    expect(screen.getByText('Edit action')).toBeInTheDocument();
+  });
+
+  it('renders fallback when role check fails', () => {
+    render(
+      <EditableGuard isArchived={false} fallback={<div>View-only</div>}>
+        <div>Edit action</div>
+      </EditableGuard>,
+      { wrapper: createAuthWrapper(['rst-viewer']) },
+    );
+
+    expect(screen.queryByText('Edit action')).not.toBeInTheDocument();
+    expect(screen.getByText('View-only')).toBeInTheDocument();
   });
 });

--- a/admin/frontend/test/hooks/useAuthorizations.test.ts
+++ b/admin/frontend/test/hooks/useAuthorizations.test.ts
@@ -12,6 +12,7 @@ describe('useAuthorizations', () => {
     expect(result.current).toEqual({
       canView: true,
       canEdit: false,
+      canEditArchived: false,
       canViewFeatureFlag: false,
       canEditFeatureFlag: false,
     });
@@ -25,6 +26,21 @@ describe('useAuthorizations', () => {
     expect(result.current).toEqual({
       canView: true,
       canEdit: true,
+      canEditArchived: false,
+      canViewFeatureFlag: false,
+      canEditFeatureFlag: false,
+    });
+  });
+
+  it('super-admin role', () => {
+    const { result } = renderHook(() => useAuthorizations(), {
+      wrapper: createAuthWrapper(['rst-super-admin']),
+    });
+
+    expect(result.current).toEqual({
+      canView: true,
+      canEdit: true,
+      canEditArchived: true,
       canViewFeatureFlag: false,
       canEditFeatureFlag: false,
     });
@@ -38,6 +54,7 @@ describe('useAuthorizations', () => {
     expect(result.current).toEqual({
       canView: false,
       canEdit: false,
+      canEditArchived: false,
       canViewFeatureFlag: false,
       canEditFeatureFlag: false,
     });
@@ -51,6 +68,7 @@ describe('useAuthorizations', () => {
     expect(result.current).toEqual({
       canView: true,
       canEdit: false,
+      canEditArchived: false,
       canViewFeatureFlag: true,
       canEditFeatureFlag: false,
     });
@@ -64,6 +82,21 @@ describe('useAuthorizations', () => {
     expect(result.current).toEqual({
       canView: true,
       canEdit: true,
+      canEditArchived: false,
+      canViewFeatureFlag: true,
+      canEditFeatureFlag: true,
+    });
+  });
+
+  it('super-admin + developer roles', () => {
+    const { result } = renderHook(() => useAuthorizations(), {
+      wrapper: createAuthWrapper(['rst-super-admin', 'rst-developer']),
+    });
+
+    expect(result.current).toEqual({
+      canView: true,
+      canEdit: true,
+      canEditArchived: true,
       canViewFeatureFlag: true,
       canEditFeatureFlag: true,
     });

--- a/admin/frontend/test/pages/rec-resource-page/components/RecResourceFeesSection/RecResourceFeesSection.test.tsx
+++ b/admin/frontend/test/pages/rec-resource-page/components/RecResourceFeesSection/RecResourceFeesSection.test.tsx
@@ -42,12 +42,9 @@ vi.mock('@/components/auth', () => ({
 
     return <>{children}</>;
   },
-  EditableGuard: ({ children, requireAll, isArchived }: any) => {
+  EditableGuard: ({ children, isArchived }: any) => {
     const auth = mockUseAuthorizations();
-    const isAdminGuard =
-      Array.isArray(requireAll) && requireAll.includes('rst-admin');
-
-    if ((isAdminGuard && !auth.canEdit) || isArchived) {
+    if (!auth.canEdit || isArchived) {
       return null;
     }
 

--- a/admin/frontend/test/routes/helpers/roleGuardTestHelper.tsx
+++ b/admin/frontend/test/routes/helpers/roleGuardTestHelper.tsx
@@ -7,6 +7,7 @@ import { ReactNode } from 'react';
  */
 export const ROLE_ACCESS_CASES = [
   ['rst-admin', [ROLES.ADMIN], true],
+  ['rst-super-admin', [ROLES.SUPER_ADMIN], true],
   ['rst-viewer', [ROLES.VIEWER], false],
   ['rst-developer', [ROLES.DEVELOPER], false],
   ['no roles', [], false],


### PR DESCRIPTION
Card: https://bcparksdigital.atlassian.net/browse/ORCA-957
**What changed**
**Search table** -  archived resources are now visible to all admins when browsing (no text query). When a text search is active, only rst-super-admin sees archived results.
**Typeahead suggestions** - archived resources are no longer suggested to non-super admins, keeping suggestions consistent with search results.
**Edit guard** - mirrors the frontend EditableGuard on the API: non-super admins receive 403 Forbidden when attempting to update an archived resource.
**New auth utilities (reusable for future features)**
**@IsSuperAdmin() -** parameter decorator that injects a boolean from the JWT token directly into any handler.
**SuperAdminGuard -** a NestJS guard to lock an entire endpoint to rst-super-admin only via @UseGuards(SuperAdminGuard).
