### PR TITLE
fix: Use hook to display mobile view instead of just css

### DIFF
--- a/admin/frontend/src/hooks/useIsDesktop.ts
+++ b/admin/frontend/src/hooks/useIsDesktop.ts
@@ -1,0 +1,21 @@
+import { useSyncExternalStore } from 'react';
+
+// Matches Bootstrap's default `md` breakpoint used by the `d-md-*` classes.
+const DESKTOP_QUERY = '(min-width: 768px)';
+
+function subscribe(callback: () => void) {
+  const mql = window.matchMedia(DESKTOP_QUERY);
+  mql.addEventListener('change', callback);
+  return () => mql.removeEventListener('change', callback);
+}
+
+function getSnapshot(): boolean {
+  return window.matchMedia(DESKTOP_QUERY).matches;
+}
+
+/**
+ * Tracks whether the viewport is at or above the desktop breakpoint.
+ */
+export function useIsDesktop(): boolean {
+  return useSyncExternalStore(subscribe, getSnapshot);
+}

--- a/admin/frontend/src/routes/__root.tsx
+++ b/admin/frontend/src/routes/__root.tsx
@@ -2,24 +2,22 @@ import { createRootRoute, Outlet } from '@tanstack/react-router';
 import { Header, NotificationBar } from '@/components';
 import { ViewOnlyBanner } from '@/components/auth';
 import { Sidebar } from '@/components/sidebar/Sidebar';
