### PR TITLE
feat: orca 830 act cud api

### DIFF
--- a/.github/workflows/.deploy-app.yml
+++ b/.github/workflows/.deploy-app.yml
@@ -101,7 +101,7 @@ jobs:
       - name: setup node
         uses: actions/setup-node@v6
         with:
-          node-version: '24'
+          node-version: '24.18.0'
           cache: 'npm'
           cache-dependency-path: package-lock.json
       - name: Configure AWS Credentials

--- a/.github/workflows/.e2e.yml
+++ b/.github/workflows/.e2e.yml
@@ -62,7 +62,7 @@ jobs:
     - name: Setup node
       uses: actions/setup-node@v6
       with:
-        node-version: '24'
+        node-version: '24.18.0'
     - run: npm install --@fortawesome:registry=https://npm.fontawesome.com/ --//npm.fontawesome.com/:_authToken=${{ secrets.FONT_AWESOME_PRO_TOKEN }}
       working-directory: ./${{ inputs.app }}/frontend
     - run: npx @playwright/test install --with-deps

--- a/.github/workflows/.shared.yml
+++ b/.github/workflows/.shared.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '24'
+          node-version: '24.18.0'
           cache: 'npm'
 
       - name: Install dependencies

--- a/.github/workflows/matomo-deploy.yaml
+++ b/.github/workflows/matomo-deploy.yaml
@@ -39,7 +39,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v6
         with:
-          node-version: '24'
+          node-version: '24.18.0'
 
       - name: Install CDK CLI
         run: npm install -g aws-cdk

--- a/admin/backend/.env.example
+++ b/admin/backend/.env.example
@@ -21,3 +21,14 @@ RST_STORAGE_IMAGES_BUCKET=rst-storage-images-dev
 RST_STORAGE_PUBLIC_DOCUMENTS_BUCKET=rst-storage-public-documents-dev
 RST_STORAGE_CONSENT_FORMS_BUCKET=rst-storage-consent-forms-dev
 RST_STORAGE_CLOUDFRONT_URL=http://localstack:4566
+
+# CSS (Common Hosted Single Sign-On) OAuth2 token endpoint used by the
+# Act integration for the Client Credentials grant flow. Optional - if
+# unset, defaults to "${KEYCLOAK_ISSUER}/protocol/openid-connect/token".
+CSS_TOKEN_URL=
+
+# Act integration: CSS Client ID provisioned for the Act service
+# account. The Act-only Keycloak Passport strategy validates the JWT
+# `aud` claim against this value. Tokens addressed to any other client
+# (including the RST admin client) will be rejected with 401.
+ACT_CSS_CLIENT_ID=

--- a/admin/backend/src/act/act-advisories.controller.ts
+++ b/admin/backend/src/act/act-advisories.controller.ts
@@ -1,0 +1,229 @@
+import {
+  AUTH_STRATEGY,
+  AuthRoles,
+  AuthRolesGuard,
+  RecreationResourceAuthRole,
+  ROLE_MODE,
+} from '@/auth';
+import { BadRequestResponseDto } from '@/common/dtos/bad-request-response.dto';
+import { GenericErrorResponseDto } from '@/common/dtos/generic-error-response.dto';
+import {
+  Body,
+  Controller,
+  Delete,
+  HttpCode,
+  HttpStatus,
+  Param,
+  ParseIntPipe,
+  Post,
+  Put,
+  UseGuards,
+} from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+import {
+  ApiBadRequestResponse,
+  ApiBearerAuth,
+  ApiBody,
+  ApiCreatedResponse,
+  ApiExtraModels,
+  ApiNotFoundResponse,
+  ApiOAuth2,
+  ApiOkResponse,
+  ApiOperation,
+  ApiParam,
+  ApiTags,
+  ApiUnauthorizedResponse,
+} from '@nestjs/swagger';
+import { ActAdvisoryResponseDto } from './dtos/act-advisory-response.dto';
+import { ActAdvisoryUpdateDto } from './dtos/act-advisory-update.dto';
+import { ActAdvisoryUpsertDto } from './dtos/act-advisory-upsert.dto';
+import { ActAdvisoriesService } from './act-advisories.service';
+import { ACT_ADVISORIES_PATH, ACT_API_TAG } from './act.constants';
+
+/**
+ * Controller exposing the secure CUD (Create / Update / Delete) advisory
+ * endpoints consumed by the Act integration.
+ *
+ * Authentication: CSS (Common Hosted Single Sign-On) issued bearer tokens
+ *  obtained via the OAuth2 **Client Credentials** grant flow.
+ *  - Tokens are validated by the Keycloak bearer Passport strategy.
+ *  - Missing / malformed / expired tokens are rejected with 401.
+ *
+ * Authorization: requests must carry the `act-service` client role.
+ *  Tokens without the role are rejected with 403 by {@link AuthRolesGuard}.
+ *
+ * All requests must include:
+ *   Authorization: Bearer &lt;token&gt;
+ */
+@ApiTags(ACT_API_TAG)
+@ApiExtraModels(
+  ActAdvisoryUpsertDto,
+  ActAdvisoryUpdateDto,
+  ActAdvisoryResponseDto,
+)
+@ApiBearerAuth(AUTH_STRATEGY.ACT_KEYCLOAK)
+@ApiOAuth2([], AUTH_STRATEGY.CSS_OAUTH2)
+@ApiUnauthorizedResponse({
+  description:
+    'Unauthorized - missing, malformed, or expired bearer token. ' +
+    'Act must obtain a new token from the CSS token endpoint using ' +
+    'the OAuth2 Client Credentials flow.',
+  type: GenericErrorResponseDto,
+})
+@UseGuards(AuthGuard(AUTH_STRATEGY.ACT_KEYCLOAK), AuthRolesGuard)
+@AuthRoles([RecreationResourceAuthRole.ACT_SERVICE], ROLE_MODE.ALL)
+@Controller({ path: ACT_ADVISORIES_PATH, version: '1' })
+export class ActAdvisoriesController {
+  constructor(private readonly actAdvisoriesService: ActAdvisoriesService) {}
+
+  /**
+   * POST /api/v1/act/advisories
+   *
+   * Upserts an advisory addressed by its natural key
+   * (`rec_resource_id`, `advisory_number`).
+   *
+   * - If a matching row already exists, it is **updated** in place and the
+   *   response includes `action: 'updated'` with HTTP 200.
+   * - Otherwise a new row is **created** and the response includes
+   *   `action: 'created'` with HTTP 201.
+   */
+  @Post()
+  @HttpCode(HttpStatus.CREATED)
+  @ApiOperation({
+    operationId: 'upsertActAdvisory',
+    summary: 'Create or update an advisory pushed from Act (upsert).',
+    description:
+      'Idempotent upsert of an advisory in `rst.act_advisories_flat`. ' +
+      'The composite natural key (rec_resource_id, advisory_number) determines ' +
+      'whether a record is created or updated.',
+  })
+  @ApiBody({
+    type: ActAdvisoryUpsertDto,
+    description: 'Full advisory payload pushed by Act.',
+  })
+  @ApiCreatedResponse({
+    description: 'Advisory successfully created or updated.',
+    type: ActAdvisoryResponseDto,
+  })
+  @ApiBadRequestResponse({
+    description: 'Validation error in the payload.',
+    type: BadRequestResponseDto,
+  })
+  @ApiNotFoundResponse({
+    description: 'Recreation resource referenced by rec_resource_id not found.',
+    type: GenericErrorResponseDto,
+  })
+  async upsert(
+    @Body() payload: ActAdvisoryUpsertDto,
+  ): Promise<ActAdvisoryResponseDto> {
+    return this.actAdvisoriesService.upsert(payload);
+  }
+
+  /**
+   * PUT /api/v1/act/advisories/:rec_resource_id/:advisory_number
+   *
+   * Partially updates an existing advisory addressed by its natural key.
+   */
+  @Put(':rec_resource_id/:advisory_number')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    operationId: 'updateActAdvisory',
+    summary: 'Update an existing advisory pushed from Act.',
+    description:
+      'Partial update of an existing advisory in `rst.act_advisories_flat`. ' +
+      'The composite natural key is supplied via URL path parameters.',
+  })
+  @ApiParam({
+    name: 'rec_resource_id',
+    required: true,
+    description: 'Recreation resource ID the advisory applies to.',
+    type: 'string',
+    example: 'REC0002',
+  })
+  @ApiParam({
+    name: 'advisory_number',
+    required: true,
+    description: 'Act advisory number.',
+    type: 'integer',
+    example: 3791,
+  })
+  @ApiBody({
+    type: ActAdvisoryUpdateDto,
+    description: 'Partial advisory payload. Only provided fields are updated.',
+  })
+  @ApiOkResponse({
+    description: 'Advisory successfully updated.',
+    type: ActAdvisoryResponseDto,
+  })
+  @ApiBadRequestResponse({
+    description: 'Validation error in the payload or path parameters.',
+    type: BadRequestResponseDto,
+  })
+  @ApiNotFoundResponse({
+    description: 'No advisory exists for the given natural key.',
+    type: GenericErrorResponseDto,
+  })
+  async update(
+    @Param('rec_resource_id') rec_resource_id: string,
+    @Param('advisory_number', ParseIntPipe) advisory_number: number,
+    @Body() payload: ActAdvisoryUpdateDto,
+  ): Promise<ActAdvisoryResponseDto> {
+    return this.actAdvisoriesService.update(
+      { rec_resource_id, advisory_number },
+      payload,
+    );
+  }
+
+  /**
+   * DELETE /api/v1/act/advisories/:rec_resource_id/:advisory_number
+   *
+   * Removes an advisory addressed by its natural key from
+   * `rst.act_advisories_flat`. Act calls this when an advisory is
+   * deleted on their end and should be immediately unlinked from ORCA.
+   */
+  @Delete(':rec_resource_id/:advisory_number')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    operationId: 'deleteActAdvisory',
+    summary: 'Delete an advisory pushed from Act.',
+    description:
+      'Removes the advisory row in `rst.act_advisories_flat` for the given ' +
+      'natural key. This is invoked by Act when the advisory is deleted ' +
+      'on their side.',
+  })
+  @ApiParam({
+    name: 'rec_resource_id',
+    required: true,
+    description: 'Recreation resource ID the advisory applies to.',
+    type: 'string',
+    example: 'REC0002',
+  })
+  @ApiParam({
+    name: 'advisory_number',
+    required: true,
+    description: 'Act advisory number.',
+    type: 'integer',
+    example: 3791,
+  })
+  @ApiOkResponse({
+    description: 'Advisory successfully deleted.',
+    type: ActAdvisoryResponseDto,
+  })
+  @ApiBadRequestResponse({
+    description: 'Invalid path parameters.',
+    type: BadRequestResponseDto,
+  })
+  @ApiNotFoundResponse({
+    description: 'No advisory exists for the given natural key.',
+    type: GenericErrorResponseDto,
+  })
+  async delete(
+    @Param('rec_resource_id') rec_resource_id: string,
+    @Param('advisory_number', ParseIntPipe) advisory_number: number,
+  ): Promise<ActAdvisoryResponseDto> {
+    return this.actAdvisoriesService.delete({
+      rec_resource_id,
+      advisory_number,
+    });
+  }
+}

