### PR TITLE
chore: fix non sticky menu

### DIFF
--- a/shared/src/styles/global.scss
+++ b/shared/src/styles/global.scss
@@ -140,8 +140,6 @@ body {
   min-height: 100vh;
   min-width: 100%;
   margin: 0;
-  /* Prevents horizontal overflows from causing structural shrinking */
-  overflow-x: hidden;
 }
 
 body {


### PR DESCRIPTION
Fix non sticky menu on Rec Resource page.

Card: https://bcparksdigital.atlassian.net/browse/ORCA-622

This **overflow-x: hidden**  was added on the recspace sidebar PR, but introduced this breaking change on the menu.
Removing the tag fix the issue, but, doesn't change the previous PR, it was unecessary tag.