+import { useIsDesktop } from '@/hooks/useIsDesktop';
 
 export const Route = createRootRoute({
   component: RootComponent,
 });
 
 function RootComponent() {
-  return (
-    <>
-      {/** Mobile version - No Sidebar */}
-      <div className="d-block d-md-none">
-        <Header />
-        <ViewOnlyBanner />
-        <NotificationBar />
-        <main id="main-content">
-          <Outlet />
-        </main>
-      </div>
-      {/** Desktop version */}
+  // Render only the layout matching the current viewport rather than
+  // mounting both and toggling visibility with CSS: with both mounted,
+  // the route tree (including everything under <Outlet />) is mounted
+  // twice simultaneously, which breaks components relying on a single
+  // DOM identity, like the recreation resource map.
+  const isDesktop = useIsDesktop();
+
+  if (isDesktop) {
+    return (
       <div className="d-none d-md-flex flex-column vh-100 overflow-hidden bg-light">
         <Header />
         <ViewOnlyBanner />
@@ -31,6 +29,17 @@ function RootComponent() {
           </main>
         </div>
       </div>
-    </>
+    );
+  }
+
+  return (
+    <div className="d-block d-md-none">
+      <Header />
+      <ViewOnlyBanner />
+      <NotificationBar />
+      <main id="main-content">
+        <Outlet />
+      </main>
+    </div>
   );
 }

--- a/admin/frontend/test/hooks/useIsDesktop.test.ts
+++ b/admin/frontend/test/hooks/useIsDesktop.test.ts
@@ -1,0 +1,103 @@
+import { useIsDesktop } from '@/hooks/useIsDesktop';
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+type Listener = (event: MediaQueryListEvent) => void;
+
+function createMatchMediaMock(initialMatches: boolean) {
+  let matches = initialMatches;
+  const listeners = new Set<Listener>();
+
+  const mql = {
+    get matches() {
+      return matches;
+    },
+    media: '(min-width: 768px)',
+    addEventListener: vi.fn((_: 'change', listener: Listener) => {
+      listeners.add(listener);
+    }),
+    removeEventListener: vi.fn((_: 'change', listener: Listener) => {
+      listeners.delete(listener);
+    }),
+  };
+
+  return {
+    matchMedia: vi.fn().mockReturnValue(mql),
+    setMatches: (value: boolean) => {
+      matches = value;
+      listeners.forEach((listener) =>
+        listener({ matches: value } as MediaQueryListEvent),
+      );
+    },
+    mql,
+  };
+}
+
+describe('useIsDesktop', () => {
+  const originalMatchMedia = window.matchMedia;
+
+  afterEach(() => {
+    window.matchMedia = originalMatchMedia;
+  });
+
+  it('returns true when the viewport matches the desktop breakpoint', () => {
+    const { matchMedia } = createMatchMediaMock(true);
+    window.matchMedia = matchMedia;
+
+    const { result } = renderHook(() => useIsDesktop());
+
+    expect(result.current).toBe(true);
+  });
+
+  it('returns false when the viewport does not match the desktop breakpoint', () => {
+    const { matchMedia } = createMatchMediaMock(false);
+    window.matchMedia = matchMedia;
+
+    const { result } = renderHook(() => useIsDesktop());
+
+    expect(result.current).toBe(false);
+  });
+
+  it('queries the Bootstrap md breakpoint', () => {
+    const { matchMedia } = createMatchMediaMock(false);
+    window.matchMedia = matchMedia;
+
+    renderHook(() => useIsDesktop());
+
+    expect(matchMedia).toHaveBeenCalledWith('(min-width: 768px)');
+  });
+
+  it('updates when the viewport crosses the breakpoint', () => {
+    const { matchMedia, setMatches } = createMatchMediaMock(false);
+    window.matchMedia = matchMedia;
+
+    const { result } = renderHook(() => useIsDesktop());
+
+    expect(result.current).toBe(false);
+
+    act(() => {
+      setMatches(true);
+    });
+
+    expect(result.current).toBe(true);
+  });
+
+  it('unsubscribes from the media query on unmount', () => {
+    const { matchMedia, mql } = createMatchMediaMock(true);
+    window.matchMedia = matchMedia;
+
+    const { unmount } = renderHook(() => useIsDesktop());
+
+    expect(mql.addEventListener).toHaveBeenCalledWith(
+      'change',
+      expect.any(Function),
+    );
+
+    unmount();
+
+    expect(mql.removeEventListener).toHaveBeenCalledWith(
+      'change',
+      expect.any(Function),
+    );
+  });
+});

--- a/admin/frontend/test/routes/__root.test.tsx
+++ b/admin/frontend/test/routes/__root.test.tsx
@@ -1,7 +1,45 @@
 import { Route } from '@/routes/__root';
-import { describe, expect, it } from 'vitest';
+import { useIsDesktop } from '@/hooks/useIsDesktop';
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, Mock, vi } from 'vitest';
+
+vi.mock('@/components', () => ({
+  Header: () => <div data-testid="header">Mock Header</div>,
+  NotificationBar: () => (
+    <div data-testid="notification-bar">Mock NotificationBar</div>
+  ),
+}));
+
+vi.mock('@/components/auth', () => ({
+  ViewOnlyBanner: () => (
+    <div data-testid="view-only-banner">Mock ViewOnlyBanner</div>
+  ),
+}));
+
+vi.mock('@/components/sidebar/Sidebar', () => ({
+  Sidebar: () => <div data-testid="sidebar">Mock Sidebar</div>,
+}));
+
+vi.mock('@/hooks/useIsDesktop', () => ({
+  useIsDesktop: vi.fn(),
+}));
+
+vi.mock('@tanstack/react-router', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@tanstack/react-router')>();
+  return {
+    ...actual,
+    Outlet: () => <div data-testid="outlet">Mock Outlet</div>,
+  };
+});
+
+const mockUseIsDesktop = useIsDesktop as Mock;
 
 describe('Root Route', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it('should export a Route with a component', () => {
     expect(Route).toBeDefined();
     expect(Route.options.component).toBeDefined();
@@ -10,5 +48,53 @@ describe('Root Route', () => {
   it('should be a root route', () => {
     expect(Route).toBeDefined();
     expect(typeof Route.options.component).toBe('function');
+  });
+
+  describe('RootComponent', () => {
+    const RootComponent = Route.options.component!;
+
+    it('renders only the desktop layout (with Sidebar) when useIsDesktop is true', () => {
+      mockUseIsDesktop.mockReturnValue(true);
+
+      render(<RootComponent />);
+
+      expect(screen.getByTestId('sidebar')).toBeInTheDocument();
+      expect(screen.getAllByTestId('outlet')).toHaveLength(1);
+    });
+
+    it('renders only the mobile layout (no Sidebar) when useIsDesktop is false', () => {
+      mockUseIsDesktop.mockReturnValue(false);
+
+      render(<RootComponent />);
+
+      expect(screen.queryByTestId('sidebar')).not.toBeInTheDocument();
+      expect(screen.getAllByTestId('outlet')).toHaveLength(1);
+    });
+
+    it('never mounts both layouts at the same time', () => {
+      mockUseIsDesktop.mockReturnValue(true);
+      const { unmount } = render(<RootComponent />);
+      expect(screen.getAllByTestId('outlet')).toHaveLength(1);
+      unmount();
+
+      mockUseIsDesktop.mockReturnValue(false);
+      render(<RootComponent />);
+      expect(screen.getAllByTestId('outlet')).toHaveLength(1);
+    });
+
+    it('renders shared chrome (Header, ViewOnlyBanner, NotificationBar) in both layouts', () => {
+      mockUseIsDesktop.mockReturnValue(true);
+      const { unmount } = render(<RootComponent />);
+      expect(screen.getByTestId('header')).toBeInTheDocument();
+      expect(screen.getByTestId('view-only-banner')).toBeInTheDocument();
+      expect(screen.getByTestId('notification-bar')).toBeInTheDocument();
+      unmount();
+
+      mockUseIsDesktop.mockReturnValue(false);
+      render(<RootComponent />);
+      expect(screen.getByTestId('header')).toBeInTheDocument();
+      expect(screen.getByTestId('view-only-banner')).toBeInTheDocument();
+      expect(screen.getByTestId('notification-bar')).toBeInTheDocument();
+    });
   });
 });


### PR DESCRIPTION
The issue was that `__root.tsx` was mounting `<Outlet />`, which contains the map component, twice. One for mobile and one for desktop. It was relying on css to hide/display one of them based on the screen size. However, the elements were still there. 
The `prp-map` library relies on getting the map container by a unique id `map-container`. 
Since there were 2 components with the same ID, the library was finding the first component with that ID, the mobile one (hidden) and adding all the map visual components there. So, for desktop we only had the empty map container. 

Fixed by using a hook to return only the proper components instead of pure CSS to hide/display them. Now, we will only have the correct map-container displayed. 