--- a/admin/backend/src/act/act-advisories.repository.ts
+++ b/admin/backend/src/act/act-advisories.repository.ts
@@ -1,0 +1,236 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Prisma } from '@generated/prisma';
+import { PrismaService } from '@/prisma.service';
+import { ActAdvisoryUpdateDto } from './dtos/act-advisory-update.dto';
+import { ActAdvisoryUpsertDto } from './dtos/act-advisory-upsert.dto';
+
+/**
+ * Composite natural key used to address a row in `act_advisories_flat`.
+ */
+export interface ActAdvisoryKey {
+  rec_resource_id: string;
+  advisory_number: number;
+}
+
+/**
+ * Result of the {@link ActAdvisoriesRepository.upsert} operation.
+ */
+export interface ActAdvisoryUpsertResult {
+  /** Whether the row already existed (and was therefore updated). */
+  created: boolean;
+  /** The persisted row after the upsert. */
+  advisory: Prisma.act_advisories_flatGetPayload<true>;
+}
+
+/**
+ * Repository for managing rows in the `rst.act_advisories_flat` table
+ * that originate from the Act integration.
+ */
+@Injectable()
+export class ActAdvisoriesRepository {
+  private readonly logger = new Logger(ActAdvisoriesRepository.name);
+
+  constructor(private readonly prisma: PrismaService) {}
+
+  /**
+   * Returns true if a row already exists for the given natural key.
+   */
+  async exists(key: ActAdvisoryKey): Promise<boolean> {
+    const existing = await this.prisma.act_advisories_flat.findUnique({
+      where: {
+        rec_resource_id_advisory_number: {
+          rec_resource_id: key.rec_resource_id,
+          advisory_number: key.advisory_number,
+        },
+      },
+      select: { rec_resource_id: true },
+    });
+    return existing !== null;
+  }
+
+  /**
+   * Upserts an advisory record using the composite (rec_resource_id, advisory_number) key.
+   * If the row exists it is updated, otherwise a new row is created.
+   *
+   * @returns the persisted row and whether it was newly created.
+   */
+  async upsert(
+    payload: ActAdvisoryUpsertDto,
+  ): Promise<ActAdvisoryUpsertResult> {
+    const { rec_resource_id, advisory_number } = payload;
+
+    const created = !(await this.exists({ rec_resource_id, advisory_number }));
+
+    const advisory = await this.prisma.act_advisories_flat.upsert({
+      where: {
+        rec_resource_id_advisory_number: {
+          rec_resource_id,
+          advisory_number,
+        },
+      },
+      create: this.toCreateInput(payload),
+      update: this.toUpdateInput(payload),
+    });
+
+    this.logger.log(
+      `Act advisory ${created ? 'created' : 'updated'} (rec_resource_id=${rec_resource_id}, advisory_number=${advisory_number})`,
+    );
+
+    return { created, advisory };
+  }
+
+  /**
+   * Updates an existing advisory row. Throws Prisma P2025 if not found.
+   * Only fields present in the partial DTO are written.
+   */
+  async update(
+    key: ActAdvisoryKey,
+    payload: ActAdvisoryUpdateDto,
+  ): Promise<Prisma.act_advisories_flatGetPayload<true>> {
+    return this.prisma.act_advisories_flat.update({
+      where: {
+        rec_resource_id_advisory_number: {
+          rec_resource_id: key.rec_resource_id,
+          advisory_number: key.advisory_number,
+        },
+      },
+      data: this.toPartialUpdateInput(payload),
+    });
+  }
+
+  /**
+   * Deletes an advisory row. Throws Prisma P2025 if not found.
+   */
+  async delete(key: ActAdvisoryKey): Promise<void> {
+    await this.prisma.act_advisories_flat.delete({
+      where: {
+        rec_resource_id_advisory_number: {
+          rec_resource_id: key.rec_resource_id,
+          advisory_number: key.advisory_number,
+        },
+      },
+    });
+  }
+
+  /**
+   * Builds a Prisma create input from a full upsert payload.
+   */
+  private toCreateInput(
+    payload: ActAdvisoryUpsertDto,
+  ): Prisma.act_advisories_flatUncheckedCreateInput {
+    return {
+      rec_resource_id: payload.rec_resource_id,
+      advisory_number: payload.advisory_number,
+      title: payload.title,
+      description: payload.description ?? null,
+      submitted_by: payload.submitted_by,
+      access_status_name: payload.access_status_name,
+      access_status_grouplabel: payload.access_status_grouplabel,
+      access_status_description: payload.access_status_description ?? null,
+      event_type: payload.event_type,
+      urgency: payload.urgency,
+      advisory_status: payload.advisory_status,
+      is_reservations_affected: payload.is_reservations_affected,
+      is_advisory_date_displayed: payload.is_advisory_date_displayed,
+      is_effective_date_displayed: payload.is_effective_date_displayed,
+      is_end_date_displayed: payload.is_end_date_displayed,
+      is_updated_date_displayed: payload.is_updated_date_displayed,
+      advisory_date: payload.advisory_date,
+      effective_date: payload.effective_date,
+      end_date: payload.end_date ?? null,
+      expiry_date: payload.expiry_date ?? null,
+      updated_date: payload.updated_date,
+      published_at: payload.published_at ?? null,
+      listing_rank: payload.listing_rank ?? 0,
+      urgency_sequence: payload.urgency_sequence ?? 0,
+      access_status_precedence: payload.access_status_precedence ?? 0,
+      event_type_precedence: payload.event_type_precedence ?? 0,
+    };
+  }
+
+  /**
+   * Builds a Prisma update input from a full upsert payload.
+   * The composite key columns are intentionally omitted because they
+   * are matched in the `where` clause.
+   */
+  private toUpdateInput(
+    payload: ActAdvisoryUpsertDto,
+  ): Prisma.act_advisories_flatUncheckedUpdateInput {
+    return {
+      title: payload.title,
+      description: payload.description ?? null,
+      submitted_by: payload.submitted_by,
+      access_status_name: payload.access_status_name,
+      access_status_grouplabel: payload.access_status_grouplabel,
+      access_status_description: payload.access_status_description ?? null,
+      event_type: payload.event_type,
+      urgency: payload.urgency,
+      advisory_status: payload.advisory_status,
+      is_reservations_affected: payload.is_reservations_affected,
+      is_advisory_date_displayed: payload.is_advisory_date_displayed,
+      is_effective_date_displayed: payload.is_effective_date_displayed,
+      is_end_date_displayed: payload.is_end_date_displayed,
+      is_updated_date_displayed: payload.is_updated_date_displayed,
+      advisory_date: payload.advisory_date,
+      effective_date: payload.effective_date,
+      end_date: payload.end_date ?? null,
+      expiry_date: payload.expiry_date ?? null,
+      updated_date: payload.updated_date,
+      published_at: payload.published_at ?? null,
+      listing_rank: payload.listing_rank ?? 0,
+      urgency_sequence: payload.urgency_sequence ?? 0,
+      access_status_precedence: payload.access_status_precedence ?? 0,
+      event_type_precedence: payload.event_type_precedence ?? 0,
+    };
+  }
+
+  /**
+   * Builds a Prisma partial update input - only fields explicitly present
+   * in the partial DTO are written. Fields explicitly set to `null` are
+   * forwarded so Act can clear nullable columns.
+   */
+  private toPartialUpdateInput(
+    payload: ActAdvisoryUpdateDto,
+  ): Prisma.act_advisories_flatUncheckedUpdateInput {
+    const data: Prisma.act_advisories_flatUncheckedUpdateInput = {};
+
+    const setIfPresent = <K extends keyof ActAdvisoryUpdateDto>(
+      key: K,
+    ): void => {
+      if (Object.prototype.hasOwnProperty.call(payload, key)) {
+        (data as Record<string, unknown>)[key as string] = payload[
+          key
+        ] as unknown;
+      }
+    };
+
+    setIfPresent('title');
+    setIfPresent('description');
+    setIfPresent('submitted_by');
+    setIfPresent('access_status_name');
+    setIfPresent('access_status_grouplabel');
+    setIfPresent('access_status_description');
+    setIfPresent('event_type');
+    setIfPresent('urgency');
+    setIfPresent('advisory_status');
+    setIfPresent('is_reservations_affected');
+    setIfPresent('is_advisory_date_displayed');
+    setIfPresent('is_effective_date_displayed');
+    setIfPresent('is_end_date_displayed');
+    setIfPresent('is_updated_date_displayed');
+    setIfPresent('advisory_date');
+    setIfPresent('effective_date');
+    setIfPresent('end_date');
+    setIfPresent('expiry_date');
+    setIfPresent('removal_date');
+    setIfPresent('updated_date');
+    setIfPresent('modified_date');
+    setIfPresent('published_at');
+    setIfPresent('listing_rank');
+    setIfPresent('urgency_sequence');
+    setIfPresent('access_status_precedence');
+    setIfPresent('event_type_precedence');
+
+    return data;
+  }
+}

--- a/admin/backend/src/act/act-advisories.repository.ts
+++ b/admin/backend/src/act/act-advisories.repository.ts
@@ -37,12 +37,7 @@ export class ActAdvisoriesRepository {
    */
   async exists(key: ActAdvisoryKey): Promise<boolean> {
     const existing = await this.prisma.act_advisories_flat.findUnique({
-      where: {
-        rec_resource_id_advisory_number: {
-          rec_resource_id: key.rec_resource_id,
-          advisory_number: key.advisory_number,
-        },
-      },
+      where: this.toCompositeWhereInput(key),
       select: { rec_resource_id: true },
     });
     return existing !== null;
@@ -62,12 +57,7 @@ export class ActAdvisoriesRepository {
     const created = !(await this.exists({ rec_resource_id, advisory_number }));
 
     const advisory = await this.prisma.act_advisories_flat.upsert({
-      where: {
-        rec_resource_id_advisory_number: {
-          rec_resource_id,
-          advisory_number,
-        },
-      },
+      where: this.toCompositeWhereInput({ rec_resource_id, advisory_number }),
       create: this.toCreateInput(payload),
       update: this.toUpdateInput(payload),
     });
@@ -88,12 +78,7 @@ export class ActAdvisoriesRepository {
     payload: ActAdvisoryUpdateDto,
   ): Promise<Prisma.act_advisories_flatGetPayload<true>> {
     return this.prisma.act_advisories_flat.update({
-      where: {
-        rec_resource_id_advisory_number: {
-          rec_resource_id: key.rec_resource_id,
-          advisory_number: key.advisory_number,
-        },
-      },
+      where: this.toCompositeWhereInput(key),
       data: this.toPartialUpdateInput(payload),
     });
   }
@@ -103,13 +88,59 @@ export class ActAdvisoriesRepository {
    */
   async delete(key: ActAdvisoryKey): Promise<void> {
     await this.prisma.act_advisories_flat.delete({
-      where: {
-        rec_resource_id_advisory_number: {
-          rec_resource_id: key.rec_resource_id,
-          advisory_number: key.advisory_number,
-        },
-      },
+      where: this.toCompositeWhereInput(key),
     });
+  }
+
+  /**
+   * Builds the Prisma `where` object for the advisory composite natural key.
+   */
+  private toCompositeWhereInput(
+    key: ActAdvisoryKey,
+  ): Prisma.act_advisories_flatWhereUniqueInput {
+    return {
+      rec_resource_id_advisory_number: {
+        rec_resource_id: key.rec_resource_id,
+        advisory_number: key.advisory_number,
+      },
+    };
+  }
+
+  /**
+   * Shared normalized payload used by both create and full update operations.
+   */
+  private toWriteInput(
+    payload: ActAdvisoryUpsertDto,
+  ): Omit<
+    Prisma.act_advisories_flatUncheckedCreateInput,
+    'rec_resource_id' | 'advisory_number'
+  > {
+    return {
+      title: payload.title,
+      description: payload.description ?? null,
+      submitted_by: payload.submitted_by,
+      access_status_name: payload.access_status_name,
+      access_status_grouplabel: payload.access_status_grouplabel,
+      access_status_description: payload.access_status_description ?? null,
+      event_type: payload.event_type,
+      urgency: payload.urgency,
+      advisory_status: payload.advisory_status,
+      is_reservations_affected: payload.is_reservations_affected,
+      is_advisory_date_displayed: payload.is_advisory_date_displayed,
+      is_effective_date_displayed: payload.is_effective_date_displayed,
+      is_end_date_displayed: payload.is_end_date_displayed,
+      is_updated_date_displayed: payload.is_updated_date_displayed,
+      advisory_date: payload.advisory_date,
+      effective_date: payload.effective_date,
+      end_date: payload.end_date ?? null,
+      expiry_date: payload.expiry_date ?? null,
+      updated_date: payload.updated_date,
+      published_at: payload.published_at ?? null,
+      listing_rank: payload.listing_rank ?? 0,
+      urgency_sequence: payload.urgency_sequence ?? 0,
+      access_status_precedence: payload.access_status_precedence ?? 0,
+      event_type_precedence: payload.event_type_precedence ?? 0,
+    };
   }
 
   /**
@@ -121,30 +152,7 @@ export class ActAdvisoriesRepository {
     return {
       rec_resource_id: payload.rec_resource_id,
       advisory_number: payload.advisory_number,
-      title: payload.title,
-      description: payload.description ?? null,
-      submitted_by: payload.submitted_by,
-      access_status_name: payload.access_status_name,
-      access_status_grouplabel: payload.access_status_grouplabel,
-      access_status_description: payload.access_status_description ?? null,
-      event_type: payload.event_type,
-      urgency: payload.urgency,
-      advisory_status: payload.advisory_status,
-      is_reservations_affected: payload.is_reservations_affected,
-      is_advisory_date_displayed: payload.is_advisory_date_displayed,
-      is_effective_date_displayed: payload.is_effective_date_displayed,
-      is_end_date_displayed: payload.is_end_date_displayed,
-      is_updated_date_displayed: payload.is_updated_date_displayed,
-      advisory_date: payload.advisory_date,
-      effective_date: payload.effective_date,
-      end_date: payload.end_date ?? null,
-      expiry_date: payload.expiry_date ?? null,
-      updated_date: payload.updated_date,
-      published_at: payload.published_at ?? null,
-      listing_rank: payload.listing_rank ?? 0,
-      urgency_sequence: payload.urgency_sequence ?? 0,
-      access_status_precedence: payload.access_status_precedence ?? 0,
-      event_type_precedence: payload.event_type_precedence ?? 0,
+      ...this.toWriteInput(payload),
     };
   }
 
@@ -156,32 +164,7 @@ export class ActAdvisoriesRepository {
   private toUpdateInput(
     payload: ActAdvisoryUpsertDto,
   ): Prisma.act_advisories_flatUncheckedUpdateInput {
-    return {
-      title: payload.title,
-      description: payload.description ?? null,
-      submitted_by: payload.submitted_by,
-      access_status_name: payload.access_status_name,
-      access_status_grouplabel: payload.access_status_grouplabel,
-      access_status_description: payload.access_status_description ?? null,
-      event_type: payload.event_type,
-      urgency: payload.urgency,
-      advisory_status: payload.advisory_status,
-      is_reservations_affected: payload.is_reservations_affected,
-      is_advisory_date_displayed: payload.is_advisory_date_displayed,
-      is_effective_date_displayed: payload.is_effective_date_displayed,
-      is_end_date_displayed: payload.is_end_date_displayed,
-      is_updated_date_displayed: payload.is_updated_date_displayed,
-      advisory_date: payload.advisory_date,
-      effective_date: payload.effective_date,
-      end_date: payload.end_date ?? null,
-      expiry_date: payload.expiry_date ?? null,
-      updated_date: payload.updated_date,
-      published_at: payload.published_at ?? null,
-      listing_rank: payload.listing_rank ?? 0,
-      urgency_sequence: payload.urgency_sequence ?? 0,
-      access_status_precedence: payload.access_status_precedence ?? 0,
-      event_type_precedence: payload.event_type_precedence ?? 0,
-    };
+    return this.toWriteInput(payload);
   }
 
   /**
@@ -193,43 +176,47 @@ export class ActAdvisoriesRepository {
     payload: ActAdvisoryUpdateDto,
   ): Prisma.act_advisories_flatUncheckedUpdateInput {
     const data: Prisma.act_advisories_flatUncheckedUpdateInput = {};
+    const source = payload as Record<string, unknown>;
 
     const setIfPresent = <K extends keyof ActAdvisoryUpdateDto>(
       key: K,
     ): void => {
       if (Object.prototype.hasOwnProperty.call(payload, key)) {
-        (data as Record<string, unknown>)[key as string] = payload[
-          key
-        ] as unknown;
+        (data as Record<string, unknown>)[key as string] =
+          source[key as string];
       }
     };
 
-    setIfPresent('title');
-    setIfPresent('description');
-    setIfPresent('submitted_by');
-    setIfPresent('access_status_name');
-    setIfPresent('access_status_grouplabel');
-    setIfPresent('access_status_description');
-    setIfPresent('event_type');
-    setIfPresent('urgency');
-    setIfPresent('advisory_status');
-    setIfPresent('is_reservations_affected');
-    setIfPresent('is_advisory_date_displayed');
-    setIfPresent('is_effective_date_displayed');
-    setIfPresent('is_end_date_displayed');
-    setIfPresent('is_updated_date_displayed');
-    setIfPresent('advisory_date');
-    setIfPresent('effective_date');
-    setIfPresent('end_date');
-    setIfPresent('expiry_date');
-    setIfPresent('removal_date');
-    setIfPresent('updated_date');
-    setIfPresent('modified_date');
-    setIfPresent('published_at');
-    setIfPresent('listing_rank');
-    setIfPresent('urgency_sequence');
-    setIfPresent('access_status_precedence');
-    setIfPresent('event_type_precedence');
+    const updatableFields: Array<keyof ActAdvisoryUpdateDto> = [
+      'title',
+      'description',
+      'submitted_by',
+      'access_status_name',
+      'access_status_grouplabel',
+      'access_status_description',
+      'event_type',
+      'urgency',
+      'advisory_status',
+      'is_reservations_affected',
+      'is_advisory_date_displayed',
+      'is_effective_date_displayed',
+      'is_end_date_displayed',
+      'is_updated_date_displayed',
+      'advisory_date',
+      'effective_date',
+      'end_date',
+      'expiry_date',
+      'removal_date',
+      'updated_date',
+      'modified_date',
+      'published_at',
+      'listing_rank',
+      'urgency_sequence',
+      'access_status_precedence',
+      'event_type_precedence',
+    ];
+
+    updatableFields.forEach(setIfPresent);
 
     return data;
   }

--- a/admin/backend/src/act/act-advisories.service.ts
+++ b/admin/backend/src/act/act-advisories.service.ts
@@ -1,0 +1,123 @@
+import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { PrismaService } from '@/prisma.service';
+import { ActAdvisoryResponseDto } from './dtos/act-advisory-response.dto';
+import { ActAdvisoryUpdateDto } from './dtos/act-advisory-update.dto';
+import { ActAdvisoryUpsertDto } from './dtos/act-advisory-upsert.dto';
+import {
+  ActAdvisoriesRepository,
+  ActAdvisoryKey,
+} from './act-advisories.repository';
+import { ACT_ERROR_MESSAGES, ACT_LOG_MESSAGES } from './act.constants';
+
+/**
+ * Service that orchestrates Act-driven changes against the
+ * `rst.act_advisories_flat` table.
+ *
+ * The service is responsible for:
+ *  - Validating the referenced recreation resource exists before write
+ *  - Delegating persistence to {@link ActAdvisoriesRepository}
+ *  - Mapping persistence results into the API response shape
+ */
+@Injectable()
+export class ActAdvisoriesService {
+  private readonly logger = new Logger(ActAdvisoriesService.name);
+
+  constructor(
+    private readonly repository: ActAdvisoriesRepository,
+    private readonly prisma: PrismaService,
+  ) {}
+
+  /**
+   * Create-or-update an advisory record using the natural key.
+   */
+  async upsert(payload: ActAdvisoryUpsertDto): Promise<ActAdvisoryResponseDto> {
+    this.logger.log(
+      `${ACT_LOG_MESSAGES.UPSERT_RECEIVED} (rec_resource_id=${payload.rec_resource_id}, advisory_number=${payload.advisory_number})`,
+    );
+
+    await this.assertRecResourceExists(payload.rec_resource_id);
+
+    const { created } = await this.repository.upsert(payload);
+
+    this.logger.log(ACT_LOG_MESSAGES.UPSERT_SUCCESS);
+
+    return {
+      rec_resource_id: payload.rec_resource_id,
+      advisory_number: payload.advisory_number,
+      action: created ? 'created' : 'updated',
+      timestamp: new Date().toISOString(),
+    };
+  }
+
+  /**
+   * Partially update an existing advisory addressed by its natural key.
+   * Throws {@link NotFoundException} if no matching row exists.
+   */
+  async update(
+    key: ActAdvisoryKey,
+    payload: ActAdvisoryUpdateDto,
+  ): Promise<ActAdvisoryResponseDto> {
+    this.logger.log(
+      `${ACT_LOG_MESSAGES.UPDATE_RECEIVED} (rec_resource_id=${key.rec_resource_id}, advisory_number=${key.advisory_number})`,
+    );
+
+    if (!(await this.repository.exists(key))) {
+      throw new NotFoundException(ACT_ERROR_MESSAGES.ADVISORY_NOT_FOUND);
+    }
+
+    await this.repository.update(key, payload);
+
+    this.logger.log(ACT_LOG_MESSAGES.UPDATE_SUCCESS);
+
+    return {
+      rec_resource_id: key.rec_resource_id,
+      advisory_number: key.advisory_number,
+      action: 'updated',
+      timestamp: new Date().toISOString(),
+    };
+  }
+
+  /**
+   * Delete an advisory addressed by its natural key.
+   * Throws {@link NotFoundException} if no matching row exists.
+   */
+  async delete(key: ActAdvisoryKey): Promise<ActAdvisoryResponseDto> {
+    this.logger.log(
+      `${ACT_LOG_MESSAGES.DELETE_RECEIVED} (rec_resource_id=${key.rec_resource_id}, advisory_number=${key.advisory_number})`,
+    );
+
+    if (!(await this.repository.exists(key))) {
+      throw new NotFoundException(ACT_ERROR_MESSAGES.ADVISORY_NOT_FOUND);
+    }
+
+    await this.repository.delete(key);
+
+    this.logger.log(ACT_LOG_MESSAGES.DELETE_SUCCESS);
+
+    return {
+      rec_resource_id: key.rec_resource_id,
+      advisory_number: key.advisory_number,
+      action: 'deleted',
+      timestamp: new Date().toISOString(),
+    };
+  }
+
+  /**
+   * Ensures the referenced rec_resource exists; throws NotFoundException
+   * otherwise. This protects against orphan advisories and produces a
+   * cleaner 404 than letting the FK constraint fire.
+   */
+  private async assertRecResourceExists(
+    rec_resource_id: string,
+  ): Promise<void> {
+    const resource = await this.prisma.recreation_resource.findUnique({
+      where: { rec_resource_id },
+      select: { rec_resource_id: true },
+    });
+    if (!resource) {
+      throw new NotFoundException(
+        `${ACT_ERROR_MESSAGES.REC_RESOURCE_NOT_FOUND}: ${rec_resource_id}`,
+      );
+    }
+  }
+}

--- a/admin/backend/src/act/act.constants.ts
+++ b/admin/backend/src/act/act.constants.ts
@@ -1,0 +1,33 @@
+/**
+ * Constants for the Act integration module.
+ *
+ * The Act team pushes real-time advisory changes into ACT data tables
+ * via the secure CUD API exposed under `/api/v1/act/advisories`.
+ *
+ * Authentication is performed through CSS (Common Hosted Single Sign-On)
+ * using the OAuth2 Client Credentials grant flow. The bearer token issued
+ * by CSS must carry the `act-service` client role.
+ */
+
+// Swagger tag used to group Act endpoints in the OpenAPI docs
+export const ACT_API_TAG = 'act';
+
+// URI path segment for Act CUD endpoints
+export const ACT_ADVISORIES_PATH = 'act/advisories';
+
+// Log messages for the Act advisories service
+export const ACT_LOG_MESSAGES = {
+  UPSERT_RECEIVED: 'Received Act advisory upsert request',
+  UPSERT_SUCCESS: 'Act advisory upsert completed',
+  UPDATE_RECEIVED: 'Received Act advisory update request',
+  UPDATE_SUCCESS: 'Act advisory update completed',
+  DELETE_RECEIVED: 'Received Act advisory delete request',
+  DELETE_SUCCESS: 'Act advisory delete completed',
+} as const;
+
+// Error messages returned by the Act advisories endpoints
+export const ACT_ERROR_MESSAGES = {
+  ADVISORY_NOT_FOUND: 'Advisory not found',
+  REC_RESOURCE_NOT_FOUND: 'Recreation resource not found',
+  INVALID_ADVISORY_NUMBER: 'advisory_number must be a positive integer',
+} as const;

--- a/admin/backend/src/act/act.module.ts
+++ b/admin/backend/src/act/act.module.ts
@@ -1,0 +1,25 @@
+import { PrismaModule } from '@/prisma.module';
+import { PrismaService } from '@/prisma.service';
+import { UserContextModule } from '@/common/modules/user-context/user-context.module';
+import { Module } from '@nestjs/common';
+import { ActAuthModule } from './auth';
+import { ActAdvisoriesController } from './act-advisories.controller';
+import { ActAdvisoriesRepository } from './act-advisories.repository';
+import { ActAdvisoriesService } from './act-advisories.service';
+
+/**
+ * Module exposing the secure CUD advisory endpoints consumed by the
+ * Act integration. Endpoints live under `/api/v1/act/advisories`.
+ *
+ * Security: CSS OAuth2 Client Credentials -> Keycloak bearer JWT validated
+ *          by {@link ActAuthModule}'s isolated Act Passport strategy
+ *          (audience bound to the Act CSS client). Authorization is
+ *          enforced via the `act-service` client role.
+ */
+@Module({
+  imports: [ActAuthModule, PrismaModule, UserContextModule],
+  controllers: [ActAdvisoriesController],
+  providers: [ActAdvisoriesService, ActAdvisoriesRepository, PrismaService],
+  exports: [ActAdvisoriesService],
+})
+export class ActModule {}

--- a/admin/backend/src/act/auth/act-auth.constants.ts
+++ b/admin/backend/src/act/auth/act-auth.constants.ts
@@ -1,0 +1,14 @@
+/**
+ * Constants for the Act-specific authentication wiring.
+ *
+ * Strategy name keys live in the central {@link AUTH_STRATEGY} constant
+ * (see `src/auth/auth.constants.ts`) so guards and decorators can resolve
+ * them without depending on this module.
+ */
+
+export const ACT_AUTH_LOG_MESSAGES = {
+  STRATEGY_INITIALIZED:
+    'Act Keycloak authentication strategy initialized successfully',
+  MISSING_SERVICE_ACCOUNT:
+    'Act token is missing a recognizable service-account identifier',
+} as const;

--- a/admin/backend/src/act/auth/act-auth.module.ts
+++ b/admin/backend/src/act/auth/act-auth.module.ts
@@ -1,0 +1,23 @@
+import { UserContextModule } from '@/common/modules/user-context/user-context.module';
+import { Module } from '@nestjs/common';
+import { PassportModule } from '@nestjs/passport';
+import { AuthPassportActKeycloakStrategy } from './auth-passport-act-keycloak.strategy';
+
+/**
+ * Module that wires up the Act-only Keycloak Passport strategy.
+ *
+ * It is intentionally separate from the global RST admin {@link AuthModule}
+ * because:
+ *  - Act tokens come from a different CSS client and therefore carry
+ *    a different `aud` claim.
+ *  - The global RST admin strategy is bound to the RST admin client and
+ *    would reject Act tokens at runtime (and vice-versa).
+ *  - This module is imported only by the {@link ActModule} so the
+ *    strategy is never accidentally picked up by other parts of the app.
+ */
+@Module({
+  imports: [PassportModule, UserContextModule],
+  providers: [AuthPassportActKeycloakStrategy],
+  exports: [PassportModule],
+})
+export class ActAuthModule {}

--- a/admin/backend/src/act/auth/auth-passport-act-keycloak.strategy.ts
+++ b/admin/backend/src/act/auth/auth-passport-act-keycloak.strategy.ts
@@ -1,0 +1,106 @@
+import { AppConfigService } from '@/app-config/app-config.service';
+import { AUTH_STRATEGY } from '@/auth/auth.constants';
+import { KeycloakUserToken } from '@/auth/auth.types';
+import { UserContextService } from '@/common/modules/user-context/user-context.service';
+import { Injectable, Logger, UnauthorizedException } from '@nestjs/common';
+import { PassportStrategy } from '@nestjs/passport';
+import KeycloakBearerStrategy from 'passport-keycloak-bearer';
+import { ACT_AUTH_LOG_MESSAGES } from './act-auth.constants';
+
+/**
+ * Passport strategy dedicated to authenticating the Act integration.
+ *
+ * Why a separate strategy from {@link AuthPassportKeycloakStrategy}?
+ *  - The RST admin strategy is registered globally and validates the
+ *    audience claim against the RST admin client. Act tokens come from
+ *    a *different* CSS client (with a different `aud`) and must NOT be
+ *    accepted by RST admin endpoints, nor vice-versa.
+ *  - Keeping the strategies isolated guarantees a Act-issued bearer
+ *    token can only address `/api/v1/act/**` routes.
+ *
+ * Registered under {@link AUTH_STRATEGY.ACT_KEYCLOAK} so controllers
+ * can opt in via `@UseGuards(AuthGuard(AUTH_STRATEGY.ACT_KEYCLOAK))`.
+ *
+ * On successful validation the payload is stored in CLS with an
+ * identity provider of `'SERVICE'`, and the `idir_username` field is
+ * synthesized from the token (`azp` / `client_id` / `preferred_username`)
+ * so audit-aware downstream code keeps working.
+ */
+@Injectable()
+export class AuthPassportActKeycloakStrategy extends PassportStrategy(
+  KeycloakBearerStrategy,
+  AUTH_STRATEGY.ACT_KEYCLOAK,
+) {
+  private readonly logger = new Logger(AuthPassportActKeycloakStrategy.name);
+
+  constructor(
+    private readonly appConfig: AppConfigService,
+    private readonly userContextService: UserContextService,
+  ) {
+    const options = AuthPassportActKeycloakStrategy.buildConfig(appConfig);
+    super(options);
+    this.logger.log(ACT_AUTH_LOG_MESSAGES.STRATEGY_INITIALIZED);
+  }
+
+  /**
+   * Build the underlying `passport-keycloak-bearer` options bound to the
+   * Act CSS client audience.
+   */
+  private static buildConfig(
+    appConfigService: AppConfigService,
+  ): KeycloakBearerStrategy.Options {
+    return {
+      realm: appConfigService.keycloakRealm,
+      url: appConfigService.keycloakAuthServerUrl,
+      issuer: appConfigService.keycloakIssuer,
+      // Audience MUST match the Act CSS client - this is what keeps the
+      // strategy isolated from the RST admin strategy.
+      audience: appConfigService.actCssClientId,
+      loggingLevel: 'warn',
+    };
+  }
+
+  /**
+   * Validates the decoded JWT payload, stores a service-account user
+   * context in CLS, and returns the payload to Passport.
+   *
+   * Act tokens are issued via the Client Credentials grant flow, which
+   * has no end user. We synthesize a stable identifier from standard
+   * OAuth2 claims so the audit extension can populate `created_by` /
+   * `updated_by` fields without depending on `idir_username`.
+   */
+  async validate(payload: KeycloakUserToken): Promise<KeycloakUserToken> {
+    const serviceAccountId = this.resolveServiceAccountId(payload);
+    if (!serviceAccountId) {
+      this.logger.warn(ACT_AUTH_LOG_MESSAGES.MISSING_SERVICE_ACCOUNT);
+      throw new UnauthorizedException(
+        ACT_AUTH_LOG_MESSAGES.MISSING_SERVICE_ACCOUNT,
+      );
+    }
+
+    const enrichedPayload: KeycloakUserToken = {
+      ...payload,
+      idir_username: serviceAccountId,
+    };
+
+    this.userContextService.setCurrentUser(enrichedPayload, 'SERVICE');
+    return enrichedPayload;
+  }
+
+  /**
+   * Picks the most appropriate stable identifier from the JWT for use as
+   * the service-account username. Prefers `azp` (authorized party, the
+   * OAuth2 client that obtained the token), then `client_id`, then
+   * `preferred_username`, then `sub` as a last resort.
+   */
+  private resolveServiceAccountId(
+    payload: KeycloakUserToken,
+  ): string | undefined {
+    const azp = typeof payload.azp === 'string' ? payload.azp : undefined;
+    const clientId =
+      typeof payload.client_id === 'string' ? payload.client_id : undefined;
+    return (
+      azp ?? clientId ?? payload.preferred_username ?? payload.sub ?? undefined
+    );
+  }
+}

--- a/admin/backend/src/act/auth/index.ts
+++ b/admin/backend/src/act/auth/index.ts
@@ -1,0 +1,3 @@
+export * from './auth-passport-act-keycloak.strategy';
+export * from './act-auth.constants';
+export * from './act-auth.module';

--- a/admin/backend/src/act/dtos/act-advisory-response.dto.ts
+++ b/admin/backend/src/act/dtos/act-advisory-response.dto.ts
@@ -1,0 +1,33 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+/**
+ * Response returned by the Act CUD endpoints describing the action that
+ * was performed against `act_advisories_flat`.
+ */
+export class ActAdvisoryResponseDto {
+  @ApiProperty({
+    description:
+      'Recreation resource identifier (REC ID) the advisory applies to.',
+    example: 'REC0002',
+  })
+  rec_resource_id: string;
+
+  @ApiProperty({
+    description: 'Act advisory number.',
+    example: 3791,
+  })
+  advisory_number: number;
+
+  @ApiProperty({
+    description: 'The action that was performed.',
+    enum: ['created', 'updated', 'deleted'],
+    example: 'created',
+  })
+  action: 'created' | 'updated' | 'deleted';
+
+  @ApiProperty({
+    description: 'Timestamp (ISO 8601) at which the action was performed.',
+    example: '2026-06-10T18:30:00.000Z',
+  })
+  timestamp: string;
+}

--- a/admin/backend/src/act/dtos/act-advisory-update.dto.ts
+++ b/admin/backend/src/act/dtos/act-advisory-update.dto.ts
@@ -1,0 +1,234 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import {
+  IsBoolean,
+  IsDate,
+  IsInt,
+  IsOptional,
+  IsString,
+  MaxLength,
+} from 'class-validator';
+
+/**
+ * DTO used for the PUT endpoint:
+ *   PUT /act/advisories/:rec_resource_id/:advisory_number
+ *
+ * The natural key (`rec_resource_id`, `advisory_number`) comes from the URL,
+ * so it is intentionally absent from the body. All remaining fields are
+ * optional to support partial updates from Act.
+ */
+export class ActAdvisoryUpdateDto {
+  @ApiPropertyOptional({ description: 'Advisory title.', maxLength: 255 })
+  @IsOptional()
+  @IsString()
+  @MaxLength(255)
+  title?: string;
+
+  @ApiPropertyOptional({
+    description: 'Long-form advisory description / body.',
+    nullable: true,
+  })
+  @IsOptional()
+  @IsString()
+  description?: string | null;
+
+  @ApiPropertyOptional({
+    description:
+      'Username / identifier of the person who submitted the advisory in Act.',
+    maxLength: 120,
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(120)
+  submitted_by?: string;
+
+  @ApiPropertyOptional({
+    description: 'Display name of the access status.',
+    maxLength: 100,
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(100)
+  access_status_name?: string;
+
+  @ApiPropertyOptional({
+    description: 'Access status grouping label.',
+    maxLength: 50,
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(50)
+  access_status_grouplabel?: string;
+
+  @ApiPropertyOptional({
+    description: 'Access status description.',
+    nullable: true,
+  })
+  @IsOptional()
+  @IsString()
+  access_status_description?: string | null;
+
+  @ApiPropertyOptional({
+    description: 'Event type for the advisory.',
+    maxLength: 100,
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(100)
+  event_type?: string;
+
+  @ApiPropertyOptional({
+    description: 'Urgency level (e.g. Low / Medium / High).',
+    maxLength: 25,
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(25)
+  urgency?: string;
+
+  @ApiPropertyOptional({
+    description: 'Advisory status (e.g. Published / Draft).',
+    maxLength: 100,
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(100)
+  advisory_status?: string;
+
+  @ApiPropertyOptional({
+    description: 'Whether the advisory affects reservations.',
+  })
+  @IsOptional()
+  @IsBoolean()
+  is_reservations_affected?: boolean;
+
+  @ApiPropertyOptional({
+    description: 'Whether the advisory_date should be displayed publicly.',
+  })
+  @IsOptional()
+  @IsBoolean()
+  is_advisory_date_displayed?: boolean;
+
+  @ApiPropertyOptional({
+    description: 'Whether the effective_date should be displayed publicly.',
+  })
+  @IsOptional()
+  @IsBoolean()
+  is_effective_date_displayed?: boolean;
+
+  @ApiPropertyOptional({
+    description: 'Whether the end_date should be displayed publicly.',
+  })
+  @IsOptional()
+  @IsBoolean()
+  is_end_date_displayed?: boolean;
+
+  @ApiPropertyOptional({
+    description: 'Whether the updated_date should be displayed publicly.',
+  })
+  @IsOptional()
+  @IsBoolean()
+  is_updated_date_displayed?: boolean;
+
+  @ApiPropertyOptional({
+    description: 'Date the advisory was created in Act (ISO 8601).',
+    type: String,
+  })
+  @IsOptional()
+  @Type(() => Date)
+  @IsDate()
+  advisory_date?: Date;
+
+  @ApiPropertyOptional({
+    description: 'Date the advisory becomes effective (ISO 8601).',
+    type: String,
+  })
+  @IsOptional()
+  @Type(() => Date)
+  @IsDate()
+  effective_date?: Date;
+
+  @ApiPropertyOptional({
+    description: 'Date the advisory ends, if applicable (ISO 8601).',
+    type: String,
+    nullable: true,
+  })
+  @IsOptional()
+  @Type(() => Date)
+  @IsDate()
+  end_date?: Date | null;
+
+  @ApiPropertyOptional({
+    description: 'Date the advisory expires, if applicable (ISO 8601).',
+    type: String,
+    nullable: true,
+  })
+  @IsOptional()
+  @Type(() => Date)
+  @IsDate()
+  expiry_date?: Date | null;
+
+  @ApiPropertyOptional({
+    description: 'Date the advisory was removed in Act, if applicable.',
+    type: String,
+    nullable: true,
+  })
+  @IsOptional()
+  @Type(() => Date)
+  @IsDate()
+  removal_date?: Date | null;
+
+  @ApiPropertyOptional({
+    description: 'Date the advisory record was last updated in Act.',
+    type: String,
+  })
+  @IsOptional()
+  @Type(() => Date)
+  @IsDate()
+  updated_date?: Date;
+
+  @ApiPropertyOptional({
+    description: 'Date the advisory was last content-modified in Act.',
+    type: String,
+  })
+  @IsOptional()
+  @Type(() => Date)
+  @IsDate()
+  modified_date?: Date;
+
+  @ApiPropertyOptional({
+    description: 'Date the advisory was published, if applicable.',
+    type: String,
+    nullable: true,
+  })
+  @IsOptional()
+  @Type(() => Date)
+  @IsDate()
+  published_at?: Date | null;
+
+  @ApiPropertyOptional({
+    description: 'Listing rank used to order advisories in UIs.',
+  })
+  @IsOptional()
+  @IsInt()
+  listing_rank?: number;
+
+  @ApiPropertyOptional({ description: 'Urgency sequence used for ordering.' })
+  @IsOptional()
+  @IsInt()
+  urgency_sequence?: number;
+
+  @ApiPropertyOptional({
+    description: 'Access-status precedence used for ordering.',
+  })
+  @IsOptional()
+  @IsInt()
+  access_status_precedence?: number;
+
+  @ApiPropertyOptional({
+    description: 'Event-type precedence used for ordering.',
+  })
+  @IsOptional()
+  @IsInt()
+  event_type_precedence?: number;
+}

--- a/admin/backend/src/act/dtos/act-advisory-upsert.dto.ts
+++ b/admin/backend/src/act/dtos/act-advisory-upsert.dto.ts
@@ -1,0 +1,284 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import {
+  IsBoolean,
+  IsDate,
+  IsInt,
+  IsNotEmpty,
+  IsOptional,
+  IsPositive,
+  IsString,
+  MaxLength,
+  Min,
+} from 'class-validator';
+
+/**
+ * Payload pushed by the Act integration to upsert an advisory.
+ *
+ * The composite natural key (`rec_resource_id`, `advisory_number`)
+ * is used for the upsert decision:
+ *  - If a row with the same key exists, the record is updated.
+ *  - Otherwise a new record is created.
+ *
+ * All fields mirror the columns of `rst.act_advisories_flat`.
+ */
+export class ActAdvisoryUpsertDto {
+  @ApiProperty({
+    description:
+      'Recreation resource identifier (REC ID) the advisory applies to.',
+    example: 'REC0002',
+    maxLength: 20,
+  })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(20)
+  rec_resource_id: string;
+
+  @ApiProperty({
+    description:
+      'Act advisory number. Together with rec_resource_id this forms the unique key.',
+    example: 3791,
+    minimum: 1,
+  })
+  @IsInt()
+  @IsPositive()
+  @Min(1)
+  advisory_number: number;
+
+  @ApiProperty({
+    description: 'Advisory title.',
+    example: 'Bear in area',
+    maxLength: 255,
+  })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(255)
+  title: string;
+
+  @ApiPropertyOptional({
+    description: 'Long-form advisory description / body.',
+    example:
+      'A black bear has been spotted near the main campground. Please use bear-safe storage.',
+    nullable: true,
+  })
+  @IsOptional()
+  @IsString()
+  description?: string | null;
+
+  @ApiProperty({
+    description:
+      'Username / identifier of the person who submitted the advisory in Act.',
+    example: 'jdoe',
+    maxLength: 120,
+  })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(120)
+  submitted_by: string;
+
+  @ApiProperty({
+    description: 'Display name of the access status.',
+    example: 'Open with restrictions',
+    maxLength: 100,
+  })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(100)
+  access_status_name: string;
+
+  @ApiProperty({
+    description: 'Access status grouping label.',
+    example: 'Open',
+    maxLength: 50,
+  })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(50)
+  access_status_grouplabel: string;
+
+  @ApiPropertyOptional({
+    description: 'Access status description.',
+    example: 'The site is open but some trails are closed.',
+    nullable: true,
+  })
+  @IsOptional()
+  @IsString()
+  access_status_description?: string | null;
+
+  @ApiProperty({
+    description: 'Event type for the advisory.',
+    example: 'Wildlife',
+    maxLength: 100,
+  })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(100)
+  event_type: string;
+
+  @ApiProperty({
+    description: 'Urgency level (e.g. Low / Medium / High).',
+    example: 'High',
+    maxLength: 25,
+  })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(25)
+  urgency: string;
+
+  @ApiProperty({
+    description: 'Advisory status (e.g. Published / Draft).',
+    example: 'Published',
+    maxLength: 100,
+  })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(100)
+  advisory_status: string;
+
+  @ApiProperty({
+    description: 'Whether the advisory affects reservations.',
+    example: false,
+  })
+  @IsBoolean()
+  is_reservations_affected: boolean;
+
+  @ApiProperty({
+    description: 'Whether the advisory_date should be displayed publicly.',
+    example: true,
+  })
+  @IsBoolean()
+  is_advisory_date_displayed: boolean;
+
+  @ApiProperty({
+    description: 'Whether the effective_date should be displayed publicly.',
+    example: true,
+  })
+  @IsBoolean()
+  is_effective_date_displayed: boolean;
+
+  @ApiProperty({
+    description: 'Whether the end_date should be displayed publicly.',
+    example: false,
+  })
+  @IsBoolean()
+  is_end_date_displayed: boolean;
+
+  @ApiProperty({
+    description: 'Whether the updated_date should be displayed publicly.',
+    example: true,
+  })
+  @IsBoolean()
+  is_updated_date_displayed: boolean;
+
+  @ApiProperty({
+    description: 'Date the advisory was created in Act (ISO 8601).',
+    example: '2026-06-01T15:00:00.000Z',
+    type: String,
+  })
+  @Type(() => Date)
+  @IsDate()
+  advisory_date: Date;
+
+  @ApiProperty({
+    description: 'Date the advisory becomes effective (ISO 8601).',
+    example: '2026-06-02T00:00:00.000Z',
+    type: String,
+  })
+  @Type(() => Date)
+  @IsDate()
+  effective_date: Date;
+
+  @ApiPropertyOptional({
+    description: 'Date the advisory ends, if applicable (ISO 8601).',
+    example: '2026-09-30T23:59:59.000Z',
+    type: String,
+    nullable: true,
+  })
+  @IsOptional()
+  @Type(() => Date)
+  @IsDate()
+  end_date?: Date | null;
+
+  @ApiPropertyOptional({
+    description: 'Date the advisory expires, if applicable (ISO 8601).',
+    example: '2026-10-31T23:59:59.000Z',
+    type: String,
+    nullable: true,
+  })
+  @IsOptional()
+  @Type(() => Date)
+  @IsDate()
+  expiry_date?: Date | null;
+
+  @ApiPropertyOptional({
+    description: 'Date the advisory was removed in Act, if applicable.',
+    example: '2026-11-15T00:00:00.000Z',
+    type: String,
+    nullable: true,
+  })
+  @IsOptional()
+  @Type(() => Date)
+  @IsDate()
+  removal_date?: Date | null;
+
+  @ApiProperty({
+    description: 'Date the advisory record was last updated in Act.',
+    example: '2026-06-05T08:30:00.000Z',
+    type: String,
+  })
+  @Type(() => Date)
+  @IsDate()
+  updated_date: Date;
+
+  @ApiProperty({
+    description: 'Date the advisory was last content-modified in Act.',
+    example: '2026-06-05T08:30:00.000Z',
+    type: String,
+  })
+  @Type(() => Date)
+  @IsDate()
+  modified_date: Date;
+
+  @ApiPropertyOptional({
+    description: 'Date the advisory was published, if applicable.',
+    example: '2026-06-02T00:00:00.000Z',
+    type: String,
+    nullable: true,
+  })
+  @IsOptional()
+  @Type(() => Date)
+  @IsDate()
+  published_at?: Date | null;
+
+  @ApiPropertyOptional({
+    description: 'Listing rank used to order advisories in UIs.',
+    example: 0,
+  })
+  @IsOptional()
+  @IsInt()
+  listing_rank?: number;
+
+  @ApiPropertyOptional({
+    description: 'Urgency sequence used for ordering.',
+    example: 0,
+  })
+  @IsOptional()
+  @IsInt()
+  urgency_sequence?: number;
+
+  @ApiPropertyOptional({
+    description: 'Access-status precedence used for ordering.',
+    example: 0,
+  })
+  @IsOptional()
+  @IsInt()
+  access_status_precedence?: number;
+
+  @ApiPropertyOptional({
+    description: 'Event-type precedence used for ordering.',
+    example: 0,
+  })
+  @IsOptional()
+  @IsInt()
+  event_type_precedence?: number;
+}

--- a/admin/backend/src/app-config/app-config.schema.ts
+++ b/admin/backend/src/app-config/app-config.schema.ts
@@ -48,6 +48,15 @@ export class EnvironmentVariables {
   @IsNotEmpty()
   KEYCLOAK_ISSUER: string;
 
+  // Act integration: the CSS Client ID provisioned for the Act service
+  // account. Used as the JWT `aud` claim that the Act-specific Keycloak
+  // bearer strategy validates against. Act-issued tokens will be rejected
+  // by the (RST admin) global strategy because the audience differs - and
+  // vice-versa - which is exactly the isolation we want.
+  @IsString()
+  @IsNotEmpty()
+  ACT_CSS_CLIENT_ID: string;
+
   // AWS S3 configuration
   @IsString()
   @IsNotEmpty()

--- a/admin/backend/src/app-config/app-config.service.ts
+++ b/admin/backend/src/app-config/app-config.service.ts
@@ -56,6 +56,23 @@ export class AppConfigService {
     return this.configService.get('KEYCLOAK_ISSUER', { infer: true })!;
   }
 
+  /**
+   * CSS (Common Hosted Single Sign-On) OAuth2 token endpoint used by the
+   * Act integration for the Client Credentials grant flow.
+   * Derived from the required KEYCLOAK_ISSUER env var.
+   */
+  get cssTokenUrl(): string {
+    return `${this.keycloakIssuer.replace(/\/+$/, '')}/protocol/openid-connect/token`;
+  }
+
+  /**
+   * CSS Client ID provisioned for the Act integration. Used by the
+   * Act-only Keycloak Passport strategy as the expected `aud` claim.
+   */
+  get actCssClientId(): string {
+    return this.configService.get('ACT_CSS_CLIENT_ID', { infer: true })!;
+  }
+
   // AWS S3 Configuration
   get establishmentOrderDocsBucket(): string {
     return this.configService.get('ESTABLISHMENT_ORDER_DOCS_BUCKET', {

--- a/admin/backend/src/app.module.ts
+++ b/admin/backend/src/app.module.ts
@@ -12,6 +12,7 @@ import { AuthModule } from './auth';
 import { clsConfig } from './common/cls.config';
 import { UserContextModule } from './common/modules/user-context/user-context.module';
 import { HealthController } from './health.controller';
+import { ActModule } from './act/act.module';
 import { PrismaService } from './prisma.service';
 
 @Module({
@@ -22,6 +23,7 @@ import { PrismaService } from './prisma.service';
     AuthModule,
     TerminusModule,
     RecreationResourceModule,
+    ActModule,
     UserContextModule,
     ApiMetricsModule.forRoot({
       namespacePrefix: ADMIN_METRIC_NAMESPACE_NAME_PREFIX,

--- a/admin/backend/src/app.ts
+++ b/admin/backend/src/app.ts
@@ -5,9 +5,11 @@ import { NestFactory } from '@nestjs/core';
 import { NestExpressApplication } from '@nestjs/platform-express';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import helmet from 'helmet';
+import { AppConfigService } from './app-config/app-config.service';
 import { AppModule } from './app.module';
 import { AUTH_STRATEGY } from './auth';
 import { customLogger } from './common/logger.config';
+import { ACT_API_TAG } from './act/act.constants';
 
 /**
  * Bootstrap function to initialize the NestJS application.
@@ -32,11 +34,40 @@ export async function bootstrap() {
     type: VersioningType.URI,
     prefix: 'v',
   });
+
+  // CSS token URL is resolved from runtime config so Swagger reflects the
+  // environment (dev / test / prod) the backend is currently running in.
+  const appConfig = app.get(AppConfigService);
+  const cssTokenUrl = appConfig.cssTokenUrl;
+
   const config = new DocumentBuilder()
     .setTitle('Recreation Sites and Trails BC Admin API')
-    .setDescription('RST Admin API documentation')
+    .setDescription(
+      'RST Admin API documentation.\n\n' +
+        '## Act integration\n' +
+        'Endpoints tagged **act** are the secure CUD (Create / Update / Delete) ' +
+        'API consumed by the external Act system to push real-time advisory ' +
+        'changes into `rst.act_advisories_flat`.\n\n' +
+        '**Authentication:** OAuth2 *Client Credentials* grant flow via CSS ' +
+        '(Common Hosted Single Sign-On).\n\n' +
+        '1. The Act team retrieves their Client ID / Client Secret from the ' +
+        'CSS dashboard.\n' +
+        '2. They exchange those credentials at the CSS token endpoint to ' +
+        `receive a short-lived bearer token (\`${cssTokenUrl}\`).\n` +
+        '3. They include the token on every request as ' +
+        '`Authorization: Bearer <token>`.\n' +
+        '4. Tokens must carry the `act-service` client role. Missing, ' +
+        'malformed, or expired tokens are rejected with **401**; tokens ' +
+        'without the role are rejected with **403**.',
+    )
     .setVersion('1.0')
     .addTag('recreation-resource-admin')
+    .addTag(
+      ACT_API_TAG,
+      'Secure CUD endpoints consumed by the Act integration to push ' +
+        'advisory changes into act_advisories_flat. Requires a CSS-issued ' +
+        'OAuth2 Client Credentials bearer token carrying the act-service role.',
+    )
     .addBearerAuth(
       {
         name: 'Authorization',
@@ -48,10 +79,32 @@ export async function bootstrap() {
       },
       AUTH_STRATEGY.KEYCLOAK,
     )
+    .addBearerAuth(
+      {
+        name: 'Authorization',
+        description:
+          'Act integration bearer token (CSS-issued JWT). Audience must ' +
+          'match the Act CSS client. Use this scheme when manually pasting ' +
+          'a token rather than running the Client Credentials flow.',
+        type: 'http',
+        scheme: 'bearer',
+        bearerFormat: 'JWT',
+        in: 'header',
+      },
+      AUTH_STRATEGY.ACT_KEYCLOAK,
+    )
     .build();
 
   const document = SwaggerModule.createDocument(app, config);
-  SwaggerModule.setup('/api/docs', app, document);
+  SwaggerModule.setup('/api/docs', app, document, {
+    swaggerOptions: {
+      // Persist the "Authorize" dialog selection across page reloads so the
+      // Act team doesn't have to re-enter their CSS credentials each time.
+      persistAuthorization: true,
+      tagsSorter: 'alpha',
+      operationsSorter: 'alpha',
+    },
+  });
 
   return app;
 }

--- a/admin/backend/src/auth/auth.constants.ts
+++ b/admin/backend/src/auth/auth.constants.ts
@@ -7,6 +7,13 @@ export const AUTH_ROLES_KEY = 'roles';
 export enum RecreationResourceAuthRole {
   RST_ADMIN = 'rst-admin',
   RST_VIEWER = 'rst-viewer',
+  /**
+   * Service account role assigned (via CSS) to the Act integration client.
+   * Act authenticates using the OAuth2 Client Credentials grant flow,
+   * obtains a bearer token from CSS, and the token must carry this role
+   * to access the Act CUD advisory endpoints.
+   */
+  ACT_SERVICE = 'test-act',
   RST_SUPER_ADMIN = 'rst-super-admin',
 }
 
@@ -19,6 +26,19 @@ export const ROLE_MODE = {
 // Authentication strategies
 export const AUTH_STRATEGY = {
   KEYCLOAK: 'keycloak',
+  /**
+   * Passport strategy name used to authenticate the Act integration.
+   */
+  ACT_KEYCLOAK: 'act-keycloak',
+  /**
+   * Swagger security scheme key for the CSS (Common Hosted Single Sign-On)
+   * OAuth2 Client Credentials grant flow used by the Act integration.
+   * Tokens issued by CSS are still validated by the Keycloak Passport
+   * strategy at runtime - this constant only identifies the scheme in
+   * the generated OpenAPI document so Swagger UI can render the
+   * "Authorize" dialog with a Client ID / Client Secret form.
+   */
+  CSS_OAUTH2: 'css-oauth2',
 } as const;
 
 // Environment variable keys
@@ -56,4 +76,6 @@ export const ERROR_MESSAGES = {
 export const LOG_MESSAGES = {
   KEYCLOAK_INITIALIZED:
     'Keycloak authentication strategy initialized successfully',
+  ACT_KEYCLOAK_INITIALIZED:
+    'Act Keycloak authentication strategy initialized successfully',
 } as const;

--- a/admin/backend/src/auth/super-admin.guard.ts
+++ b/admin/backend/src/auth/super-admin.guard.ts
@@ -12,14 +12,14 @@ import { KeycloakUserToken } from './auth.types';
  * `rst-super-admin` role.  Apply it alongside the existing `AuthRolesGuard`
  * when a feature should be completely hidden from regular admins.
  *
- * @example — protect a single endpoint:
+ * @example - protect a single endpoint:
  * ```ts
  * @UseGuards(SuperAdminGuard)
  * @Delete(':id')
  * async delete(@Param('id') id: string) { ... }
  * ```
  *
- * @example — protect an entire controller:
+ * @example - protect an entire controller:
  * ```ts
  * @UseGuards(AuthGuard('keycloak'), AuthRolesGuard, SuperAdminGuard)
  * @Controller('admin/super-only')

--- a/admin/backend/src/common/modules/user-context/user-context.types.ts
+++ b/admin/backend/src/common/modules/user-context/user-context.types.ts
@@ -1,4 +1,9 @@
 /**
- * Type for authentication identity provider names
+ * Type for authentication identity provider names.
+ *
+ * - `IDIR`   - default for interactive admin users (RST UI).
+ * - `SERVICE` - service-account contexts (e.g. the Act integration
+ *   authenticated via the OAuth2 Client Credentials flow). The
+ *   "username" portion is the CSS client / service identifier.
  */
-export type AuthIdentityProviderName = 'IDIR';
+export type AuthIdentityProviderName = 'IDIR' | 'SERVICE';

--- a/admin/backend/src/recreation-resources/fees/fees.service.ts
+++ b/admin/backend/src/recreation-resources/fees/fees.service.ts
@@ -193,7 +193,7 @@ export class FeesService {
       `Updating fee ${fee_id} for rec_resource_id: ${rec_resource_id}`,
     );
 
-    // Single DB call — replaces ensureFeeBelongsToResource + separate existingFee fetch
+    // Single DB call - replaces ensureFeeBelongsToResource + separate existingFee fetch
     const existingFee = (await this.prisma.recreation_fee.findUnique({
       where: { fee_id } as any,
       select: {

--- a/admin/backend/test/act/act-advisories.controller.spec.ts
+++ b/admin/backend/test/act/act-advisories.controller.spec.ts
@@ -1,0 +1,65 @@
+import { Test } from '@nestjs/testing';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ActAdvisoriesController } from '@/act/act-advisories.controller';
+import { ActAdvisoriesService } from '@/act/act-advisories.service';
+
+describe('ActAdvisoriesController', () => {
+  let controller: ActAdvisoriesController;
+
+  const mockService = {
+    upsert: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+  };
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+
+    const moduleRef = await Test.createTestingModule({
+      controllers: [ActAdvisoriesController],
+      providers: [
+        {
+          provide: ActAdvisoriesService,
+          useValue: mockService,
+        },
+      ],
+    }).compile();
+
+    controller = moduleRef.get(ActAdvisoriesController);
+  });
+
+  it('delegates upsert to service', async () => {
+    const payload = {
+      rec_resource_id: 'REC0002',
+      advisory_number: 3791,
+    } as any;
+    mockService.upsert.mockResolvedValue({ action: 'created' });
+
+    await controller.upsert(payload);
+
+    expect(mockService.upsert).toHaveBeenCalledWith(payload);
+  });
+
+  it('delegates update to service with composite key and payload', async () => {
+    const payload = { title: 'Updated title' };
+    mockService.update.mockResolvedValue({ action: 'updated' });
+
+    await controller.update('REC0002', 3791, payload);
+
+    expect(mockService.update).toHaveBeenCalledWith(
+      { rec_resource_id: 'REC0002', advisory_number: 3791 },
+      payload,
+    );
+  });
+
+  it('delegates delete to service with composite key', async () => {
+    mockService.delete.mockResolvedValue({ action: 'deleted' });
+
+    await controller.delete('REC0002', 3791);
+
+    expect(mockService.delete).toHaveBeenCalledWith({
+      rec_resource_id: 'REC0002',
+      advisory_number: 3791,
+    });
+  });
+});

--- a/admin/backend/test/act/act-advisories.repository.spec.ts
+++ b/admin/backend/test/act/act-advisories.repository.spec.ts
@@ -1,0 +1,210 @@
+import { PrismaService } from '@/prisma.service';
+import { ActAdvisoriesRepository } from '@/act/act-advisories.repository';
+import { ActAdvisoryUpdateDto } from '@/act/dtos/act-advisory-update.dto';
+import { ActAdvisoryUpsertDto } from '@/act/dtos/act-advisory-upsert.dto';
+import { Test } from '@nestjs/testing';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('ActAdvisoriesRepository', () => {
+  let repository: ActAdvisoriesRepository;
+
+  const mockPrismaService = {
+    act_advisories_flat: {
+      findUnique: vi.fn(),
+      upsert: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+    },
+  };
+
+  const basePayload: ActAdvisoryUpsertDto = {
+    rec_resource_id: 'REC0002',
+    advisory_number: 3791,
+    title: 'Bear in area',
+    submitted_by: 'act-service-account',
+    access_status_name: 'Open with restrictions',
+    access_status_grouplabel: 'Open',
+    event_type: 'Wildlife',
+    urgency: 'High',
+    advisory_status: 'Published',
+    is_reservations_affected: false,
+    is_advisory_date_displayed: true,
+    is_effective_date_displayed: true,
+    is_end_date_displayed: false,
+    is_updated_date_displayed: true,
+    advisory_date: new Date('2026-06-01T15:00:00.000Z'),
+    effective_date: new Date('2026-06-02T00:00:00.000Z'),
+    updated_date: new Date('2026-06-05T08:30:00.000Z'),
+    modified_date: new Date('2026-06-05T08:30:00.000Z'),
+  };
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+
+    const moduleRef = await Test.createTestingModule({
+      providers: [
+        ActAdvisoriesRepository,
+        {
+          provide: PrismaService,
+          useValue: mockPrismaService,
+        },
+      ],
+    }).compile();
+
+    repository = moduleRef.get(ActAdvisoriesRepository);
+  });
+
+  it('returns true when advisory already exists', async () => {
+    mockPrismaService.act_advisories_flat.findUnique.mockResolvedValue({
+      rec_resource_id: 'REC0002',
+    });
+
+    await expect(
+      repository.exists({ rec_resource_id: 'REC0002', advisory_number: 3791 }),
+    ).resolves.toBe(true);
+  });
+
+  it('returns false when advisory does not exist', async () => {
+    mockPrismaService.act_advisories_flat.findUnique.mockResolvedValue(null);
+
+    await expect(
+      repository.exists({ rec_resource_id: 'REC0002', advisory_number: 3791 }),
+    ).resolves.toBe(false);
+  });
+
+  it('upserts and marks action as created with normalized defaults', async () => {
+    mockPrismaService.act_advisories_flat.findUnique.mockResolvedValue(null);
+    mockPrismaService.act_advisories_flat.upsert.mockResolvedValue({
+      rec_resource_id: 'REC0002',
+      advisory_number: 3791,
+    });
+
+    const result = await repository.upsert(basePayload);
+
+    expect(result.created).toBe(true);
+    expect(mockPrismaService.act_advisories_flat.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        create: expect.objectContaining({
+          description: null,
+          access_status_description: null,
+          end_date: null,
+          expiry_date: null,
+          published_at: null,
+          listing_rank: 0,
+          urgency_sequence: 0,
+          access_status_precedence: 0,
+          event_type_precedence: 0,
+        }),
+        update: expect.objectContaining({
+          description: null,
+          access_status_description: null,
+          end_date: null,
+          expiry_date: null,
+          published_at: null,
+          listing_rank: 0,
+          urgency_sequence: 0,
+          access_status_precedence: 0,
+          event_type_precedence: 0,
+        }),
+      }),
+    );
+  });
+
+  it('upserts and marks action as updated when advisory exists', async () => {
+    mockPrismaService.act_advisories_flat.findUnique.mockResolvedValue({
+      rec_resource_id: 'REC0002',
+    });
+    mockPrismaService.act_advisories_flat.upsert.mockResolvedValue({
+      rec_resource_id: 'REC0002',
+      advisory_number: 3791,
+    });
+
+    await repository.upsert({
+      ...basePayload,
+      description: 'Updated description',
+      access_status_description: 'Some restrictions apply',
+      end_date: new Date('2026-09-30T23:59:59.000Z'),
+      expiry_date: new Date('2026-10-31T23:59:59.000Z'),
+      published_at: new Date('2026-06-03T00:00:00.000Z'),
+      listing_rank: 3,
+      urgency_sequence: 4,
+      access_status_precedence: 5,
+      event_type_precedence: 6,
+    });
+
+    expect(mockPrismaService.act_advisories_flat.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        create: expect.objectContaining({
+          description: 'Updated description',
+          access_status_description: 'Some restrictions apply',
+          listing_rank: 3,
+          urgency_sequence: 4,
+          access_status_precedence: 5,
+          event_type_precedence: 6,
+        }),
+        update: expect.objectContaining({
+          description: 'Updated description',
+          access_status_description: 'Some restrictions apply',
+          listing_rank: 3,
+          urgency_sequence: 4,
+          access_status_precedence: 5,
+          event_type_precedence: 6,
+        }),
+      }),
+    );
+  });
+
+  it('updates using only fields present in partial payload', async () => {
+    const payload: ActAdvisoryUpdateDto = {
+      title: 'Updated title',
+      description: null,
+    };
+
+    await repository.update(
+      { rec_resource_id: 'REC0002', advisory_number: 3791 },
+      payload,
+    );
+
+    expect(mockPrismaService.act_advisories_flat.update).toHaveBeenCalledWith({
+      where: {
+        rec_resource_id_advisory_number: {
+          rec_resource_id: 'REC0002',
+          advisory_number: 3791,
+        },
+      },
+      data: {
+        title: 'Updated title',
+        description: null,
+      },
+    });
+  });
+
+  it('includes explicitly provided undefined values in partial updates', async () => {
+    await repository.update(
+      { rec_resource_id: 'REC0002', advisory_number: 3791 },
+      { title: undefined },
+    );
+
+    expect(mockPrismaService.act_advisories_flat.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: { title: undefined },
+      }),
+    );
+  });
+
+  it('deletes by composite key', async () => {
+    await repository.delete({
+      rec_resource_id: 'REC0002',
+      advisory_number: 3791,
+    });
+
+    expect(mockPrismaService.act_advisories_flat.delete).toHaveBeenCalledWith({
+      where: {
+        rec_resource_id_advisory_number: {
+          rec_resource_id: 'REC0002',
+          advisory_number: 3791,
+        },
+      },
+    });
+  });
+});

--- a/admin/backend/test/act/act-advisories.service.spec.ts
+++ b/admin/backend/test/act/act-advisories.service.spec.ts
@@ -1,0 +1,179 @@
+import { NotFoundException } from '@nestjs/common';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { PrismaService } from '@/prisma.service';
+import { ActAdvisoriesRepository } from '@/act/act-advisories.repository';
+import { ActAdvisoriesService } from '@/act/act-advisories.service';
+import { ACT_ERROR_MESSAGES } from '@/act/act.constants';
+import { ActAdvisoryUpsertDto } from '@/act/dtos/act-advisory-upsert.dto';
+
+describe('ActAdvisoriesService', () => {
+  let service: ActAdvisoriesService;
+
+  const mockRepository = {
+    exists: vi.fn(),
+    upsert: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+  };
+
+  const mockPrisma = {
+    recreation_resource: {
+      findUnique: vi.fn(),
+    },
+  };
+
+  const upsertPayload: ActAdvisoryUpsertDto = {
+    rec_resource_id: 'REC0002',
+    advisory_number: 3791,
+    title: 'Bear in area',
+    submitted_by: 'act-service-account',
+    access_status_name: 'Open with restrictions',
+    access_status_grouplabel: 'Open',
+    event_type: 'Wildlife',
+    urgency: 'High',
+    advisory_status: 'Published',
+    is_reservations_affected: false,
+    is_advisory_date_displayed: true,
+    is_effective_date_displayed: true,
+    is_end_date_displayed: false,
+    is_updated_date_displayed: true,
+    advisory_date: new Date('2026-06-01T15:00:00.000Z'),
+    effective_date: new Date('2026-06-02T00:00:00.000Z'),
+    updated_date: new Date('2026-06-05T08:30:00.000Z'),
+    modified_date: new Date('2026-06-05T08:30:00.000Z'),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    service = new ActAdvisoriesService(
+      mockRepository as unknown as ActAdvisoriesRepository,
+      mockPrisma as unknown as PrismaService,
+    );
+  });
+
+  it('returns created response for successful upsert', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-06-29T12:00:00.000Z'));
+
+    mockPrisma.recreation_resource.findUnique.mockResolvedValue({
+      rec_resource_id: 'REC0002',
+    });
+    mockRepository.upsert.mockResolvedValue({
+      created: true,
+      advisory: {},
+    });
+
+    const result = await service.upsert(upsertPayload);
+
+    expect(result).toEqual({
+      rec_resource_id: 'REC0002',
+      advisory_number: 3791,
+      action: 'created',
+      timestamp: '2026-06-29T12:00:00.000Z',
+    });
+
+    vi.useRealTimers();
+  });
+
+  it('returns updated response for successful upsert of existing advisory', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-06-29T12:01:00.000Z'));
+
+    mockPrisma.recreation_resource.findUnique.mockResolvedValue({
+      rec_resource_id: 'REC0002',
+    });
+    mockRepository.upsert.mockResolvedValue({
+      created: false,
+      advisory: {},
+    });
+
+    const result = await service.upsert(upsertPayload);
+
+    expect(result.action).toBe('updated');
+    expect(result.timestamp).toBe('2026-06-29T12:01:00.000Z');
+
+    vi.useRealTimers();
+  });
+
+  it('throws NotFoundException when rec_resource_id does not exist for upsert', async () => {
+    mockPrisma.recreation_resource.findUnique.mockResolvedValue(null);
+
+    await expect(service.upsert(upsertPayload)).rejects.toThrow(
+      NotFoundException,
+    );
+    await expect(service.upsert(upsertPayload)).rejects.toThrow(
+      `${ACT_ERROR_MESSAGES.REC_RESOURCE_NOT_FOUND}: REC0002`,
+    );
+  });
+
+  it('throws NotFoundException when update target advisory does not exist', async () => {
+    mockRepository.exists.mockResolvedValue(false);
+
+    await expect(
+      service.update(
+        { rec_resource_id: 'REC0002', advisory_number: 3791 },
+        { title: 'Updated title' },
+      ),
+    ).rejects.toThrow(ACT_ERROR_MESSAGES.ADVISORY_NOT_FOUND);
+  });
+
+  it('returns updated response when update succeeds', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-06-29T12:02:00.000Z'));
+
+    mockRepository.exists.mockResolvedValue(true);
+    mockRepository.update.mockResolvedValue({});
+
+    const result = await service.update(
+      { rec_resource_id: 'REC0002', advisory_number: 3791 },
+      { title: 'Updated title' },
+    );
+
+    expect(mockRepository.update).toHaveBeenCalledWith(
+      { rec_resource_id: 'REC0002', advisory_number: 3791 },
+      { title: 'Updated title' },
+    );
+    expect(result).toEqual({
+      rec_resource_id: 'REC0002',
+      advisory_number: 3791,
+      action: 'updated',
+      timestamp: '2026-06-29T12:02:00.000Z',
+    });
+
+    vi.useRealTimers();
+  });
+
+  it('throws NotFoundException when delete target advisory does not exist', async () => {
+    mockRepository.exists.mockResolvedValue(false);
+
+    await expect(
+      service.delete({ rec_resource_id: 'REC0002', advisory_number: 3791 }),
+    ).rejects.toThrow(ACT_ERROR_MESSAGES.ADVISORY_NOT_FOUND);
+  });
+
+  it('returns deleted response when delete succeeds', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-06-29T12:03:00.000Z'));
+
+    mockRepository.exists.mockResolvedValue(true);
+    mockRepository.delete.mockResolvedValue(undefined);
+
+    const result = await service.delete({
+      rec_resource_id: 'REC0002',
+      advisory_number: 3791,
+    });
+
+    expect(mockRepository.delete).toHaveBeenCalledWith({
+      rec_resource_id: 'REC0002',
+      advisory_number: 3791,
+    });
+    expect(result).toEqual({
+      rec_resource_id: 'REC0002',
+      advisory_number: 3791,
+      action: 'deleted',
+      timestamp: '2026-06-29T12:03:00.000Z',
+    });
+
+    vi.useRealTimers();
+  });
+});

--- a/admin/backend/test/act/auth-passport-act-keycloak-strategy.service.spec.ts
+++ b/admin/backend/test/act/auth-passport-act-keycloak-strategy.service.spec.ts
@@ -1,0 +1,110 @@
+import { AppConfigModule } from '@/app-config/app-config.module';
+import { AuthPassportActKeycloakStrategy } from '@/act/auth/auth-passport-act-keycloak.strategy';
+import { UserContextService } from '@/common/modules/user-context/user-context.service';
+import { UnauthorizedException } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { describe, expect, it, vi } from 'vitest';
+
+describe('AuthPassportActKeycloakStrategy', () => {
+  const createModule = () => {
+    return Test.createTestingModule({
+      imports: [AppConfigModule],
+      providers: [
+        AuthPassportActKeycloakStrategy,
+        {
+          provide: UserContextService,
+          useValue: { setCurrentUser: vi.fn() },
+        },
+      ],
+    }).compile();
+  };
+
+  it('should create strategy with valid configuration', async () => {
+    const module = await createModule();
+    const strategy = module.get(AuthPassportActKeycloakStrategy);
+    expect(strategy).toBeDefined();
+  });
+
+  it('uses azp as the service account identifier when present', async () => {
+    const module = await createModule();
+    const strategy = module.get(AuthPassportActKeycloakStrategy);
+    const userContext = module.get(UserContextService);
+
+    const payload = {
+      sub: 'sub-123',
+      iss: 'issuer',
+      idir_username: '',
+      azp: 'act-client-azp',
+      client_id: 'act-client-id',
+      preferred_username: 'preferred',
+    } as any;
+
+    const result = await strategy.validate(payload);
+
+    expect(result.idir_username).toBe('act-client-azp');
+    expect(userContext.setCurrentUser).toHaveBeenCalledWith(
+      expect.objectContaining({ idir_username: 'act-client-azp' }),
+      'SERVICE',
+    );
+  });
+
+  it('falls back to client_id when azp is missing', async () => {
+    const module = await createModule();
+    const strategy = module.get(AuthPassportActKeycloakStrategy);
+
+    const payload = {
+      sub: 'sub-123',
+      iss: 'issuer',
+      idir_username: '',
+      client_id: 'act-client-id',
+    } as any;
+
+    const result = await strategy.validate(payload);
+
+    expect(result.idir_username).toBe('act-client-id');
+  });
+
+  it('falls back to preferred_username and then sub', async () => {
+    const module = await createModule();
+    const strategy = module.get(AuthPassportActKeycloakStrategy);
+
+    const preferredPayload = {
+      sub: 'sub-123',
+      iss: 'issuer',
+      idir_username: '',
+      preferred_username: 'service-account-username',
+    } as any;
+
+    const subPayload = {
+      sub: 'sub-only-id',
+      iss: 'issuer',
+      idir_username: '',
+    } as any;
+
+    const preferredResult = await strategy.validate(preferredPayload);
+    const subResult = await strategy.validate(subPayload);
+
+    expect(preferredResult.idir_username).toBe('service-account-username');
+    expect(subResult.idir_username).toBe('sub-only-id');
+  });
+
+  it('throws UnauthorizedException when no service account identifier can be resolved', async () => {
+    const module = await createModule();
+    const strategy = module.get(AuthPassportActKeycloakStrategy);
+    const userContext = module.get(UserContextService);
+
+    const payload = {
+      sub: '',
+      iss: 'issuer',
+      idir_username: '',
+      azp: 123,
+      client_id: null,
+      preferred_username: undefined,
+    } as any;
+
+    await expect(strategy.validate(payload)).rejects.toThrow(
+      UnauthorizedException,
+    );
+    expect(userContext.setCurrentUser).not.toHaveBeenCalled();
+  });
+});

--- a/admin/backend/test/app-config/app-config.schema.spec.ts
+++ b/admin/backend/test/app-config/app-config.schema.spec.ts
@@ -23,6 +23,7 @@ describe('AppConfigSchema', () => {
     KEYCLOAK_REALM: 'test-realm',
     KEYCLOAK_CLIENT_ID: 'test-client',
     KEYCLOAK_ISSUER: 'http://localhost:8080/auth/realms/test-realm',
+    ACT_CSS_CLIENT_ID: 'test-act-css-client',
     ESTABLISHMENT_ORDER_DOCS_BUCKET: 'test-establishment-order-docs-bucket',
     RST_STORAGE_IMAGES_BUCKET: 'test-rec-resource-images-bucket',
     RST_STORAGE_PUBLIC_DOCUMENTS_BUCKET: 'test-rec-resource-docs-bucket',

--- a/admin/backend/test/app-config/app-config.service.spec.ts
+++ b/admin/backend/test/app-config/app-config.service.spec.ts
@@ -3,7 +3,7 @@ import { AppConfigService } from '@/app-config/app-config.service';
 import { ConfigModule } from '@nestjs/config';
 import { Test, TestingModule } from '@nestjs/testing';
 import 'reflect-metadata';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 describe('AppConfigService', () => {
   let service: AppConfigService;
@@ -21,6 +21,10 @@ describe('AppConfigService', () => {
     }).compile();
 
     service = module.get<AppConfigService>(AppConfigService);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
   });
 
   it('should be defined', () => {
@@ -78,8 +82,6 @@ describe('AppConfigService', () => {
       const expectedUrl =
         'postgresql://test_user:test%40pass%23123@localhost:5432/test_db?schema=test_schema&connection_limit=10';
       expect(serviceWithSpecialPass.databaseUrl).toBe(expectedUrl);
-
-      vi.unstubAllEnvs();
     });
   });
 
@@ -102,6 +104,30 @@ describe('AppConfigService', () => {
       expect(service.keycloakIssuer).toBe(
         'https://test-keycloak.example.com/auth/realms/test-realm',
       );
+    });
+
+    it('should build css token URL from issuer and strip trailing slashes', async () => {
+      vi.stubEnv('KEYCLOAK_ISSUER', 'https://issuer.example.com/realms/dev///');
+
+      const module: TestingModule = await Test.createTestingModule({
+        imports: [
+          ConfigModule.forRoot({
+            isGlobal: true,
+            validate,
+            ignoreEnvFile: true,
+          }),
+        ],
+        providers: [AppConfigService],
+      }).compile();
+
+      const envService = module.get<AppConfigService>(AppConfigService);
+      expect(envService.cssTokenUrl).toBe(
+        'https://issuer.example.com/realms/dev/protocol/openid-connect/token',
+      );
+    });
+
+    it('should return Act CSS client ID', () => {
+      expect(service.actCssClientId).toBe('test-act-css-client');
     });
   });
 });

--- a/admin/backend/test/app.module.spec.ts
+++ b/admin/backend/test/app.module.spec.ts
@@ -2,6 +2,7 @@ import { AppController } from '@/app.controller';
 import { AppModule } from '@/app.module';
 import { AppService } from '@/app.service';
 import { AuthModule } from '@/auth';
+import { ActModule } from '@/act/act.module';
 import { ConfigModule } from '@nestjs/config';
 import { PassportModule } from '@nestjs/passport';
 import { Test, TestingModule } from '@nestjs/testing';
@@ -51,11 +52,12 @@ describe('AppModule', () => {
       const moduleFixture = AppModule;
       const metadata = Reflect.getMetadata('imports', moduleFixture);
 
-      expect(metadata).toHaveLength(8);
+      expect(metadata).toHaveLength(9);
       expect(metadata).toEqual(
         expect.arrayContaining([
           PassportModule,
           AuthModule,
+          ActModule,
           expect.any(Function), // ClsModule.forRoot() returns a DynamicModule
           expect.any(Object), // AppConfigModule
           expect.any(Object), // UserContextModule

--- a/admin/backend/test/app.spec.ts
+++ b/admin/backend/test/app.spec.ts
@@ -1,0 +1,172 @@
+import { VersioningType } from '@nestjs/common';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { AUTH_STRATEGY } from '@/auth';
+import { ACT_API_TAG } from '@/act/act.constants';
+
+const helmetMiddleware = vi.fn();
+const helmetMock = vi.fn(() => helmetMiddleware);
+
+const appMock = {
+  use: vi.fn(),
+  enableCors: vi.fn(),
+  set: vi.fn(),
+  enableShutdownHooks: vi.fn(),
+  setGlobalPrefix: vi.fn(),
+  useGlobalPipes: vi.fn(),
+  useGlobalFilters: vi.fn(),
+  enableVersioning: vi.fn(),
+  get: vi.fn(),
+};
+
+const createDocumentMock = vi.fn();
+const setupSwaggerMock = vi.fn();
+
+const builderMocks = {
+  setTitle: vi.fn(),
+  setDescription: vi.fn(),
+  setVersion: vi.fn(),
+  addTag: vi.fn(),
+  addBearerAuth: vi.fn(),
+  build: vi.fn(),
+};
+
+vi.mock('helmet', () => ({
+  default: helmetMock,
+}));
+
+vi.mock('@/common/logger.config', () => ({
+  customLogger: { log: vi.fn() },
+}));
+
+vi.mock('@/config/global-validation-pipe.config', () => ({
+  globalValidationPipe: { _pipe: 'validation' },
+}));
+
+vi.mock('@/common/filters/all-exceptions.filter', () => ({
+  AllExceptionsFilter: class MockAllExceptionsFilter {},
+}));
+
+vi.mock('@nestjs/core', async () => {
+  const actual =
+    await vi.importActual<typeof import('@nestjs/core')>('@nestjs/core');
+  return {
+    ...actual,
+    NestFactory: {
+      create: vi.fn(async () => appMock),
+    },
+  };
+});
+
+vi.mock('@nestjs/swagger', async () => {
+  const actual =
+    await vi.importActual<typeof import('@nestjs/swagger')>('@nestjs/swagger');
+  return {
+    ...actual,
+    DocumentBuilder: class MockDocumentBuilder {
+      setTitle(title: string) {
+        builderMocks.setTitle(title);
+        return this;
+      }
+      setDescription(description: string) {
+        builderMocks.setDescription(description);
+        return this;
+      }
+      setVersion(version: string) {
+        builderMocks.setVersion(version);
+        return this;
+      }
+      addTag(name: string, description?: string) {
+        builderMocks.addTag(name, description);
+        return this;
+      }
+      addBearerAuth(options: unknown, key: string) {
+        builderMocks.addBearerAuth(options, key);
+        return this;
+      }
+      build() {
+        builderMocks.build();
+        return { mocked: true };
+      }
+    },
+    SwaggerModule: {
+      ...actual.SwaggerModule,
+      createDocument: createDocumentMock,
+      setup: setupSwaggerMock,
+    },
+  };
+});
+
+describe('bootstrap', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    appMock.get.mockReturnValue({
+      cssTokenUrl:
+        'https://test-keycloak.example.com/auth/realms/test-realm/protocol/openid-connect/token',
+    });
+    createDocumentMock.mockReturnValue({ openapi: '3.0.0' });
+  });
+
+  it('configures Nest app and Swagger with Act auth settings', async () => {
+    const { bootstrap } = await import('@/app');
+
+    const app = await bootstrap();
+
+    expect(helmetMock).toHaveBeenCalledTimes(1);
+    expect(appMock.use).toHaveBeenCalledWith(helmetMiddleware);
+    expect(appMock.enableCors).toHaveBeenCalledTimes(1);
+    expect(appMock.set).toHaveBeenCalledWith('trust proxy', 1);
+    expect(appMock.enableShutdownHooks).toHaveBeenCalledTimes(1);
+    expect(appMock.setGlobalPrefix).toHaveBeenCalledWith('api');
+    expect(appMock.useGlobalPipes).toHaveBeenCalledWith({
+      _pipe: 'validation',
+    });
+    expect(appMock.useGlobalFilters).toHaveBeenCalledTimes(1);
+    expect(appMock.enableVersioning).toHaveBeenCalledWith({
+      type: VersioningType.URI,
+      prefix: 'v',
+    });
+
+    expect(appMock.get).toHaveBeenCalledTimes(1);
+
+    expect(builderMocks.setTitle).toHaveBeenCalledWith(
+      'Recreation Sites and Trails BC Admin API',
+    );
+    expect(builderMocks.setVersion).toHaveBeenCalledWith('1.0');
+    expect(builderMocks.setDescription).toHaveBeenCalledWith(
+      expect.stringContaining('protocol/openid-connect/token'),
+    );
+    expect(builderMocks.addTag).toHaveBeenCalledWith(
+      ACT_API_TAG,
+      expect.stringContaining(
+        'Secure CUD endpoints consumed by the Act integration',
+      ),
+    );
+    expect(builderMocks.addBearerAuth).toHaveBeenCalledWith(
+      expect.any(Object),
+      AUTH_STRATEGY.KEYCLOAK,
+    );
+    expect(builderMocks.addBearerAuth).toHaveBeenCalledWith(
+      expect.any(Object),
+      AUTH_STRATEGY.ACT_KEYCLOAK,
+    );
+
+    expect(createDocumentMock).toHaveBeenCalledWith(
+      appMock,
+      expect.objectContaining({ mocked: true }),
+    );
+    expect(setupSwaggerMock).toHaveBeenCalledWith(
+      '/api/docs',
+      appMock,
+      { openapi: '3.0.0' },
+      {
+        swaggerOptions: {
+          persistAuthorization: true,
+          tagsSorter: 'alpha',
+          operationsSorter: 'alpha',
+        },
+      },
+    );
+
+    expect(app).toBe(appMock);
+  });
+});

--- a/admin/backend/vitest.config.mts
+++ b/admin/backend/vitest.config.mts
@@ -23,6 +23,7 @@ export default defineConfig({
       KEYCLOAK_CLIENT_ID: 'test-client',
       KEYCLOAK_ISSUER:
         'https://test-keycloak.example.com/auth/realms/test-realm',
+      ACT_CSS_CLIENT_ID: 'test-act-css-client',
       ESTABLISHMENT_ORDER_DOCS_BUCKET: 'rst-lza-establishment-order-docs-dev',
       RST_STORAGE_IMAGES_BUCKET: 'rst-lza-rec-resource-images-dev',
       RST_STORAGE_PUBLIC_DOCUMENTS_BUCKET: 'rst-lza-rec-resource-docs-dev',

--- a/public/backend/src/recreation-resource/utils/getRecreationResourceSelect.ts
+++ b/public/backend/src/recreation-resource/utils/getRecreationResourceSelect.ts
@@ -42,11 +42,6 @@ export const getRecreationResourceSelect = () => {
           notIn: EXCLUDED_ACTIVITY_CODES,
         },
       },
-      with_sub_description: {
-        select: {
-          description: true,
-        },
-      },
     },
     recreation_activity_code_trails: {
       select: {

--- a/public/backend/src/recreation-resource/utils/getRecreationResourceSelect.ts
+++ b/public/backend/src/recreation-resource/utils/getRecreationResourceSelect.ts
@@ -42,6 +42,11 @@ export const getRecreationResourceSelect = () => {
           notIn: EXCLUDED_ACTIVITY_CODES,
         },
       },
+      with_sub_description: {
+        select: {
+          description: true,
+        },
+      },
     },
     recreation_activity_code_trails: {
       select: {


### PR DESCRIPTION
**Card:** https://bcparksdigital.atlassian.net/browse/ORCA-830
**Changes:** Added CUD API for ACT 
Created new auth Strategy for act as the cliend id with be different. 
Also updated swagger to show act auth and cud api for testing

**To test:-**

- Navigate to localhost:8001/api/docs
- Download dev client details for act integration from https://sso-requests.apps.gold.devops.gov.bc.ca/my-dashboard/integrations
- set act client in env variable
- generate token using client id and secret
- Add the token in act-keycloak (authorize)
- Test POST, PUT and Delete endpoints